### PR TITLE
Activate "NordicTrack" compatibility mode from the command line

### DIFF
--- a/docs/30_usage.md
+++ b/docs/30_usage.md
@@ -21,32 +21,33 @@ Please refer to this article for more information under [QML Operations](https:/
 This is the list of settings available in the application. These settings needs to be appended to the binary command line.  
 *Example :* `sudo ./qdomyos-zwift -no-gui` for disabling any graphical interface.
 
-| **Option**              | **Type** | **Default** | **Function**                                                                 |
-|:------------------------|:---------|:------------|:-----------------------------------------------------------------------------|
-| -no-gui                 | Boolean  | False       | Disable GUI                                                                  |
-| -qml                    | Boolean  | False       | Enables the QML interface                                                    |
-| -miles                  | Boolean  | False       | Swithes to Imperial Units System                                             |
-| -no-console             | Boolean  | False       | Not in use                                                                   |
-| -test-resistance        | Boolean  | False       |                                                                              |
-| -no-log                 | Boolean  | False       | Disable Logging                                                              |
-| -no-write-resistance    | Boolean  | False       | Disable resistance instructions from QZ to your fitness equipment            |
-| -no-heart-service       | Boolean  | False       | Do not simulate external HR monitor, use only FTMS                           |
-| -heart-service          | Boolean  | True        | Simulate HR service (required for applications not reading FTMS)             |
-| -only-virtualbike       | Boolean  | False       |                                                                              |
-| -only-virtualtreadmill  | Boolean  | False       |                                                                              |
-| -no-reconnection        | Boolean  | False       | QZ will not try to reconnect your fitness equipement if enabled              |
-| -bluetooth-relaxed      | Boolean  | False       | In case of deconnections from QZ to your fitness equipement                  |
-| -bike-cadence-sensor    | Boolean  | False       |                                                                              |
-| -bike-power-sensor      | Boolean  | False       |                                                                              |
-| -battery-service        | Boolean  | False       |                                                                              |
-| -service-changed        | Boolean  | False       |                                                                              |
-| -bike-wheel-revs        | Boolean  | False       |                                                                              |
-| -run-cadence-sensor     | Boolean  | False       |                                                                              |
-| -train                  | String   |             | Force training program                                                       |
-| -name                   | String   |             | Force bluetooth device name (if QZ struggles finding your fitness equipment) |
-| -poll-device-time       | Int      | 200 (ms)    | Frequency to refresh informations from QZ to Fitness equipment               |
-| -bike-resistance-gain   | Int      |             | Adjust resistance from the fitness application                               |
-| -bike-resistance-offset | Int      |             | Set another resistance point than default                                    |
+| **Option**              		| **Type** | **Default** | **Function**                                                                 |
+|:------------------------------|:---------|:------------|:-----------------------------------------------------------------------------|
+| -no-gui                 		| Boolean  | False       | Disable GUI                                                                  |
+| -qml                    		| Boolean  | False       | Enables the QML interface                                                    |
+| -miles                  		| Boolean  | False       | Swithes to Imperial Units System                                             |
+| -no-console             		| Boolean  | False       | Not in use                                                                   |
+| -test-resistance        		| Boolean  | False       |                                                                              |
+| -no-log                 		| Boolean  | False       | Disable Logging                                                              |
+| -no-write-resistance    		| Boolean  | False       | Disable resistance instructions from QZ to your fitness equipment            |
+| -no-heart-service       		| Boolean  | False       | Do not simulate external HR monitor, use only FTMS                           |
+| -heart-service          		| Boolean  | True        | Simulate HR service (required for applications not reading FTMS)             |
+| -only-virtualbike       		| Boolean  | False       |                                                                              |
+| -only-virtualtreadmill  		| Boolean  | False       |                                                                              |
+| -no-reconnection        		| Boolean  | False       | QZ will not try to reconnect your fitness equipement if enabled              |
+| -bluetooth-relaxed      		| Boolean  | False       | In case of deconnections from QZ to your fitness equipement                  |
+| -bike-cadence-sensor    		| Boolean  | False       |                                                                              |
+| -bike-power-sensor      		| Boolean  | False       |                                                                              |
+| -battery-service        		| Boolean  | False       |                                                                              |
+| -service-changed        		| Boolean  | False       |                                                                              |
+| -bike-wheel-revs        		| Boolean  | False       |                                                                              |
+| -run-cadence-sensor     		| Boolean  | False       |                                                                              |
+| --nordictrack-10-treadmill    | Boolean  | False       | Enable NordicTrack compatibility mode                                        |
+| -train                  		| String   |             | Force training program                                                       |
+| -name                   		| String   |             | Force bluetooth device name (if QZ struggles finding your fitness equipment) |
+| -poll-device-time       		| Int      | 200 (ms)    | Frequency to refresh informations from QZ to Fitness equipment               |
+| -bike-resistance-gain   		| Int      |             | Adjust resistance from the fitness application                               |
+| -bike-resistance-offset 		| Int      |             | Set another resistance point than default                                    |
 
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -63,6 +63,7 @@ bool battery_service = false;
 bool service_changed = false;
 bool bike_wheel_revs = false;
 bool run_cadence_sensor = false;
+bool nordictrack_10_treadmill = false;
 QString trainProgram;
 QString deviceName = QLatin1String("");
 uint32_t pollDeviceTime = 200;
@@ -121,6 +122,8 @@ QCoreApplication *createApplication(int &argc, char *argv[]) {
             bike_wheel_revs = true;
         if (!qstrcmp(argv[i], "-run-cadence-sensor"))
             run_cadence_sensor = true;
+        if (!qstrcmp(argv[i], "-nordictrack-10-treadmill"))
+            nordictrack_10_treadmill = true;
         if (!qstrcmp(argv[i], "-test-peloton"))
             testPeloton = true;
         if (!qstrcmp(argv[i], "-test-hfb"))
@@ -323,6 +326,7 @@ int main(int argc, char *argv[]) {
         settings.setValue(QStringLiteral("service_changed"), service_changed);
         settings.setValue(QStringLiteral("bike_wheel_revs"), bike_wheel_revs);
         settings.setValue(QStringLiteral("run_cadence_sensor"), run_cadence_sensor);
+		settings.setValue(QStringLiteral("nordictrack_10_treadmill"), nordictrack_10_treadmill);
     }
 #endif
 


### PR DESCRIPTION
I added a new parameter (-nordictrack-10-treadmill) for the command line to enable NordicTrack compatibility.
`sudo /home/pi/qdomyos-zwift/src/qdomyos-zwift -no-log -no-gui -heart-service -nordictrack-10-treadmill`