### PR TITLE
Fix typo in parameters' list

### DIFF
--- a/docs/30_usage.md
+++ b/docs/30_usage.md
@@ -42,7 +42,7 @@ This is the list of settings available in the application. These settings needs 
 | -service-changed        		| Boolean  | False       |                                                                              |
 | -bike-wheel-revs        		| Boolean  | False       |                                                                              |
 | -run-cadence-sensor     		| Boolean  | False       |                                                                              |
-| --nordictrack-10-treadmill    | Boolean  | False       | Enable NordicTrack compatibility mode                                        |
+| -nordictrack-10-treadmill   	| Boolean  | False       | Enable NordicTrack compatibility mode                                        |
 | -train                  		| String   |             | Force training program                                                       |
 | -name                   		| String   |             | Force bluetooth device name (if QZ struggles finding your fitness equipment) |
 | -poll-device-time       		| Int      | 200 (ms)    | Frequency to refresh informations from QZ to Fitness equipment               |


### PR DESCRIPTION
Parameter value is "`-nordictrack-10-treadmill`" and not "`--nordictrack-10-treadmill`" as previously edited.