### PR TITLE
Main/logmanagement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ src/qdomyos-zwift
 
 src/ui_charts.h
 src/ui_mainwindow.h
+
+src/debug-*

--- a/docs/10_Installation.md
+++ b/docs/10_Installation.md
@@ -131,7 +131,7 @@ After=multi-user.target
 Type=idle  
 Restart=always
 RestartSec=30
-ExecStart=/home/pi/qdomyos-zwift/src/qdomyos-zwift -no-gui -heart-service
+ExecStart=/home/pi/qdomyos-zwift/src/qdomyos-zwift -no-gui -no-log -heart-service
 ExecStop=killall -9 qdomyos-zwift
 User=root  
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -54,7 +54,7 @@ QString deviceName = "";
 uint32_t pollDeviceTime = 200;
 uint8_t bikeResistanceOffset = 4;
 double bikeResistanceGain = 1.0;
-static QString logfilename = "debug-" + QDateTime::currentDateTime().toString().replace(":", "_") + ".log";
+static QString logfilename = "debug-" + QDateTime::currentDateTime().toString().replace(":", "_").replace(" ","_").replace(".","_") + ".log";
 static const QtMessageHandler QT_DEFAULT_MESSAGE_HANDLER = qInstallMessageHandler(0);
 
 QCoreApplication* createApplication(int &argc, char *argv[])
@@ -207,6 +207,8 @@ void myMessageOutput(QtMsgType type, const QMessageLogContext &context, const QS
 #elif defined(Q_OS_IOS)
         path = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation) + "/";
 #endif
+
+        // Linux log files are generated on binary location
 
         QFile outFile(path + logfilename);
         outFile.open(QIODevice::WriteOnly | QIODevice::Append);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,7 +32,7 @@
 #include "ios/lockscreen.h"
 #endif
 
-bool nologs = false;
+bool logs = true;
 bool noWriteResistance = false;
 bool noHeartService = true;
 bool noConsole = false;
@@ -74,7 +74,7 @@ QCoreApplication* createApplication(int &argc, char *argv[])
         if (!qstrcmp(argv[i], "-test-resistance"))
             testResistance = true;
         if (!qstrcmp(argv[i], "-no-log"))
-            nologs = true;
+            logs = false;
         if (!qstrcmp(argv[i], "-no-write-resistance"))
             noWriteResistance = true;
         if (!qstrcmp(argv[i], "-no-heart-service"))
@@ -170,8 +170,8 @@ void myMessageOutput(QtMsgType type, const QMessageLogContext &context, const QS
 {
     QSettings settings;
     static bool logdebug = settings.value("log_debug", false).toBool();
-#if defined (Q_OS_LINUX)
-    if(nologs == true && logdebug == false)
+#if defined (Q_OS_LINUX) // Linux OS does not read settings file for now
+    if(logs == false)
 #elif
     if(logdebug == false)
 #endif
@@ -199,7 +199,7 @@ void myMessageOutput(QtMsgType type, const QMessageLogContext &context, const QS
         abort();
     }
 
-    if(nologs == false)
+    if(logs == true || logdebug == true)
     {
         QString path = "";
 #if defined(Q_OS_ANDROID) || defined(Q_OS_MACOS) || defined(Q_OS_OSX)
@@ -308,7 +308,7 @@ int main(int argc, char *argv[])
         }
     }
 #endif
-    bluetooth* bl = new bluetooth(!nologs, deviceName, noWriteResistance, noHeartService, pollDeviceTime, noConsole, testResistance, bikeResistanceOffset, bikeResistanceGain);
+    bluetooth* bl = new bluetooth(logs, deviceName, noWriteResistance, noHeartService, pollDeviceTime, noConsole, testResistance, bikeResistanceOffset, bikeResistanceGain);
 
 #ifdef Q_OS_IOS
 #ifndef IO_UNDER_QT

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -169,14 +169,9 @@ QCoreApplication* createApplication(int &argc, char *argv[])
 void myMessageOutput(QtMsgType type, const QMessageLogContext &context, const QString &msg)
 {
     QSettings settings;
-    static bool debuglog = settings.value("log_debug", false).toBool();
-    if(debuglog == false)
-#if defined(Q_OS_LINUX) || defined(Q_OS_WINDOWS)
-#ifndef Q_OS_ANDROID
-        if(forceQml)
-#endif
-#endif
-        return;
+    static bool logdebug = settings.value("log_debug", false).toBool();
+    if(nologs == true && logdebug == false)
+      return;
 
     QByteArray localMsg = msg.toLocal8Bit();
     const char *file = context.file ? context.file : "";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -170,7 +170,11 @@ void myMessageOutput(QtMsgType type, const QMessageLogContext &context, const QS
 {
     QSettings settings;
     static bool logdebug = settings.value("log_debug", false).toBool();
+#if defined (Q_OS_LINUX)
     if(nologs == true && logdebug == false)
+#elif
+    if(logdebug == false)
+#endif
       return;
 
     QByteArray localMsg = msg.toLocal8Bit();


### PR DESCRIPTION
The CLI switch for logs in Linux client is now working.

Removing the condition for qml interface and logs.

Tested on linux client.