### PR TITLE
Improve functionality for Peloton App users

### DIFF
--- a/src/homeform.cpp
+++ b/src/homeform.cpp
@@ -211,6 +211,9 @@ homeform::homeform(QQmlApplicationEngine *engine, bluetooth *bl) {
     peloton_offset =
         new DataObject(QStringLiteral("Peloton Offset"), QStringLiteral("icons/icons/clock.png"), QStringLiteral("0"),
                        true, QStringLiteral("peloton_offset"), valueElapsedFontSize, labelFontSize);
+    peloton_remaining =
+        new DataObject(QStringLiteral("Peloton Rem."), QStringLiteral("icons/icons/clock.png"), QStringLiteral("0"),
+                       true, QStringLiteral("peloton_remaining"), valueElapsedFontSize, labelFontSize);
     strokesCount = new DataObject(QStringLiteral("Strokes Count"), QStringLiteral("icons/icons/cadence.png"),
                                   QStringLiteral("0"), false, QStringLiteral("strokes_count"), 48, labelFontSize);
     strokesLength = new DataObject(QStringLiteral("Strokes Length"), QStringLiteral("icons/icons/cadence.png"),
@@ -642,6 +645,12 @@ void homeform::sortTiles() {
                 dataList.append(peloton_offset);
             }
 
+            if (settings.value(QStringLiteral("tile_peloton_remaining_enabled"), false).toBool() &&
+                settings.value(QStringLiteral("tile_peloton_remaining_order"), 20).toInt() == i) {
+                peloton_remaining->setGridId(i);
+                dataList.append(peloton_remaining);
+            }
+
             if (settings.value(QStringLiteral("tile_calories_enabled"), true).toBool() &&
                 settings.value(QStringLiteral("tile_calories_order"), 0).toInt() == i) {
                 calories->setGridId(i);
@@ -808,6 +817,12 @@ void homeform::sortTiles() {
                 settings.value(QStringLiteral("tile_peloton_offset_order"), 20).toInt() == i) {
                 peloton_offset->setGridId(i);
                 dataList.append(peloton_offset);
+            }
+
+            if (settings.value(QStringLiteral("tile_peloton_remaining_enabled"), false).toBool() &&
+                settings.value(QStringLiteral("tile_peloton_remaining_order"), 20).toInt() == i) {
+                peloton_remaining->setGridId(i);
+                dataList.append(peloton_remaining);
             }
 
             if (settings.value(QStringLiteral("tile_calories_enabled"), true).toBool() &&
@@ -1021,6 +1036,12 @@ void homeform::sortTiles() {
                 dataList.append(peloton_offset);
             }
 
+            if (settings.value(QStringLiteral("tile_peloton_remaining_enabled"), false).toBool() &&
+                settings.value(QStringLiteral("tile_peloton_remaining_order"), 20).toInt() == i) {
+                peloton_remaining->setGridId(i);
+                dataList.append(peloton_remaining);
+            }
+
             if (settings.value(QStringLiteral("tile_calories_enabled"), true).toBool() &&
                 settings.value(QStringLiteral("tile_calories_order"), 0).toInt() == i) {
                 calories->setGridId(i);
@@ -1221,6 +1242,12 @@ void homeform::sortTiles() {
                 settings.value(QStringLiteral("tile_peloton_offset_order"), 20).toInt() == i) {
                 peloton_offset->setGridId(i);
                 dataList.append(peloton_offset);
+            }
+
+            if (settings.value(QStringLiteral("tile_peloton_remaining_enabled"), false).toBool() &&
+                settings.value(QStringLiteral("tile_peloton_remaining_order"), 20).toInt() == i) {
+                peloton_remaining->setGridId(i);
+                dataList.append(peloton_remaining);
             }
 
             if (settings.value(QStringLiteral("tile_calories_enabled"), true).toBool() &&
@@ -1581,7 +1608,8 @@ void homeform::Plus(const QString &name) {
             } else
                 bluetoothManager->device()->changeFanSpeed(bluetoothManager->device()->fanSpeed() + 1);
         }
-    } else if (name.contains(QStringLiteral("peloton_offset"))) {
+    } else if (name.contains(QStringLiteral("peloton_offset"))
+               || name.contains(QStringLiteral("peloton_remaining"))) {
 
         if (bluetoothManager->device() && trainProgram) {
             trainProgram->increaseElapsedTime(1);
@@ -1720,7 +1748,8 @@ void homeform::Minus(const QString &name) {
             } else
                 bluetoothManager->device()->changeFanSpeed(bluetoothManager->device()->fanSpeed() - 1);
         }
-    } else if (name.contains(QStringLiteral("peloton_offset"))) {
+    } else if (name.contains(QStringLiteral("peloton_offset"))
+               || name.contains(QStringLiteral("peloton_remaining"))) {
 
         if (bluetoothManager->device() && trainProgram) {
             trainProgram->decreaseElapsedTime(1);
@@ -1973,6 +2002,8 @@ void homeform::update() {
 
         if (trainProgram) {
             peloton_offset->setValue(QString::number(trainProgram->offsetElapsedTime()) + QStringLiteral(" sec."));
+            peloton_remaining->setValue(trainProgram->remainingTime().toString("h:mm:ss"));
+            peloton_remaining->setSecondLine(QString::number(trainProgram->offsetElapsedTime()) + QStringLiteral(" sec."));
             remaningTimeTrainingProgramCurrentRow->setValue(
                 trainProgram->currentRowRemainingTime().toString(QStringLiteral("h:mm:ss")));
             targetMets->setValue(QString::number(trainProgram->currentTargetMets(), 'f', 1));

--- a/src/homeform.cpp
+++ b/src/homeform.cpp
@@ -2251,43 +2251,49 @@ void homeform::update() {
                                 'f', 0));
             if (trainProgram) {
                 int8_t lower_requested_peloton_resistance = trainProgram->currentRow().lower_requested_peloton_resistance;
+                int8_t upper_requested_peloton_resistance = trainProgram->currentRow().upper_requested_peloton_resistance;
                 if (lower_requested_peloton_resistance != -1) {
-                    int8_t upper_requested_peloton_resistance = trainProgram->currentRow().upper_requested_peloton_resistance;
                     this->target_peloton_resistance->setSecondLine(
                         QStringLiteral("MIN: ") +
                         QString::number(lower_requested_peloton_resistance, 'f', 0) +
                         QStringLiteral(" MAX: ") +
                         QString::number(upper_requested_peloton_resistance, 'f', 0));
+                } else {
+                    this->target_peloton_resistance->setSecondLine(QLatin1String(""));
+                }
 
-                    if (peloton_resistance < lower_requested_peloton_resistance) {
+                if (settings.value(QStringLiteral("tile_peloton_resistance_color_enabled"), false).toBool()) {
+                    if (lower_requested_peloton_resistance == -1) {
+                        this->peloton_resistance->setValueFontColor(QStringLiteral("white"));
+                    } else if (peloton_resistance < lower_requested_peloton_resistance) {
                         this->peloton_resistance->setValueFontColor(QStringLiteral("red"));
                     } else if (peloton_resistance <= upper_requested_peloton_resistance) {
                         this->peloton_resistance->setValueFontColor(QStringLiteral("limegreen"));
                     } else {
                         this->peloton_resistance->setValueFontColor(QStringLiteral("orange"));
                     }
-                } else {
-                    this->target_peloton_resistance->setSecondLine(QLatin1String(""));
-                    this->peloton_resistance->setValueFontColor(QStringLiteral("white"));
                 }
 
                 int16_t lower_cadence = trainProgram->currentRow().lower_cadence;
+                int16_t upper_cadence = trainProgram->currentRow().upper_cadence;
                 if (lower_cadence != -1) {
-                    int16_t upper_cadence = trainProgram->currentRow().upper_cadence;
                     this->target_cadence->setSecondLine(
                         QStringLiteral("MIN: ") + QString::number(lower_cadence, 'f', 0) +
                         QStringLiteral(" MAX: ") + QString::number(upper_cadence, 'f', 0));
+                } else {
+                    this->target_cadence->setSecondLine(QLatin1String(""));
+                }
 
-                    if (cadence < lower_cadence) {
+                if (settings.value(QStringLiteral("tile_cadence_color_enabled"), false).toBool()) {
+                    if (lower_cadence == -1) {
+                        this->cadence->setValueFontColor(QStringLiteral("white"));
+                    } else if (cadence < lower_cadence) {
                         this->cadence->setValueFontColor(QStringLiteral("red"));
                     } else if (cadence <= upper_cadence) {
                         this->cadence->setValueFontColor(QStringLiteral("limegreen"));
                     } else {
                         this->cadence->setValueFontColor(QStringLiteral("orange"));
                     }
-                } else {
-                    this->target_cadence->setSecondLine(QLatin1String(""));
-                    this->cadence->setValueFontColor(QStringLiteral("white"));
                 }
             }
 

--- a/src/homeform.cpp
+++ b/src/homeform.cpp
@@ -195,7 +195,7 @@ homeform::homeform(QQmlApplicationEngine *engine, bluetooth *bl) {
                                 QStringLiteral("0:00:00"), false, QStringLiteral("lapElapsed"), valueElapsedFontSize,
                                 labelFontSize);
     remaningTimeTrainingProgramCurrentRow = new DataObject(
-        QStringLiteral("Time to Next"), QStringLiteral("icons/icons/clock.png"), QStringLiteral("0:00:00"), false,
+        QStringLiteral("Time to Next"), QStringLiteral("icons/icons/clock.png"), QStringLiteral("0:00:00"), true,
         QStringLiteral("remainingtimetrainprogramrow"), valueElapsedFontSize, labelFontSize);
 
     nextRows =
@@ -1608,9 +1608,12 @@ void homeform::Plus(const QString &name) {
             } else
                 bluetoothManager->device()->changeFanSpeed(bluetoothManager->device()->fanSpeed() + 1);
         }
+    } else if (name.contains(QStringLiteral("remainingtimetrainprogramrow"))) {
+        if (bluetoothManager->device() && trainProgram) {
+            trainProgram->increaseElapsedTime(QTime(0, 0, 0).secsTo(trainProgram->currentRowRemainingTime()));
+        }
     } else if (name.contains(QStringLiteral("peloton_offset"))
                || name.contains(QStringLiteral("peloton_remaining"))) {
-
         if (bluetoothManager->device() && trainProgram) {
             trainProgram->increaseElapsedTime(1);
         }
@@ -1748,9 +1751,15 @@ void homeform::Minus(const QString &name) {
             } else
                 bluetoothManager->device()->changeFanSpeed(bluetoothManager->device()->fanSpeed() - 1);
         }
+    } else if (name.contains(QStringLiteral("remainingtimetrainprogramrow"))) {
+        if (bluetoothManager->device() && trainProgram) {
+            // Offset:
+            // 1. To account for current tick
+            // 2. To bounce back to previous
+            trainProgram->decreaseElapsedTime(QTime(0, 0, 0).secsTo(trainProgram->currentRowElapsedTime()) + 2);
+        }
     } else if (name.contains(QStringLiteral("peloton_offset"))
                || name.contains(QStringLiteral("peloton_remaining"))) {
-
         if (bluetoothManager->device() && trainProgram) {
             trainProgram->decreaseElapsedTime(1);
         }
@@ -2006,6 +2015,8 @@ void homeform::update() {
             peloton_remaining->setSecondLine(QString::number(trainProgram->offsetElapsedTime()) + QStringLiteral(" sec."));
             remaningTimeTrainingProgramCurrentRow->setValue(
                 trainProgram->currentRowRemainingTime().toString(QStringLiteral("h:mm:ss")));
+            remaningTimeTrainingProgramCurrentRow->setSecondLine(
+                trainProgram->currentRowElapsedTime().toString(QStringLiteral("h:mm:ss")));
             targetMets->setValue(QString::number(trainProgram->currentTargetMets(), 'f', 1));
             trainrow next = trainProgram->getRowFromCurrent(1);
             trainrow next_1 = trainProgram->getRowFromCurrent(2);

--- a/src/homeform.cpp
+++ b/src/homeform.cpp
@@ -2219,21 +2219,44 @@ void homeform::update() {
                                     settings.value(QStringLiteral("bike_resistance_offset"), 4.0).toDouble(),
                                 'f', 0));
             if (trainProgram) {
-                if (trainProgram->currentRow().lower_requested_peloton_resistance != -1) {
+                int8_t lower_requested_peloton_resistance = trainProgram->currentRow().lower_requested_peloton_resistance;
+                if (lower_requested_peloton_resistance != -1) {
+                    int8_t upper_requested_peloton_resistance = trainProgram->currentRow().upper_requested_peloton_resistance;
                     this->target_peloton_resistance->setSecondLine(
                         QStringLiteral("MIN: ") +
-                        QString::number(trainProgram->currentRow().lower_requested_peloton_resistance, 'f', 0) +
+                        QString::number(lower_requested_peloton_resistance, 'f', 0) +
                         QStringLiteral(" MAX: ") +
-                        QString::number(trainProgram->currentRow().upper_requested_peloton_resistance, 'f', 0));
+                        QString::number(upper_requested_peloton_resistance, 'f', 0));
+
+                    if (peloton_resistance < lower_requested_peloton_resistance) {
+                        this->peloton_resistance->setValueFontColor(QStringLiteral("red"));
+                    } else if (peloton_resistance <= upper_requested_peloton_resistance) {
+                        this->peloton_resistance->setValueFontColor(QStringLiteral("limegreen"));
+                    } else {
+                        this->peloton_resistance->setValueFontColor(QStringLiteral("orange"));
+                    }
                 } else {
                     this->target_peloton_resistance->setSecondLine(QLatin1String(""));
+                    this->peloton_resistance->setValueFontColor(QStringLiteral("white"));
                 }
-                if (trainProgram->currentRow().lower_cadence != -1) {
+
+                int16_t lower_cadence = trainProgram->currentRow().lower_cadence;
+                if (lower_cadence != -1) {
+                    int16_t upper_cadence = trainProgram->currentRow().upper_cadence;
                     this->target_cadence->setSecondLine(
-                        QStringLiteral("MIN: ") + QString::number(trainProgram->currentRow().lower_cadence, 'f', 0) +
-                        QStringLiteral(" MAX: ") + QString::number(trainProgram->currentRow().upper_cadence, 'f', 0));
+                        QStringLiteral("MIN: ") + QString::number(lower_cadence, 'f', 0) +
+                        QStringLiteral(" MAX: ") + QString::number(upper_cadence, 'f', 0));
+
+                    if (cadence < lower_cadence) {
+                        this->cadence->setValueFontColor(QStringLiteral("red"));
+                    } else if (cadence <= upper_cadence) {
+                        this->cadence->setValueFontColor(QStringLiteral("limegreen"));
+                    } else {
+                        this->cadence->setValueFontColor(QStringLiteral("orange"));
+                    }
                 } else {
                     this->target_cadence->setSecondLine(QLatin1String(""));
+                    this->cadence->setValueFontColor(QStringLiteral("white"));
                 }
             }
 

--- a/src/homeform.h
+++ b/src/homeform.h
@@ -453,6 +453,7 @@ class homeform : public QObject {
     DataObject *fan;
     DataObject *jouls;
     DataObject *peloton_offset;
+    DataObject *peloton_remaining;
     DataObject *elapsed;
     DataObject *moving_time;
     DataObject *peloton_resistance;

--- a/src/settings.qml
+++ b/src/settings.qml
@@ -103,6 +103,8 @@ import Qt.labs.settings 1.0
             property int  tile_moving_time_order: 21
             property bool tile_peloton_offset_enabled: false
             property int  tile_peloton_offset_order: 22
+            property bool tile_peloton_remaining_enabled: false
+            property int  tile_peloton_remaining_order: 22
             property bool tile_peloton_difficulty_enabled: false
             property int  tile_peloton_difficulty_order: 32
             property bool tile_peloton_resistance_enabled: true
@@ -2436,6 +2438,38 @@ import Qt.labs.settings 1.0
                                 text: "OK"
                                 Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
                                 onClicked: settings.tile_peloton_offset_order = pelotonOffsetOrderTextField.displayText
+                            }
+                        }
+                    }
+
+                    AccordionCheckElement {
+                        id: pelotonRemainingEnabledAccordion
+                        title: qsTr("Peloton Remaining")
+                        linkedBoolSetting: "tile_peloton_remaining_enabled"
+                        settings: settings
+                        accordionContent: RowLayout {
+                            spacing: 10
+                            Label {
+                                id: labelPelotonRemainingOrder
+                                text: qsTr("order index:")
+                                Layout.fillWidth: true
+                                horizontalAlignment: Text.AlignRight
+                            }
+                            ComboBox {
+                                id: pelotonRemainingOrderTextField
+                                model: rootItem.tile_order
+                                displayText: settings.tile_peloton_remaining_order
+                                Layout.fillHeight: false
+                                Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                                onActivated: {
+                                    displayText = pelotonRemainingOrderTextField.currentValue
+                                 }
+                            }
+                            Button {
+                                id: okPelotonRemainingOrderButton
+                                text: "OK"
+                                Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                                onClicked: settings.tile_peloton_remaining_order = pelotonRemainingOrderTextField.displayText
                             }
                         }
                     }

--- a/src/settings.qml
+++ b/src/settings.qml
@@ -70,7 +70,6 @@ import Qt.labs.settings 1.0
             property bool tile_inclination_enabled: true
             property int  tile_inclination_order: 1
             property bool tile_cadence_enabled: true
-            property bool tile_cadence_color_enabled: false
             property int  tile_cadence_order: 2
             property bool tile_elevation_enabled: true
             property int  tile_elevation_order: 3
@@ -104,12 +103,9 @@ import Qt.labs.settings 1.0
             property int  tile_moving_time_order: 21
             property bool tile_peloton_offset_enabled: false
             property int  tile_peloton_offset_order: 22
-            property bool tile_peloton_remaining_enabled: false
-            property int  tile_peloton_remaining_order: 22
             property bool tile_peloton_difficulty_enabled: false
             property int  tile_peloton_difficulty_order: 32
-            property bool tile_peloton_resistance_enabled: true
-            property bool tile_peloton_resistance_color_enabled: false
+            property bool tile_peloton_resistance_enabled: true            
             property int  tile_peloton_resistance_order: 15
             property bool tile_datetime_enabled: true
             property int  tile_datetime_order: 16
@@ -347,6 +343,15 @@ import Qt.labs.settings 1.0
 
             // from the version 2.10.44
             property bool horizon_treadmill_7_8: false
+
+            // from the version 2.10.45
+            property string profile_name: "default"
+
+            // from the version 2.10.46
+            property bool tile_cadence_color_enabled: false
+            property bool tile_peloton_remaining_enabled: false
+            property int  tile_peloton_remaining_order: 22
+            property bool tile_peloton_resistance_color_enabled: false
         }
 
         function paddingZeros(text, limit) {

--- a/src/settings.qml
+++ b/src/settings.qml
@@ -70,6 +70,7 @@ import Qt.labs.settings 1.0
             property bool tile_inclination_enabled: true
             property int  tile_inclination_order: 1
             property bool tile_cadence_enabled: true
+            property bool tile_cadence_color_enabled: false
             property int  tile_cadence_order: 2
             property bool tile_elevation_enabled: true
             property int  tile_elevation_order: 3
@@ -108,6 +109,7 @@ import Qt.labs.settings 1.0
             property bool tile_peloton_difficulty_enabled: false
             property int  tile_peloton_difficulty_order: 32
             property bool tile_peloton_resistance_enabled: true
+            property bool tile_peloton_resistance_color_enabled: false
             property int  tile_peloton_resistance_order: 15
             property bool tile_datetime_enabled: true
             property int  tile_datetime_order: 16
@@ -1935,29 +1937,45 @@ import Qt.labs.settings 1.0
                         title: qsTr("Cadence")
                         linkedBoolSetting: "tile_cadence_enabled"
                         settings: settings
-                        accordionContent: RowLayout {
-                            spacing: 10
-                            Label {
-                                id: labelcadenceOrder
-                                text: qsTr("order index:")
+                        accordionContent:  ColumnLayout {
+                            SwitchDelegate {
+                                id: cadenceColorEnabled
+                                text: qsTr("Enable Cadence color")
+                                spacing: 0
+                                bottomPadding: 0
+                                topPadding: 0
+                                rightPadding: 0
+                                leftPadding: 0
+                                clip: false
+                                checked: settings.tile_cadence_color_enabled
+                                Layout.alignment: Qt.AlignLeft | Qt.AlignTop
                                 Layout.fillWidth: true
-                                horizontalAlignment: Text.AlignRight
+                                onClicked: settings.tile_cadence_color_enabled = checked
                             }
-                            ComboBox {
-                                id: cadenceOrderTextField
-                                model: rootItem.tile_order
-                                displayText: settings.tile_cadence_order
-                                Layout.fillHeight: false
-                                Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
-                                onActivated: {
-                                    displayText = cadenceOrderTextField.currentValue
-                                 }
-                            }
-                            Button {
-                                id: okcadenceOrderButton
-                                text: "OK"
-                                Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
-                                onClicked: settings.tile_cadence_order = cadenceOrderTextField.displayText
+                            RowLayout {
+                                spacing: 10
+                                Label {
+                                    id: labelcadenceOrder
+                                    text: qsTr("order index:")
+                                    Layout.fillWidth: true
+                                    horizontalAlignment: Text.AlignRight
+                                }
+                                ComboBox {
+                                    id: cadenceOrderTextField
+                                    model: rootItem.tile_order
+                                    displayText: settings.tile_cadence_order
+                                    Layout.fillHeight: false
+                                    Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                                    onActivated: {
+                                        displayText = cadenceOrderTextField.currentValue
+                                     }
+                                }
+                                Button {
+                                    id: okcadenceOrderButton
+                                    text: "OK"
+                                    Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                                    onClicked: settings.tile_cadence_order = cadenceOrderTextField.displayText
+                                }
                             }
                         }
                     }
@@ -2544,29 +2562,45 @@ import Qt.labs.settings 1.0
                         title: qsTr("Peloton Resistance")
                         linkedBoolSetting: "tile_peloton_resistance_enabled"
                         settings: settings
-                        accordionContent: RowLayout {
-                            spacing: 10
-                            Label {
-                                id: labelpeloton_resistanceOrder
-                                text: qsTr("order index:")
+                        accordionContent: ColumnLayout {
+                            SwitchDelegate {
+                                id: pelotonResistanceColorEnabled
+                                text: qsTr("Enable Peloton Resistance color")
+                                spacing: 0
+                                bottomPadding: 0
+                                topPadding: 0
+                                rightPadding: 0
+                                leftPadding: 0
+                                clip: false
+                                checked: settings.tile_peloton_resistance_color_enabled
+                                Layout.alignment: Qt.AlignLeft | Qt.AlignTop
                                 Layout.fillWidth: true
-                                horizontalAlignment: Text.AlignRight
+                                onClicked: settings.tile_peloton_resistance_color_enabled = checked
                             }
-                            ComboBox {
-                                id: peloton_resistanceOrderTextField
-                                model: rootItem.tile_order
-                                displayText: settings.tile_peloton_resistance_order
-                                Layout.fillHeight: false
-                                Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
-                                onActivated: {
-                                    displayText = peloton_resistanceOrderTextField.currentValue
-                                 }
-                            }
-                            Button {
-                                id: okpeloton_resistanceOrderButton
-                                text: "OK"
-                                Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
-                                onClicked: settings.tile_peloton_resistance_order = peloton_resistanceOrderTextField.displayText
+                            RowLayout {
+                                spacing: 10
+                                Label {
+                                    id: labelpeloton_resistanceOrder
+                                    text: qsTr("order index:")
+                                    Layout.fillWidth: true
+                                    horizontalAlignment: Text.AlignRight
+                                }
+                                ComboBox {
+                                    id: peloton_resistanceOrderTextField
+                                    model: rootItem.tile_order
+                                    displayText: settings.tile_peloton_resistance_order
+                                    Layout.fillHeight: false
+                                    Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                                    onActivated: {
+                                        displayText = peloton_resistanceOrderTextField.currentValue
+                                     }
+                                }
+                                Button {
+                                    id: okpeloton_resistanceOrderButton
+                                    text: "OK"
+                                    Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                                    onClicked: settings.tile_peloton_resistance_order = peloton_resistanceOrderTextField.displayText
+                                }
                             }
                         }
                     }

--- a/src/trainprogram.cpp
+++ b/src/trainprogram.cpp
@@ -540,6 +540,19 @@ QTime trainprogram::currentRowRemainingTime() {
     return QTime(0, 0, 0);
 }
 
+QTime trainprogram::remainingTime() {
+    uint32_t calculatedLine;
+    uint32_t calculatedTotalTime = 0;
+
+    if (rows.length() == 0)
+        return QTime(0, 0, 0);
+
+    for (calculatedLine = 0; calculatedLine < static_cast<uint32_t>(rows.length()); calculatedLine++) {
+        calculatedTotalTime += calculateTimeForRow(calculatedLine);
+    }
+    return QTime(0, 0, 0).addSecs(calculatedTotalTime - ticks);
+}
+
 QTime trainprogram::duration() {
 
     QTime total(0, 0, 0, 0);

--- a/src/trainprogram.cpp
+++ b/src/trainprogram.cpp
@@ -490,7 +490,6 @@ double trainprogram::currentTargetMets() {
 }
 
 QTime trainprogram::currentRowElapsedTime() {
-
     uint32_t calculatedLine;
     uint32_t calculatedElapsedTime = 0;
 
@@ -503,7 +502,7 @@ QTime trainprogram::currentRowElapsedTime() {
         calculatedElapsedTime += currentLine;
 
         if (calculatedElapsedTime > static_cast<uint32_t>(ticks)) {
-            return QTime(0, 0, ticks - (calculatedElapsedTime - currentLine));
+            return QTime(0, 0, 0).addSecs(ticks - (calculatedElapsedTime - currentLine));
         }
     }
     return QTime(0, 0, 0);

--- a/src/trainprogram.h
+++ b/src/trainprogram.h
@@ -54,6 +54,7 @@ class trainprogram : public QObject {
     QTime totalElapsedTime();
     QTime currentRowElapsedTime();
     QTime currentRowRemainingTime();
+    QTime remainingTime();
     double currentTargetMets();
     QTime duration();
     double totalDistance();


### PR DESCRIPTION
* Cadence and Resistance Tiles - Improve readability for bikes using red, limegreen, and orange for < min, <= max, < max respectively
* Peloton Offset Tile
  * Rename to Peloton Remaining/Rem.
  * Add remaining time to make it easier to match with Peloton app
  * Swap remaining time with offset as remaining time is more useful
* Time to Next Tile
  * Add Current Row Elapsed Time as secondary text
  * Enable writing to skip forward/back to next/previous row

Note: Time To Next -/+ along with Peloton Remaining makes it super easy to catch up to the correct timestamp now!

![Screenshot_1645774076](https://user-images.githubusercontent.com/277030/155673293-128c5e5c-8333-4a59-bab3-214770144a67.png)