### PR TITLE
qt5package name change

### DIFF
--- a/docs/10_Installation.md
+++ b/docs/10_Installation.md
@@ -104,9 +104,10 @@ This operation takes a moment to complete.
 
 `git clone https://github.com/cagnulein/qdomyos-zwift.git`  
 `cd qdomyos-zwift`  
-`git submodule update --init src/smtpclient/`
-`cd src`  
-`qmake`  
+`git submodule update --init src/smtpclient/`  
+`git submodule update --init src/qmdnsengine/`  
+`cd src`    
+`qmake`    
 `make`  
 
 Please note :

--- a/docs/10_Installation.md
+++ b/docs/10_Installation.md
@@ -100,7 +100,7 @@ This operation takes a moment to complete.
 
 #### Install qdomyos-zwift from sources
 
-`sudo apt install git libqt5bluetooth5 libqt5widgets5 libqt5positioning5 libqt5xml5 qtconnectivity5-dev qtpositioning5-dev libqt5charts5-dev libqt5charts5 qt5-default libqt5networkauth5-dev libqt5websockets5-dev`
+`sudo apt install git libqt5bluetooth5 libqt5widgets5 libqt5positioning5 libqt5xml5 qtconnectivity5-dev qtpositioning5-dev libqt5charts5-dev libqt5charts5 qt5-assistant libqt5networkauth5-dev libqt5websockets5-dev`
 
 `git clone https://github.com/cagnulein/qdomyos-zwift.git`  
 `cd qdomyos-zwift`  


### PR DESCRIPTION
Modified the raspberry pi install instructions as the qt5-default package has been renamed qt5-assistant in the raspbian sources.