### PR TITLE
Update resistance from trainprogram based on previous resistance %

### DIFF
--- a/src/bike.cpp
+++ b/src/bike.cpp
@@ -5,14 +5,31 @@
 
 bike::bike() { elapsed.setType(metric::METRIC_ELAPSED); }
 
+void bike::changeResistanceRange(int8_t lower, int8_t upper) {
+    // 0.0 is floor and 1.0 is ceil
+    double lastResistanceOffsetPerc = 0.0;
+    if (RequestedLowerResistance >= 0) {
+        lastResistanceOffsetPerc = (Resistance.value() - RequestedLowerResistance) / (RequestedUpperResistance - RequestedLowerResistance);
+    } else {
+        lastResistanceOffsetPerc = 0.0;
+    }
+
+    RequestedLowerResistance = lower;
+    RequestedUpperResistance = upper;
+
+    double calculatedResistance = RequestedLowerResistance + (lastResistanceOffsetPerc * (RequestedUpperResistance - RequestedLowerResistance));
+    changeResistance(calculatedResistance);
+}
+
 void bike::changeResistance(int8_t resistance) {
+    double calculatedResistance = resistance * m_difficult + gears();
     lastRawRequestedResistanceValue = resistance;
+
     if (autoResistanceEnable) {
-        double v = (resistance * m_difficult) + gears();
-        requestResistance = v;
+        requestResistance = calculatedResistance;
         emit resistanceChanged(requestResistance);
     }
-    RequestedResistance = resistance * m_difficult + gears();
+    RequestedResistance = calculatedResistance;
 }
 
 void bike::changeInclination(double grade, double percentage) {

--- a/src/bike.h
+++ b/src/bike.h
@@ -36,6 +36,7 @@ class bike : public bluetoothdevice {
     virtual bool inclinationAvailableByHardware();
 
   public Q_SLOTS:
+    virtual void changeResistanceRange(int8_t lower, int8_t upper);
     virtual void changeResistance(int8_t res);
     virtual void changeCadence(int16_t cad);
     virtual void changePower(int32_t power);
@@ -53,6 +54,8 @@ class bike : public bluetoothdevice {
     void steeringAngleChanged(double angle);
 
   protected:
+    int16_t RequestedLowerResistance = -1;
+    int16_t RequestedUpperResistance = -1;
     metric RequestedResistance;
     metric RequestedPelotonResistance;
     metric RequestedCadence;

--- a/src/homeform.cpp
+++ b/src/homeform.cpp
@@ -535,6 +535,8 @@ void homeform::trainProgramSignals() {
                    &treadmill::changeFanSpeed);
         disconnect(trainProgram, &trainprogram::changeSpeedAndInclination, ((treadmill *)bluetoothManager->device()),
                    &treadmill::changeSpeedAndInclination);
+        disconnect(trainProgram, &trainprogram::changeResistanceRange, ((bike *)bluetoothManager->device()),
+                   &bike::changeResistanceRange);
         disconnect(trainProgram, &trainprogram::changeResistance, ((bike *)bluetoothManager->device()),
                    &bike::changeResistance);
         disconnect(trainProgram, &trainprogram::changeRequestedPelotonResistance, ((bike *)bluetoothManager->device()),
@@ -562,6 +564,8 @@ void homeform::trainProgramSignals() {
                 &treadmill::changeInclination);
         connect(trainProgram, &trainprogram::changeSpeedAndInclination, ((treadmill *)bluetoothManager->device()),
                 &treadmill::changeSpeedAndInclination);
+        connect(trainProgram, &trainprogram::changeResistanceRange, ((bike *)bluetoothManager->device()),
+                &bike::changeResistanceRange);
         connect(trainProgram, &trainprogram::changeResistance, ((bike *)bluetoothManager->device()),
                 &bike::changeResistance);
         connect(trainProgram, &trainprogram::changeRequestedPelotonResistance, ((bike *)bluetoothManager->device()),

--- a/src/trainprogram.cpp
+++ b/src/trainprogram.cpp
@@ -99,6 +99,12 @@ void trainprogram::scheduler() {
                 emit changeInclination(rows.at(0).inclination, rows.at(0).inclination);
             }
         } else {
+            // Set both to ensure that we are tracking the range, but utilize intial value from trainprogram
+            if (rows.at(0).lower_resistance != -1 && true) {
+                qDebug() << "trainprogram change resistance range: " <<
+                                rows.at(0).lower_resistance << "-" << rows.at(0).upper_resistance;
+                emit changeResistanceRange(rows.at(0).lower_resistance, rows.at(0).upper_resistance);
+            }
             if (rows.at(0).resistance != -1) {
                 qDebug() << QStringLiteral("trainprogram change resistance") + QString::number(rows.at(0).resistance);
                 emit changeResistance(rows.at(0).resistance);
@@ -191,7 +197,12 @@ void trainprogram::scheduler() {
                     emit changeInclination(rows.at(currentStep).inclination, rows.at(currentStep).inclination);
                 }
             } else {
-                if (rows.at(currentStep).resistance != -1) {
+                // Only set range if available to ensure we update based on range instead of trainprogram
+                if (rows.at(currentStep).lower_resistance != -1 && true) {
+                    qDebug() << "trainprogram change resistance range: " <<
+                                    rows.at(currentStep).lower_resistance << "-" << rows.at(currentStep).upper_resistance;
+                    emit changeResistanceRange(rows.at(currentStep).lower_resistance, rows.at(currentStep).upper_resistance);
+                } else if (rows.at(currentStep).resistance != -1) {
                     qDebug() << QStringLiteral("trainprogram change resistance ") +
                                     QString::number(rows.at(currentStep).resistance);
                     emit changeResistance(rows.at(currentStep).resistance);

--- a/src/trainprogram.h
+++ b/src/trainprogram.h
@@ -84,8 +84,10 @@ class trainprogram : public QObject {
     void changeSpeed(double speed);
     bool changeFanSpeed(uint8_t speed);
     void changeInclination(double grade, double inclination);
+    void changeResistanceRange(int8_t lower, int8_t upper);
     void changeResistance(int8_t resistance);
     void changeRequestedPelotonResistance(int8_t resistance);
+    void changeCadenceRange(int16_t lower, int16_t upper);
     void changeCadence(int16_t cadence);
     void changePower(int32_t power);
     void changeSpeedAndInclination(double speed, double inclination);


### PR DESCRIPTION
It's more in line with how the Peloton Bike+ functions where each cue change updates the auto-resistance to the same % between prev-lower/pre-upper to post-lower/post-upper.

For instance if lower-upper is 40-50 and you're set at 42 (20% of 10), the next cue change to 30-40 will automatically change your resistance to 32 (20% of 10).

This would also allow you to adjust yourself on the fly as you can use the knob or on-screen controls to change to 35 (50% of 10, same lower-upper of 30-40) and the next cue change to 50-70 will automatically change your resistance to 60 (50% of 20).

Also addresses #718 