### PR TITLE
SS2K Shift Step calibration

### DIFF
--- a/src/settings.qml
+++ b/src/settings.qml
@@ -273,6 +273,8 @@ import Qt.labs.settings 1.0
 
             property string ftms_accessory_name: "Disabled"
             property real ss2k_shift_step: 900
+            property real ss2k_calibrated_slope: 0
+            property real ss2k_calibrated_intercept: 0
 
             property bool fitmetria_fanfit_enable: false
             property string fitmetria_fanfit_mode: "Heart"

--- a/src/settings.qml
+++ b/src/settings.qml
@@ -273,8 +273,14 @@ import Qt.labs.settings 1.0
 
             property string ftms_accessory_name: "Disabled"
             property real ss2k_shift_step: 900
-            property real ss2k_calibrated_slope: 0
-            property real ss2k_calibrated_intercept: 0
+            property real ss2k_resistance_sample_1: 20
+            property real ss2k_shift_step_sample_1: 332
+            property real ss2k_resistance_sample_2: 30
+            property real ss2k_shift_step_sample_2: 323
+            property real ss2k_resistance_sample_3: 40
+            property real ss2k_shift_step_sample_3: 300
+            property real ss2k_resistance_sample_4: 50
+            property real ss2k_shift_step_sample_4: 282
 
             property bool fitmetria_fanfit_enable: false
             property string fitmetria_fanfit_mode: "Heart"
@@ -5077,6 +5083,204 @@ import Qt.labs.settings 1.0
                                     text: "OK"
                                     Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
                                     onClicked: settings.ss2k_shift_step = ss2kShiftStepTextField.text
+                                }
+                            }
+                            AccordionElement {
+                                id: ftmsAccessoryAdvancedOptionsAccordion
+                                title: qsTr("Advanced SmartSpin2k Calibration")
+                                indicatRectColor: Material.color(Material.Grey)
+                                textColor: Material.color(Material.Yellow)
+                                color: Material.backgroundColor
+                                accordionContent: ColumnLayout {
+                                    spacing: 10
+                                    RowLayout {
+                                        spacing: 10
+                                        Label {
+                                            id: labelSS2KResistanceSample1
+                                            text: qsTr("Resistance Sample 1")
+                                            Layout.fillWidth: true
+                                        }
+                                        TextField {
+                                            id: ss2kResistanceSample1TextField
+                                            text: settings.ss2k_resistance_sample_1
+                                            horizontalAlignment: Text.AlignRight
+                                            Layout.fillHeight: false
+                                            Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                                            inputMethodHints: Qt.ImhDigitsOnly
+                                            onAccepted: settings.resistance_sample_1 = text
+                                            onActiveFocusChanged: if(this.focus) this.cursorPosition = this.text.length
+                                        }
+                                        Button {
+                                            id: okSS2kResistanceSample1
+                                            text: "OK"
+                                            Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                                            onClicked: settings.ss2k_resistance_sample_1 = ss2kResistanceSample1TextField.text
+                                        }
+                                    }
+                                    RowLayout {
+                                        Label {
+                                            id: labelSS2KShiftStepSample1
+                                            text: qsTr("Shift Step Sample 1")
+                                            Layout.fillWidth: true
+                                        }
+                                        TextField {
+                                            id: ss2kShiftStepSample1TextField
+                                            text: settings.ss2k_shift_step_sample_1
+                                            horizontalAlignment: Text.AlignRight
+                                            Layout.fillHeight: false
+                                            Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                                            inputMethodHints: Qt.ImhDigitsOnly
+                                            onAccepted: settings.ss2k_shift_step_sample_1 = text
+                                            onActiveFocusChanged: if(this.focus) this.cursorPosition = this.text.length
+                                        }
+                                        Button {
+                                            id: okSS2kShiftStepSample1
+                                            text: "OK"
+                                            Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                                            onClicked: settings.ss2k_shift_step_sample_1 = ss2kShiftStepSample1TextField.text
+                                        }
+                                    }
+                                    RowLayout {
+                                        spacing: 10
+                                        Label {
+                                            id: labelSS2KResistanceSample2
+                                            text: qsTr("Resistance Sample 2")
+                                            Layout.fillWidth: true
+                                        }
+                                        TextField {
+                                            id: ss2kResistanceSample2TextField
+                                            text: settings.ss2k_resistance_sample_2
+                                            horizontalAlignment: Text.AlignRight
+                                            Layout.fillHeight: false
+                                            Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                                            inputMethodHints: Qt.ImhDigitsOnly
+                                            onAccepted: settings.resistance_sample_2 = text
+                                            onActiveFocusChanged: if(this.focus) this.cursorPosition = this.text.length
+                                        }
+                                        Button {
+                                            id: okSS2kResistanceSample2
+                                            text: "OK"
+                                            Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                                            onClicked: settings.ss2k_resistance_sample_2 = ss2kResistanceSample2TextField.text
+                                        }
+                                    }
+                                    RowLayout {
+                                        Label {
+                                            id: labelSS2KShiftStepSample2
+                                            text: qsTr("Shift Step Sample 2")
+                                            Layout.fillWidth: true
+                                        }
+                                        TextField {
+                                            id: ss2kShiftStepSample2TextField
+                                            text: settings.ss2k_shift_step_sample_2
+                                            horizontalAlignment: Text.AlignRight
+                                            Layout.fillHeight: false
+                                            Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                                            inputMethodHints: Qt.ImhDigitsOnly
+                                            onAccepted: settings.ss2k_shift_step_sample_2 = text
+                                            onActiveFocusChanged: if(this.focus) this.cursorPosition = this.text.length
+                                        }
+                                        Button {
+                                            id: okSS2kShiftStepSample2
+                                            text: "OK"
+                                            Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                                            onClicked: settings.ss2k_shift_step_sample_2 = ss2kShiftStepSample2TextField.text
+                                        }
+                                    }
+                                    RowLayout {
+                                        spacing: 10
+                                        Label {
+                                            id: labelSS2KResistanceSample3
+                                            text: qsTr("Resistance Sample 3")
+                                            Layout.fillWidth: true
+                                        }
+                                        TextField {
+                                            id: ss2kResistanceSample3TextField
+                                            text: settings.ss2k_resistance_sample_3
+                                            horizontalAlignment: Text.AlignRight
+                                            Layout.fillHeight: false
+                                            Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                                            inputMethodHints: Qt.ImhDigitsOnly
+                                            onAccepted: settings.resistance_sample_3 = text
+                                            onActiveFocusChanged: if(this.focus) this.cursorPosition = this.text.length
+                                        }
+                                        Button {
+                                            id: okSS2kResistanceSample3
+                                            text: "OK"
+                                            Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                                            onClicked: settings.ss2k_resistance_sample_3 = ss2kResistanceSample3TextField.text
+                                        }
+                                    }
+                                    RowLayout {
+                                        Label {
+                                            id: labelSS2KShiftStepSample3
+                                            text: qsTr("Shift Step Sample 3")
+                                            Layout.fillWidth: true
+                                        }
+                                        TextField {
+                                            id: ss2kShiftStepSample3TextField
+                                            text: settings.ss2k_shift_step_sample_3
+                                            horizontalAlignment: Text.AlignRight
+                                            Layout.fillHeight: false
+                                            Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                                            inputMethodHints: Qt.ImhDigitsOnly
+                                            onAccepted: settings.ss2k_shift_step_sample_3 = text
+                                            onActiveFocusChanged: if(this.focus) this.cursorPosition = this.text.length
+                                        }
+                                        Button {
+                                            id: okSS2kShiftStepSample3
+                                            text: "OK"
+                                            Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                                            onClicked: settings.ss2k_shift_step_sample_3 = ss2kShiftStepSample3TextField.text
+                                        }
+                                    }
+                                    RowLayout {
+                                        spacing: 10
+                                        Label {
+                                            id: labelSS2KResistanceSample4
+                                            text: qsTr("Resistance Sample 4")
+                                            Layout.fillWidth: true
+                                        }
+                                        TextField {
+                                            id: ss2kResistanceSample4TextField
+                                            text: settings.ss2k_resistance_sample_4
+                                            horizontalAlignment: Text.AlignRight
+                                            Layout.fillHeight: false
+                                            Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                                            inputMethodHints: Qt.ImhDigitsOnly
+                                            onAccepted: settings.resistance_sample_4 = text
+                                            onActiveFocusChanged: if(this.focus) this.cursorPosition = this.text.length
+                                        }
+                                        Button {
+                                            id: okSS2kResistanceSample4
+                                            text: "OK"
+                                            Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                                            onClicked: settings.ss2k_resistance_sample_4 = ss2kResistanceSample4TextField.text
+                                        }
+                                    }
+                                    RowLayout {
+                                        Label {
+                                            id: labelSS2KShiftStepSample4
+                                            text: qsTr("Shift Step Sample 4")
+                                            Layout.fillWidth: true
+                                        }
+                                        TextField {
+                                            id: ss2kShiftStepSample4TextField
+                                            text: settings.ss2k_shift_step_sample_4
+                                            horizontalAlignment: Text.AlignRight
+                                            Layout.fillHeight: false
+                                            Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                                            inputMethodHints: Qt.ImhDigitsOnly
+                                            onAccepted: settings.ss2k_shift_step_sample_4 = text
+                                            onActiveFocusChanged: if(this.focus) this.cursorPosition = this.text.length
+                                        }
+                                        Button {
+                                            id: okSS2kShiftStepSample4
+                                            text: "OK"
+                                            Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                                            onClicked: settings.ss2k_shift_step_sample_4 = ss2kShiftStepSample4TextField.text
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/src/settings.qml
+++ b/src/settings.qml
@@ -273,14 +273,6 @@ import Qt.labs.settings 1.0
 
             property string ftms_accessory_name: "Disabled"
             property real ss2k_shift_step: 900
-            property real ss2k_resistance_sample_1: 20
-            property real ss2k_shift_step_sample_1: 0
-            property real ss2k_resistance_sample_2: 30
-            property real ss2k_shift_step_sample_2: 0
-            property real ss2k_resistance_sample_3: 40
-            property real ss2k_shift_step_sample_3: 0
-            property real ss2k_resistance_sample_4: 50
-            property real ss2k_shift_step_sample_4: 0
 
             property bool fitmetria_fanfit_enable: false
             property string fitmetria_fanfit_mode: "Heart"
@@ -320,6 +312,16 @@ import Qt.labs.settings 1.0
 
             // from version 2.10.21
             property bool nordictrack_s30_treadmill: false
+            
+            // from version 2.10.27
+            property real ss2k_resistance_sample_1: 20
+            property real ss2k_shift_step_sample_1: 0
+            property real ss2k_resistance_sample_2: 30
+            property real ss2k_shift_step_sample_2: 0
+            property real ss2k_resistance_sample_3: 40
+            property real ss2k_shift_step_sample_3: 0
+            property real ss2k_resistance_sample_4: 50
+            property real ss2k_shift_step_sample_4: 0            
         }
 
         function paddingZeros(text, limit) {

--- a/src/settings.qml
+++ b/src/settings.qml
@@ -274,13 +274,13 @@ import Qt.labs.settings 1.0
             property string ftms_accessory_name: "Disabled"
             property real ss2k_shift_step: 900
             property real ss2k_resistance_sample_1: 20
-            property real ss2k_shift_step_sample_1: 332
+            property real ss2k_shift_step_sample_1: 0
             property real ss2k_resistance_sample_2: 30
-            property real ss2k_shift_step_sample_2: 323
+            property real ss2k_shift_step_sample_2: 0
             property real ss2k_resistance_sample_3: 40
-            property real ss2k_shift_step_sample_3: 300
+            property real ss2k_shift_step_sample_3: 0
             property real ss2k_resistance_sample_4: 50
-            property real ss2k_shift_step_sample_4: 282
+            property real ss2k_shift_step_sample_4: 0
 
             property bool fitmetria_fanfit_enable: false
             property string fitmetria_fanfit_mode: "Heart"

--- a/src/smartspin2k.cpp
+++ b/src/smartspin2k.cpp
@@ -18,6 +18,7 @@
 using namespace std::chrono_literals;
 
 smartspin2k::smartspin2k(bool noWriteResistance, bool noHeartService, uint8_t max_resistance, bike *parentDevice) {
+    QSettings settings;
     m_watt.setType(metric::METRIC_WATT);
     Speed.setType(metric::METRIC_SPEED);
     this->max_resistance = max_resistance;
@@ -25,6 +26,18 @@ smartspin2k::smartspin2k(bool noWriteResistance, bool noHeartService, uint8_t ma
     refresh = new QTimer(this);
     this->noWriteResistance = noWriteResistance;
     this->noHeartService = noHeartService;
+    this->slope = settings.value(QStringLiteral("ss2k_calibrated_slope"), 0).toReal();
+    this->intercept = settings.value(QStringLiteral("ss2k_calibrated_intercept"), 0).toReal();
+    if (this->intercept == 0) {
+        this->intercept = settings.value("ss2k_shift_step", 900).toUInt();
+    }
+
+    // test
+    double xSamples[] = {20,30,40,50};
+    double ySamples[] = { 332,323,300,282};
+    calibrateShiftStep(4, xSamples, ySamples);
+    // end test
+    
     initDone = false;
     connect(refresh, &QTimer::timeout, this, &smartspin2k::update);
     refresh->start(200ms);
@@ -37,9 +50,8 @@ void smartspin2k::autoResistanceChanged(bool value) {
     }
 }
 
-void smartspin2k::setShiftStep() {
-    QSettings settings;
-    uint16_t steps = settings.value("ss2k_shift_step", 900).toUInt();
+
+void smartspin2k::setShiftStep(uint16_t steps) {
     uint8_t shiftStep[] = {0x02, 0x08, 0x00, 0x00};
     shiftStep[2] = (uint8_t)(steps & 0xFF);
     shiftStep[3] = (uint8_t)(steps >> 8);
@@ -47,7 +59,6 @@ void smartspin2k::setShiftStep() {
 }
 
 void smartspin2k::lowInit(int8_t resistance) {
-    setShiftStep();
     uint8_t enable_syncmode[] = {0x02, 0x1B, 0x01};
     uint8_t disable_syncmode[] = {0x02, 0x1B, 0x00};
     writeCharacteristic(enable_syncmode, sizeof(enable_syncmode), "BLE_syncMode enabling", false, true);
@@ -135,8 +146,37 @@ void smartspin2k::writeCharacteristicFTMS(uint8_t *data, uint8_t data_len, const
     loop.exec();
 }
 
+void smartspin2k::calibrateShiftStep (int8_t nSamples, double *x, double *y) {
+    QSettings settings;
+    
+    // calculate slope and intercept using least squares regression
+    double xsum = 0, ysum = 0, x2sum=0, xysum=0;
+    
+    for (int8_t i=0; i<nSamples; i++) {
+        xsum += x[i];
+        ysum += y[i];
+        x2sum += x[i] * x[i];
+        xysum += x[i] * y[i];
+    }
+    
+    slope = (nSamples * xysum - xsum*ysum) / (nSamples * x2sum - xsum * xsum);
+    intercept = (x2sum * ysum - xsum * xysum)/(x2sum * nSamples - xsum * xsum);
+     
+    settings.setValue(QStringLiteral("ss2k_calibrated_slope"), slope);
+    settings.setValue(QStringLiteral("ss2k_calibrated_intercept"), intercept);
+    
+    emit debug(QStringLiteral("Calibrating SS2K:  slope=") + QString::number(slope) + QStringLiteral(" intercept=") + QString::number(intercept) );
+}
+
 void smartspin2k::forceResistance(int8_t requestResistance) {
 
+    QSettings settings;
+   
+    // if not calibrated, slope=0 and intercept is the configured shift step
+    uint16_t steps = slope * requestResistance + intercept;
+    
+    setShiftStep(steps);
+    
     lastRequestResistance = requestResistance;
 
     uint8_t write[] = {0x02, 0x17, 0x00, 0x00};
@@ -145,6 +185,7 @@ void smartspin2k::forceResistance(int8_t requestResistance) {
 
     writeCharacteristic(write, sizeof(write), QStringLiteral("forceResistance ") + QString::number(requestResistance));
 }
+
 
 void smartspin2k::update() {
     if (m_control->state() == QLowEnergyController::UnconnectedState) {

--- a/src/smartspin2k.h
+++ b/src/smartspin2k.h
@@ -54,7 +54,7 @@ class smartspin2k : public bike {
     void startDiscover();
     uint16_t watts();
     void forceResistance(int8_t requestResistance);
-    void setShiftStep();
+    void setShiftStep(uint16_t);
     void lowInit(int8_t resistance);
 
     QTimer *refresh;
@@ -83,6 +83,9 @@ class smartspin2k : public bike {
 
     uint8_t max_resistance;
 
+    double slope = 0.0;
+    double intercept = 0.0;
+    
     bike *parentDevice = nullptr;
 
 #ifdef Q_OS_IOS
@@ -99,6 +102,7 @@ class smartspin2k : public bike {
     void deviceDiscovered(const QBluetoothDeviceInfo &device);
     void resistanceReadFromTheBike(int8_t resistance);
     void autoResistanceChanged(bool value);
+    void calibrateShiftStep(int8_t nSamples, double *xSamples, double *ySamples);
 
   private slots:
 

--- a/src/smartspin2k.h
+++ b/src/smartspin2k.h
@@ -47,6 +47,7 @@ class smartspin2k : public bike {
     void *VirtualDevice();
 
   private:
+    const int max_calibration_samples = 4;
     void writeCharacteristic(uint8_t *data, uint8_t data_len, const QString &info, bool disable_log = false,
                              bool wait_for_response = false);
     void writeCharacteristicFTMS(uint8_t *data, uint8_t data_len, const QString &info, bool disable_log = false,
@@ -102,7 +103,7 @@ class smartspin2k : public bike {
     void deviceDiscovered(const QBluetoothDeviceInfo &device);
     void resistanceReadFromTheBike(int8_t resistance);
     void autoResistanceChanged(bool value);
-    void calibrateShiftStep(int8_t nSamples, double *xSamples, double *ySamples);
+    void calibrateShiftStep();
 
   private slots:
 


### PR DESCRIPTION
SS2K Shift Step calibration

Add calibration of SS2K shift step by resistance level using least squares method.  Sampling of data points in configuration TBD

I'm thinking it could work like this:
1. For each of the data points, QZ would set the resistance on the SS2K.  
2. The user would pedal and tap +/- to adjust the shift step for that data point.   setShiftStep is called with the new value.
3. When the resistances match, they'd tap OK and move on to the next data point.
4. When all 4 data points are set, calibrateShiftStep is called to calculate the slope and intercept which are then saved to settings.
