### PR TITLE
Add on Websocket start / pause / stop commands

### DIFF
--- a/src/templateinfosenderbuilder.cpp
+++ b/src/templateinfosenderbuilder.cpp
@@ -508,6 +508,7 @@ void TemplateInfoSenderBuilder::onStop(TemplateInfoSender *tempSender) {
     device->stop();
     device->setPaused(true);
     device->clearStats();
+    emit workoutEventStateChanged(bluetoothdevice::STOPPED);
     QJsonObject main;
     main[QStringLiteral("msg")] = QStringLiteral("R_stop");
     QJsonDocument out(main);

--- a/src/templateinfosenderbuilder.cpp
+++ b/src/templateinfosenderbuilder.cpp
@@ -476,6 +476,44 @@ void TemplateInfoSenderBuilder::onGetSessionArray(TemplateInfoSender *tempSender
     tempSender->send(out.toJson());
 }
 
+void TemplateInfoSenderBuilder::onStart(TemplateInfoSender *tempSender) {
+    if (!device->isPaused()) {
+        device->clearStats();
+        device->start();
+        emit workoutEventStateChanged(bluetoothdevice::STARTED);
+    } else {
+        device->start();
+        device->setPaused(false);
+        emit workoutEventStateChanged(bluetoothdevice::RESUMED);
+    }
+    QJsonObject main;
+    main[QStringLiteral("msg")] = QStringLiteral("R_start");
+    QJsonDocument out(main);
+    tempSender->send(out.toJson());
+}
+
+void TemplateInfoSenderBuilder::onPause(TemplateInfoSender *tempSender) {
+    if (!device->isPaused()) {
+        device->stop();
+        device->setPaused(true);
+        emit workoutEventStateChanged(bluetoothdevice::PAUSED);
+    }
+    QJsonObject main;
+    main[QStringLiteral("msg")] = QStringLiteral("R_pause");
+    QJsonDocument out(main);
+    tempSender->send(out.toJson());
+}
+
+void TemplateInfoSenderBuilder::onStop(TemplateInfoSender *tempSender) {
+    device->stop();
+    device->setPaused(true);
+    device->clearStats();
+    QJsonObject main;
+    main[QStringLiteral("msg")] = QStringLiteral("R_stop");
+    QJsonDocument out(main);
+    tempSender->send(out.toJson());
+}
+
 void TemplateInfoSenderBuilder::onSaveTrainingProgram(const QJsonValue &msgContent, TemplateInfoSender *tempSender) {
     QString fileName;
     QJsonArray rows;
@@ -627,6 +665,18 @@ void TemplateInfoSenderBuilder::onDataReceived(const QByteArray &data) {
                     return;
                 } else if (msg == QStringLiteral("getsessionarray")) {
                     onGetSessionArray(sender);
+                    return;
+                } 
+                if (msg == QStringLiteral("start")) {
+                    onStart(sender);
+                    return;
+                }
+                if (msg == QStringLiteral("pause")) {
+                    onPause(sender);
+                    return;
+                }
+                if (msg == QStringLiteral("stop")) {
+                    onStop(sender);
                     return;
                 }
             }

--- a/src/templateinfosenderbuilder.h
+++ b/src/templateinfosenderbuilder.h
@@ -58,6 +58,9 @@ class TemplateInfoSenderBuilder : public QObject {
     void onLoadTrainingPrograms(const QJsonValue &msgContent, TemplateInfoSender *tempSender);
     void onAppendActivityDescription(const QJsonValue &msgContent, TemplateInfoSender *tempSender);
     void onGetSessionArray(TemplateInfoSender *tempSender);
+    void onStart(TemplateInfoSender *tempSender);
+    void onPause(TemplateInfoSender *tempSender);
+    void onStop(TemplateInfoSender *tempSender);
     QString workoutName = QStringLiteral("");
     QString workoutStartDate = QStringLiteral("");
     QString instructorName = QStringLiteral("");


### PR DESCRIPTION
This pull request implements 3 commands to control `qdosmyos` by WebSocket for issue #582.
Start who when `qdosmyos` is on pause resume or otherwise reset timer (and distance...) and start from new.
Pause who only pause `qdosmyos` when pause is not active.
Stop who stop `qdosmyos` and reset all data.

One of my problem of my PR is with the current `bluetoothdevice.h` I can't know if the state is on stop or start so start will always if the state is not on pause reset all data. After this is not very bad cause we can presume on the external side with "workout" state if the state the machine is running or not (if speed is at zero for example).

Second and last problem of my PR is I don't know how communicate from `templateinfosenderbuild.cpp` to `homeform.cpp` to update the UI state when I stop / start / pause. For me this is not a problem cause I don't use the UI and for the user it will not be too cause this API is most reserve for developer.

Anyways I'm open to any changes or review. 