### PR TITLE
#890 fixed resource leak in PathController: don't use a QGeoPositionI…

### DIFF
--- a/src/PathController.cpp
+++ b/src/PathController.cpp
@@ -12,7 +12,28 @@ PathController::PathController(QObject *parent)
 {
     QGeoPositionInfoSource *source = QGeoPositionInfoSource::createDefaultSource(this);
     if (source) {
+
+        auto sourceName = source->sourceName();
+        auto objectName = source->objectName();
+
+        qDebug() << "Found QGeoPositionInfoSource: sourceName:" << sourceName
+                 << ", objectName:"<<objectName;
+
         QGeoCoordinate const coordinate = source->lastKnownPosition().coordinate();
-        this->setCenter(coordinate);
+
+        if(coordinate.isValid()) {
+            this->setCenter(coordinate);
+        } else {
+            // This has been known to happen.
+            // The Trixter X-Dream V1 bike using a Prolific PL2303HXA Serial to USB converter
+            // is identified by QGeoPositionInfoSource in Qt 5.15.2 as a source, but it delivers
+            // invalid data.
+
+            qDebug() << "Last known coordinate was not valid. Ignoring device.";
+            delete source;
+        }
     }
 }
+
+
+


### PR DESCRIPTION
…nfoSource that delivers an invalid last known position. Also added some logging.