### PR TITLE
Minor optimizations in m3ibike class

### DIFF
--- a/src/m3ibike.cpp
+++ b/src/m3ibike.cpp
@@ -500,18 +500,14 @@ bool m3ibike::isCorrectUnit(const QBluetoothDeviceInfo &device) {
         keiser_m3i_out_t k3;
         QSettings settings;
         int id = settings.value("m3i_bike_id", 256).toInt();
-        if (valid_id(id)) {
-            QHash<quint16, QByteArray> datas = device.manufacturerData();
-            QHashIterator<quint16, QByteArray> i(datas);
-            while (i.hasNext()) {
-                i.next();
-                if (parse_data(i.value(), &k3) && k3.system_id == id) {
-                    return true;
-                }
+        QHash<quint16, QByteArray> datas = device.manufacturerData();
+        QHashIterator<quint16, QByteArray> i(datas);
+        while (i.hasNext()) {
+            i.next();
+            if (parse_data(i.value(), &k3) && (!valid_id(id) || k3.system_id == id)) {
+                return true;
             }
         }
-        else
-            return true;
     }
     return false;
 }

--- a/src/m3ibike.cpp
+++ b/src/m3ibike.cpp
@@ -223,6 +223,9 @@ bool KeiserM3iDeviceSimulator::step_cyc(keiser_m3i_out_t * f, qint64 now) {
 }
 
 m3ibike::m3ibike(bool noWriteResistance, bool noHeartService) {
+    QSettings settings;
+    antHeart = settings.value("ant_heart", false).toBool();
+    heartRateBeltDisabled = settings.value("heart_rate_belt_name", "Disabled").toString().startsWith("Disabled");
     m_watt.setType(metric::METRIC_WATT);
     this->noWriteResistance = noWriteResistance;
     this->noHeartService = noHeartService;
@@ -497,14 +500,18 @@ bool m3ibike::isCorrectUnit(const QBluetoothDeviceInfo &device) {
         keiser_m3i_out_t k3;
         QSettings settings;
         int id = settings.value("m3i_bike_id", 256).toInt();
-        QHash<quint16, QByteArray> datas = device.manufacturerData();
-        QHashIterator<quint16, QByteArray> i(datas);
-        while (i.hasNext()) {
-            i.next();
-            if (parse_data(i.value(), &k3) && k3.system_id == id) {
-                return true;
+        if (valid_id(id)) {
+            QHash<quint16, QByteArray> datas = device.manufacturerData();
+            QHashIterator<quint16, QByteArray> i(datas);
+            while (i.hasNext()) {
+                i.next();
+                if (parse_data(i.value(), &k3) && k3.system_id == id) {
+                    return true;
+                }
             }
         }
+        else
+            return true;
     }
     return false;
 }
@@ -512,8 +519,6 @@ bool m3ibike::isCorrectUnit(const QBluetoothDeviceInfo &device) {
 void m3ibike::processAdvertising(const QByteArray& data) {
     if (disconnecting)
         return;
-    QSettings settings;
-    int buffSize = settings.value("m3i_bike_speed_buffsize", 90).toInt();
     debug(" << " + data.toHex(' '));
     if (parse_data(data, &k3)) {
         detectDisc->start(6000);
@@ -524,6 +529,7 @@ void m3ibike::processAdvertising(const QByteArray& data) {
                 && !h
 #endif
                 ) {
+                QSettings settings;
                 bool virtual_device_enabled = settings.value("virtual_device_enabled", true).toBool();
 #if defined(Q_OS_IOS) && !defined(IO_UNDER_QT)
                 h = new lockscreen();
@@ -540,6 +546,7 @@ void m3ibike::processAdvertising(const QByteArray& data) {
                     virtualBike = new virtualbike(this, noWriteResistance, noHeartService);
                     connect(virtualBike, &virtualbike::debug, this, &m3ibike::debug);
                 }
+                int buffSize = settings.value("m3i_bike_speed_buffsize", 90).toInt();
                 k3s.inner_reset(buffSize);
             }
             emit connectedAndDiscovered();
@@ -547,9 +554,7 @@ void m3ibike::processAdvertising(const QByteArray& data) {
             debug("M3i (re)connected");
         }
         k3s.inner_step(&k3);
-        QSettings settings;
         double angular_coeff;
-        QString heartRateBeltName = settings.value("heart_rate_belt_name", "Disabled").toString();
 
         if ((int)(Resistance.value() + 0.5) != k3.incline) {
             Resistance = k3.incline;
@@ -571,12 +576,12 @@ void m3ibike::processAdvertising(const QByteArray& data) {
         }
 
 #ifdef Q_OS_ANDROID
-        if (settings.value("ant_heart", false).toBool())
+        if (antHeart)
             Heart = (uint8_t)KeepAwakeHelper::heart();
         else
 #endif
         {
-            if (heartRateBeltName.startsWith("Disabled")) {
+            if (heartRateBeltDisabled) {
 #if defined(Q_OS_IOS) && !defined(IO_UNDER_QT)
                 long appleWatchHeartRate = h->heartRate();
                 Heart = appleWatchHeartRate;

--- a/src/m3ibike.h
+++ b/src/m3ibike.h
@@ -151,6 +151,8 @@ public slots:
     void searchingStop();
     void deviceDiscovered(const QBluetoothDeviceInfo &device);
 private:
+    bool heartRateBeltDisabled = true;
+    bool antHeart = false;
     bool disconnecting = false;
     void initScan();
     Q_INVOKABLE void processAdvertising(const QByteArray& data);


### PR DESCRIPTION
Setting the bike ID is no more required if you don't have more than one bike (which is very likely).