### PR TITLE
VIRTUALBIKE Append 0 byte object after HR

### DIFF
--- a/src/virtualbike.cpp
+++ b/src/virtualbike.cpp
@@ -628,6 +628,7 @@ void virtualbike::bikeProvider()
                 value.append((char)(Bike->watts() >> 8) & 0xFF); // watts
 
                 value.append(char(Bike->currentHeart().value())); // Actual value.
+                value.append((char)0); // Bkool FTMS protocol HRM offset 1280 fix
 
                 QLowEnergyCharacteristic characteristic
                         = serviceFIT->characteristic((QBluetoothUuid::CharacteristicType)0x2AD2);


### PR DESCRIPTION
Appending a byte with zeros fixes an issue with the "BKOOL application" : the application has an offset of "+1280" on HR PPM value.