### PR TITLE
#1221 decoupled template managers from class bluetooth and added tests

### DIFF
--- a/src/bluetooth.cpp
+++ b/src/bluetooth.cpp
@@ -118,12 +118,8 @@ bluetooth::~bluetooth() {
     }*/
 }
 
-void bluetooth::startTemplateManagers(bluetoothdevice *b) {
+void bluetooth::signalBluetoothDeviceConnected(bluetoothdevice *b) {
     emit this->bluetoothDeviceConnected(b);
-}
-
-void bluetooth::stopTemplateManagers() {
-    emit this->bluetoothDeviceDisconnected();
 }
 
 void bluetooth::finished() {
@@ -548,7 +544,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                     connect(this, &bluetooth::searchingStop, m3iBike, &m3ibike::searchingStop);
                     if (this->discoveryAgent && !this->discoveryAgent->isActive())
                         emit searchingStop();
-                    this->startTemplateManagers(m3iBike);
+                    this->signalBluetoothDeviceConnected(m3iBike);
                 }
             } else if (fake_bike && !fakeBike) {
                 this->stopDiscovery();
@@ -562,7 +558,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 if (this->discoveryAgent && !this->discoveryAgent->isActive()) {
                     emit searchingStop();
                 }
-                this->startTemplateManagers(fakeBike);
+                this->signalBluetoothDeviceConnected(fakeBike);
             } else if (fakedevice_elliptical && !fakeElliptical) {
                 this->stopDiscovery();
                 fakeElliptical = new fakeelliptical(noWriteResistance, noHeartService, false);
@@ -576,7 +572,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 if (this->discoveryAgent && !this->discoveryAgent->isActive()) {
                     emit searchingStop();
                 }
-                this->startTemplateManagers(fakeElliptical);
+                this->signalBluetoothDeviceConnected(fakeElliptical);
             } else if (fakedevice_treadmill && !fakeTreadmill) {
                 this->stopDiscovery();
                 fakeTreadmill = new faketreadmill(noWriteResistance, noHeartService, false);
@@ -590,7 +586,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 if (this->discoveryAgent && !this->discoveryAgent->isActive()) {
                     emit searchingStop();
                 }
-                this->startTemplateManagers(fakeTreadmill);
+                this->signalBluetoothDeviceConnected(fakeTreadmill);
 
             } else if (!proformtdf4ip.isEmpty() && !proformWifiBike) {
                 this->stopDiscovery();
@@ -606,7 +602,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 if (this->discoveryAgent && !this->discoveryAgent->isActive()) {
                     emit searchingStop();
                 }
-                this->startTemplateManagers(proformWifiBike);
+                this->signalBluetoothDeviceConnected(proformWifiBike);
 #ifndef Q_OS_IOS
             } else if (!computrainerSerialPort.isEmpty() && !computrainerBike) {
                 this->stopDiscovery();
@@ -622,7 +618,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 if (this->discoveryAgent && !this->discoveryAgent->isActive()) {
                     emit searchingStop();
                 }
-                this->startTemplateManagers(computrainerBike);
+                this->signalBluetoothDeviceConnected(computrainerBike);
 #endif
             } else if (!proformtreadmillip.isEmpty() && !proformWifiTreadmill) {
                 this->stopDiscovery();
@@ -638,7 +634,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 if (this->discoveryAgent && !this->discoveryAgent->isActive()) {
                     emit searchingStop();
                 }
-                this->startTemplateManagers(proformWifiTreadmill);
+                this->signalBluetoothDeviceConnected(proformWifiTreadmill);
             } else if (!nordictrack_2950_ip.isEmpty() && !nordictrackifitadbTreadmill) {
                 this->stopDiscovery();
                 nordictrackifitadbTreadmill = new nordictrackifitadbtreadmill(noWriteResistance, noHeartService);
@@ -651,7 +647,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 if (this->discoveryAgent && !this->discoveryAgent->isActive()) {
                     emit searchingStop();
                 }
-                this->startTemplateManagers(nordictrackifitadbTreadmill);
+                this->signalBluetoothDeviceConnected(nordictrackifitadbTreadmill);
             } else if (!tdf_10_ip.isEmpty() && !nordictrackifitadbBike) {
                 this->stopDiscovery();
                 nordictrackifitadbBike = new nordictrackifitadbbike(noWriteResistance, noHeartService);
@@ -664,7 +660,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 if (this->discoveryAgent && !this->discoveryAgent->isActive()) {
                     emit searchingStop();
                 }
-                this->startTemplateManagers(nordictrackifitadbBike);
+                this->signalBluetoothDeviceConnected(nordictrackifitadbBike);
             } else if (csc_as_bike && b.name().startsWith(cscName) && !cscBike && filter) {
                 this->setLastBluetoothDevice(b);
                 this->stopDiscovery();
@@ -678,7 +674,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 if (this->discoveryAgent && !this->discoveryAgent->isActive()) {
                     emit searchingStop();
                 }
-                this->startTemplateManagers(cscBike);
+                this->signalBluetoothDeviceConnected(cscBike);
             } else if (power_as_bike && b.name().startsWith(powerSensorName) && !powerBike && filter) {
                 this->setLastBluetoothDevice(b);
                 this->stopDiscovery();
@@ -692,7 +688,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 if (this->discoveryAgent && !this->discoveryAgent->isActive()) {
                     emit searchingStop();
                 }
-                this->startTemplateManagers(powerBike);
+                this->signalBluetoothDeviceConnected(powerBike);
             } else if ((((power_as_treadmill && b.name().startsWith(powerSensorName))) ||
                         b.name().toUpper().startsWith(QStringLiteral("ZWIFT RUNPOD"))) &&
                        !powerTreadmill && filter) {
@@ -709,7 +705,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 if (this->discoveryAgent && !this->discoveryAgent->isActive()) {
                     emit searchingStop();
                 }
-                this->startTemplateManagers(powerTreadmill);
+                this->signalBluetoothDeviceConnected(powerTreadmill);
             } else if (b.name().toUpper().startsWith(QStringLiteral("DOMYOS-ROW")) &&
                        !b.name().startsWith(QStringLiteral("DomyosBridge")) && !domyosRower && filter) {
                 this->setLastBluetoothDevice(b);
@@ -726,7 +722,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 if (this->discoveryAgent && !this->discoveryAgent->isActive()) {
                     emit searchingStop();
                 }
-                this->startTemplateManagers(domyosRower);
+                this->signalBluetoothDeviceConnected(domyosRower);
             } else if (b.name().startsWith(QStringLiteral("Domyos-Bike")) &&
                        !b.name().startsWith(QStringLiteral("DomyosBridge")) && !domyosBike && filter) {
                 this->setLastBluetoothDevice(b);
@@ -742,7 +738,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 if (this->discoveryAgent && !this->discoveryAgent->isActive()) {
                     emit searchingStop();
                 }
-                this->startTemplateManagers(domyosBike);
+                this->signalBluetoothDeviceConnected(domyosBike);
             } else if (b.name().startsWith(QStringLiteral("Domyos-EL")) &&
                        !b.name().startsWith(QStringLiteral("DomyosBridge")) && !domyosElliptical && filter) {
                 this->setLastBluetoothDevice(b);
@@ -759,7 +755,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 if (this->discoveryAgent && !this->discoveryAgent->isActive()) {
                     emit searchingStop();
                 }
-                this->startTemplateManagers(domyosElliptical);
+                this->signalBluetoothDeviceConnected(domyosElliptical);
             } else if ((b.name().toUpper().startsWith(QStringLiteral("NAUTILUS E"))) &&
                        !nautilusElliptical && // NAUTILUS E616
                        filter) {
@@ -776,7 +772,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 connect(this, &bluetooth::searchingStop, nautilusElliptical, &nautiluselliptical::searchingStop);
                 if (this->discoveryAgent && !this->discoveryAgent->isActive())
                     emit searchingStop();
-                this->startTemplateManagers(nautilusElliptical);
+                this->signalBluetoothDeviceConnected(nautilusElliptical);
             } else if ((b.name().toUpper().startsWith(QStringLiteral("NAUTILUS B"))) && !nautilusBike &&
                        filter) { // NAUTILUS B628
                 this->setLastBluetoothDevice(b);
@@ -792,7 +788,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 connect(this, &bluetooth::searchingStop, nautilusBike, &nautilusbike::searchingStop);
                 if (this->discoveryAgent && !this->discoveryAgent->isActive())
                     emit searchingStop();
-                this->startTemplateManagers(nautilusBike);
+                this->signalBluetoothDeviceConnected(nautilusBike);
             } else if ((b.name().toUpper().startsWith(QStringLiteral("I_FS"))) && !proformElliptical && filter) {
                 this->setLastBluetoothDevice(b);
                 this->stopDiscovery();
@@ -806,7 +802,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 // connect(this, &bluetooth::searchingStop, proformElliptical, &proformelliptical::searchingStop);
                 if (this->discoveryAgent && !this->discoveryAgent->isActive())
                     emit searchingStop();
-                this->startTemplateManagers(proformElliptical);
+                this->signalBluetoothDeviceConnected(proformElliptical);
             } else if ((b.name().toUpper().startsWith(QStringLiteral("I_EL"))) && !nordictrackElliptical && filter) {
                 this->setLastBluetoothDevice(b);
                 this->stopDiscovery();
@@ -821,7 +817,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 // connect(this, &bluetooth::searchingStop, proformElliptical, &proformelliptical::searchingStop);
                 if (this->discoveryAgent && !this->discoveryAgent->isActive())
                     emit searchingStop();
-                this->startTemplateManagers(nordictrackElliptical);
+                this->signalBluetoothDeviceConnected(nordictrackElliptical);
 
             } else if ((b.name().toUpper().startsWith(QStringLiteral("I_VE"))) && !proformEllipticalTrainer && filter) {
                 this->setLastBluetoothDevice(b);
@@ -838,7 +834,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 // &proformellipticaltrainer::searchingStop);
                 if (this->discoveryAgent && !this->discoveryAgent->isActive())
                     emit searchingStop();
-                this->startTemplateManagers(proformEllipticalTrainer);
+                this->signalBluetoothDeviceConnected(proformEllipticalTrainer);
             } else if ((b.name().toUpper().startsWith(QStringLiteral("I_RW"))) && !proformRower && filter) {
                 this->setLastBluetoothDevice(b);
                 this->stopDiscovery();
@@ -852,7 +848,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 // connect(this, &bluetooth::searchingStop, proformElliptical, &proformelliptical::searchingStop);
                 if (this->discoveryAgent && !this->discoveryAgent->isActive())
                     emit searchingStop();
-                this->startTemplateManagers(proformRower);
+                this->signalBluetoothDeviceConnected(proformRower);
             } else if ((b.name().toUpper().startsWith(QStringLiteral("B01_"))) && !bhFitnessElliptical && filter) {
                 this->setLastBluetoothDevice(b);
                 this->stopDiscovery();
@@ -867,7 +863,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 // connect(this, &bluetooth::searchingStop, bhFitnessElliptical, &bhfitnesselliptical::searchingStop);
                 if (this->discoveryAgent && !this->discoveryAgent->isActive())
                     emit searchingStop();
-                this->startTemplateManagers(bhFitnessElliptical);
+                this->signalBluetoothDeviceConnected(bhFitnessElliptical);
             } else if ((b.name().toUpper().startsWith(QStringLiteral("E95S")) ||
                         b.name().toUpper().startsWith(QStringLiteral("E25")) ||
                         b.name().toUpper().startsWith(QStringLiteral("E35")) ||
@@ -890,7 +886,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 connect(this, &bluetooth::searchingStop, soleElliptical, &soleelliptical::searchingStop);
                 if (this->discoveryAgent && !this->discoveryAgent->isActive())
                     emit searchingStop();
-                this->startTemplateManagers(soleElliptical);
+                this->signalBluetoothDeviceConnected(soleElliptical);
             } else if (b.name().startsWith(QStringLiteral("Domyos")) &&
                        !b.name().startsWith(QStringLiteral("DomyosBr")) && !domyos && !domyosElliptical &&
                        !domyosBike && !domyosRower && filter) {
@@ -910,7 +906,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 connect(this, &bluetooth::searchingStop, domyos, &domyostreadmill::searchingStop);
                 if (this->discoveryAgent && !this->discoveryAgent->isActive())
                     emit searchingStop();
-                this->startTemplateManagers(domyos);
+                this->signalBluetoothDeviceConnected(domyos);
             } else if ((
                            // Xiaomi k12 pro treadmill KS-ST-K12PRO
                            b.name().toUpper().startsWith(QStringLiteral("KS-ST-K12PRO")) ||
@@ -942,7 +938,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 connect(this, &bluetooth::searchingStop, kingsmithR2Treadmill, &kingsmithr2treadmill::searchingStop);
                 if (this->discoveryAgent && !this->discoveryAgent->isActive())
                     emit searchingStop();
-                this->startTemplateManagers(kingsmithR2Treadmill);
+                this->signalBluetoothDeviceConnected(kingsmithR2Treadmill);
             } else if ((b.name().toUpper().startsWith(QStringLiteral("R1 PRO")) ||
                         b.name().toUpper().startsWith(QStringLiteral("KINGSMITH")) ||
                         !b.name().toUpper().compare(QStringLiteral("RE")) || // just "RE"
@@ -970,7 +966,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                         &kingsmithr1protreadmill::searchingStop);
                 if (this->discoveryAgent && !this->discoveryAgent->isActive())
                     emit searchingStop();
-                this->startTemplateManagers(kingsmithR1ProTreadmill);
+                this->signalBluetoothDeviceConnected(kingsmithR1ProTreadmill);
             } else if ((b.name().toUpper().startsWith(QStringLiteral("ZW-"))) && !shuaA5Treadmill && filter) {
                 this->setLastBluetoothDevice(b);
                 this->stopDiscovery();
@@ -988,7 +984,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 shuaA5Treadmill->deviceDiscovered(b);
                 if (this->discoveryAgent && !this->discoveryAgent->isActive())
                     emit searchingStop();
-                this->startTemplateManagers(shuaA5Treadmill);
+                this->signalBluetoothDeviceConnected(shuaA5Treadmill);
             } else if ((b.name().toUpper().startsWith(QStringLiteral("TRUE")) ||
                         b.name().toUpper().startsWith(QStringLiteral("TREADMILL"))) &&
                        !trueTreadmill && filter) {
@@ -1008,7 +1004,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 trueTreadmill->deviceDiscovered(b);
                 if (this->discoveryAgent && !this->discoveryAgent->isActive())
                     emit searchingStop();
-                this->startTemplateManagers(trueTreadmill);
+                this->signalBluetoothDeviceConnected(trueTreadmill);
             } else if ((b.name().toUpper().startsWith(QStringLiteral("F80")) ||
                         b.name().toUpper().startsWith(QStringLiteral("F65")) ||
                         b.name().toUpper().startsWith(QStringLiteral("TT8")) ||
@@ -1037,7 +1033,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 if (this->discoveryAgent && !this->discoveryAgent->isActive()) {
                     emit searchingStop();
                 }
-                this->startTemplateManagers(soleF80);
+                this->signalBluetoothDeviceConnected(soleF80);
             } else if ((b.name().toUpper().startsWith(QStringLiteral("LF")) && b.name().length() == 18) &&
                        !lifefitnessTreadmill && filter) {
                 this->setLastBluetoothDevice(b);
@@ -1062,7 +1058,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 if (this->discoveryAgent && !this->discoveryAgent->isActive()) {
                     emit searchingStop();
                 }
-                this->startTemplateManagers(lifefitnessTreadmill);
+                this->signalBluetoothDeviceConnected(lifefitnessTreadmill);
             } else if ((b.name().toUpper().startsWith(QStringLiteral("HORIZON")) ||
                         b.name().toUpper().startsWith(QStringLiteral("AFG SPORT")) ||
                         b.name().toUpper().startsWith(QStringLiteral("WLT2541")) ||
@@ -1103,7 +1099,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 if (this->discoveryAgent && !this->discoveryAgent->isActive()) {
                     emit searchingStop();
                 }
-                this->startTemplateManagers(horizonTreadmill);
+                this->signalBluetoothDeviceConnected(horizonTreadmill);
             } else if ((b.name().toUpper().startsWith(QStringLiteral("MYRUN ")) ||
                         b.name().toUpper().startsWith(QStringLiteral("MERACH-U3")) // FTMS
                         ) &&
@@ -1140,7 +1136,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                     if (this->discoveryAgent && !this->discoveryAgent->isActive()) {
                         emit searchingStop();
                     }
-                    this->startTemplateManagers(technogymmyrunTreadmill);
+                    this->signalBluetoothDeviceConnected(technogymmyrunTreadmill);
                 }
 #ifndef Q_OS_IOS
                 else {
@@ -1164,7 +1160,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                     if (this->discoveryAgent && !this->discoveryAgent->isActive()) {
                         emit searchingStop();
                     }
-                    this->startTemplateManagers(technogymmyrunrfcommTreadmill);
+                    this->signalBluetoothDeviceConnected(technogymmyrunrfcommTreadmill);
                 }
 #endif
             } else if ((b.name().toUpper().startsWith("TACX NEO") ||
@@ -1183,7 +1179,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 // connect(tacxneo2Bike, SIGNAL(speedChanged(double)), this, SLOT(speedChanged(double)));
                 // connect(tacxneo2Bike, SIGNAL(inclinationChanged(double)), this, SLOT(inclinationChanged(double)));
                 tacxneo2Bike->deviceDiscovered(b);
-                this->startTemplateManagers(tacxneo2Bike);
+                this->signalBluetoothDeviceConnected(tacxneo2Bike);
             } else if ((b.name().toUpper().startsWith(QStringLiteral(">CABLE")) ||
                         (b.name().toUpper().startsWith(QStringLiteral("MD")) && b.name().length() == 7) ||
                         // BIKE 1, BIKE 2, BIKE 3...
@@ -1203,7 +1199,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 // connect(echelonConnectSport, SIGNAL(inclinationChanged(double)), this,
                 // SLOT(inclinationChanged(double)));
                 npeCableBike->deviceDiscovered(b);
-                this->startTemplateManagers(npeCableBike);
+                this->signalBluetoothDeviceConnected(npeCableBike);
             } else if (((b.name().startsWith("FS-") && hammerRacerS) ||
                         (b.name().toUpper().startsWith("DHZ-")) ||   // JK fitness 577
                         (b.name().toUpper().startsWith("MKSM")) ||   // MKSM3600036
@@ -1231,7 +1227,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 // connect(trxappgateusb, SIGNAL(disconnected()), this, SLOT(restart()));
                 connect(ftmsBike, &ftmsbike::debug, this, &bluetooth::debug);
                 ftmsBike->deviceDiscovered(b);
-                this->startTemplateManagers(ftmsBike);
+                this->signalBluetoothDeviceConnected(ftmsBike);
             } else if ((b.name().toUpper().startsWith("KICKR SNAP") || b.name().toUpper().startsWith("KICKR BIKE") ||
                         b.name().toUpper().startsWith("KICKR ROLLR")) &&
                        !wahooKickrSnapBike && filter) {
@@ -1245,7 +1241,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 // connect(wahooKickrSnapBike, SIGNAL(disconnected()), this, SLOT(restart()));
                 connect(wahooKickrSnapBike, &wahookickrsnapbike::debug, this, &bluetooth::debug);
                 wahooKickrSnapBike->deviceDiscovered(b);
-                this->startTemplateManagers(wahooKickrSnapBike);
+                this->signalBluetoothDeviceConnected(wahooKickrSnapBike);
             } else if (((b.name().toUpper().startsWith("JFIC")) // HORIZON GR7
                         ) &&
                        !horizonGr7Bike && filter) {
@@ -1259,7 +1255,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 // connect(trxappgateusb, SIGNAL(disconnected()), this, SLOT(restart()));
                 connect(horizonGr7Bike, &horizongr7bike::debug, this, &bluetooth::debug);
                 horizonGr7Bike->deviceDiscovered(b);
-                this->startTemplateManagers(horizonGr7Bike);
+                this->signalBluetoothDeviceConnected(horizonGr7Bike);
             } else if ((b.name().toUpper().startsWith(QStringLiteral("STAGES ")) ||
                         (b.name().toUpper().startsWith(QStringLiteral("ASSIOMA")) &&
                          powerSensorName.startsWith(QStringLiteral("Disabled")))) &&
@@ -1275,7 +1271,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 // connect(stagesBike, SIGNAL(speedChanged(double)), this, SLOT(speedChanged(double)));
                 // connect(stagesBike, SIGNAL(inclinationChanged(double)), this, SLOT(inclinationChanged(double)));
                 stagesBike->deviceDiscovered(b);
-                this->startTemplateManagers(stagesBike);
+                this->signalBluetoothDeviceConnected(stagesBike);
             } else if (b.name().startsWith(QStringLiteral("SMARTROW")) && !smartrowRower && filter) {
                 this->setLastBluetoothDevice(b);
                 this->stopDiscovery();
@@ -1290,7 +1286,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 // connect(v, SIGNAL(speedChanged(double)), this, SLOT(speedChanged(double)));
                 // connect(smartrowRower, SIGNAL(inclinationChanged(double)), this, SLOT(inclinationChanged(double)));
                 smartrowRower->deviceDiscovered(b);
-                this->startTemplateManagers(smartrowRower);
+                this->signalBluetoothDeviceConnected(smartrowRower);
             } else if ((b.name().toUpper().startsWith(QStringLiteral("PM5")) &&
                         b.name().toUpper().endsWith(QStringLiteral("SKI"))) &&
                        !concept2Skierg && filter) {
@@ -1306,7 +1302,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 // connect(v, SIGNAL(speedChanged(double)), this, SLOT(speedChanged(double)));
                 // connect(concept2Skierg, SIGNAL(inclinationChanged(double)), this, SLOT(inclinationChanged(double)));
                 concept2Skierg->deviceDiscovered(b);
-                this->startTemplateManagers(concept2Skierg);
+                this->signalBluetoothDeviceConnected(concept2Skierg);
             } else if ((b.name().toUpper().startsWith(QStringLiteral("CR 00")) ||
                         b.name().toUpper().startsWith(QStringLiteral("KAYAKPRO")) ||
                         b.name().toUpper().startsWith(QStringLiteral("WHIPR")) ||
@@ -1326,7 +1322,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 // connect(v, SIGNAL(speedChanged(double)), this, SLOT(speedChanged(double)));
                 // connect(ftmsRower, SIGNAL(inclinationChanged(double)), this, SLOT(inclinationChanged(double)));
                 ftmsRower->deviceDiscovered(b);
-                this->startTemplateManagers(ftmsRower);
+                this->signalBluetoothDeviceConnected(ftmsRower);
             } else if ((b.name().toUpper().startsWith(QLatin1String("ECH-STRIDE")) ||
                         b.name().toUpper().startsWith(QLatin1String("ECH-UK-")) ||
                         b.name().toUpper().startsWith(QLatin1String("ECH-SD-SPT"))) &&
@@ -1343,7 +1339,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 connect(echelonStride, &echelonstride::speedChanged, this, &bluetooth::speedChanged);
                 connect(echelonStride, &echelonstride::inclinationChanged, this, &bluetooth::inclinationChanged);
                 echelonStride->deviceDiscovered(b);
-                this->startTemplateManagers(echelonStride);
+                this->signalBluetoothDeviceConnected(echelonStride);
             } else if ((b.name().toUpper().startsWith(QLatin1String("Q37"))) && !octaneElliptical && filter) {
                 this->setLastBluetoothDevice(b);
                 this->stopDiscovery();
@@ -1357,7 +1353,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 connect(octaneElliptical, &octaneelliptical::speedChanged, this, &bluetooth::speedChanged);
                 connect(octaneElliptical, &octaneelliptical::inclinationChanged, this, &bluetooth::inclinationChanged);
                 octaneElliptical->deviceDiscovered(b);
-                this->startTemplateManagers(octaneElliptical);
+                this->signalBluetoothDeviceConnected(octaneElliptical);
             } else if ((b.name().toUpper().startsWith(QLatin1String("ZR7"))) && !octaneTreadmill && filter) {
                 this->setLastBluetoothDevice(b);
                 this->stopDiscovery();
@@ -1371,7 +1367,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 connect(octaneTreadmill, &octanetreadmill::speedChanged, this, &bluetooth::speedChanged);
                 connect(octaneTreadmill, &octanetreadmill::inclinationChanged, this, &bluetooth::inclinationChanged);
                 octaneTreadmill->deviceDiscovered(b);
-                this->startTemplateManagers(octaneTreadmill);
+                this->signalBluetoothDeviceConnected(octaneTreadmill);
             } else if ((b.name().startsWith(QStringLiteral("ECH-ROW")) ||
                         b.name().toUpper().startsWith(QStringLiteral("ROWSPORT-")) ||
                         b.name().startsWith(QStringLiteral("ROW-S"))) &&
@@ -1389,7 +1385,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 // connect(echelonRower, SIGNAL(speedChanged(double)), this, SLOT(speedChanged(double)));
                 // connect(echelonRower, SIGNAL(inclinationChanged(double)), this, SLOT(inclinationChanged(double)));
                 echelonRower->deviceDiscovered(b);
-                this->startTemplateManagers(echelonRower);
+                this->signalBluetoothDeviceConnected(echelonRower);
             } else if (b.name().startsWith(QStringLiteral("ECH")) && !echelonRower && !echelonStride &&
                        !echelonConnectSport && filter) {
                 this->setLastBluetoothDevice(b);
@@ -1406,7 +1402,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 // connect(echelonConnectSport, SIGNAL(inclinationChanged(double)), this,
                 // SLOT(inclinationChanged(double)));
                 echelonConnectSport->deviceDiscovered(b);
-                this->startTemplateManagers(echelonConnectSport);
+                this->signalBluetoothDeviceConnected(echelonConnectSport);
             } else if (b.name().toUpper().startsWith(QStringLiteral("MEPANEL")) && !mepanelBike && filter) {
                 this->setLastBluetoothDevice(b);
                 this->stopDiscovery();
@@ -1417,7 +1413,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 connect(mepanelBike, &bluetoothdevice::connectedAndDiscovered, this,
                         &bluetooth::connectedAndDiscovered);
                 mepanelBike->deviceDiscovered(b);
-                this->startTemplateManagers(mepanelBike);
+                this->signalBluetoothDeviceConnected(mepanelBike);
             } else if ((b.name().toUpper().startsWith(QStringLiteral("IC BIKE")) ||
                         (b.name().toUpper().startsWith(QStringLiteral("C7-")) && b.name().length() != 17) ||
                         b.name().toUpper().startsWith(QStringLiteral("C9/C10"))) &&
@@ -1435,7 +1431,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 // connect(echelonConnectSport, SIGNAL(inclinationChanged(double)), this,
                 // SLOT(inclinationChanged(double)));
                 schwinnIC4Bike->deviceDiscovered(b);
-                this->startTemplateManagers(schwinnIC4Bike);
+                this->signalBluetoothDeviceConnected(schwinnIC4Bike);
             } else if (b.name().toUpper().startsWith(QStringLiteral("EW-BK")) && !sportsTechBike && filter) {
                 this->setLastBluetoothDevice(b);
                 this->stopDiscovery();
@@ -1450,7 +1446,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 // connect(echelonConnectSport, SIGNAL(inclinationChanged(double)), this,
                 // SLOT(inclinationChanged(double)));
                 sportsTechBike->deviceDiscovered(b);
-                this->startTemplateManagers(sportsTechBike);
+                this->signalBluetoothDeviceConnected(sportsTechBike);
             } else if ((b.name().toUpper().startsWith(QStringLiteral("CARDIOFIT")) ||
                         (b.name().toUpper().contains(QStringLiteral("CARE")) &&
                          b.name().length() == 11)) // CARE9040177 - Carefitness CV-351
@@ -1468,7 +1464,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 // connect(sportsPlusBike, SIGNAL(inclinationChanged(double)), this,
                 // SLOT(inclinationChanged(double)));
                 sportsPlusBike->deviceDiscovered(b);
-                this->startTemplateManagers(sportsPlusBike);
+                this->signalBluetoothDeviceConnected(sportsPlusBike);
             } else if (b.name().startsWith(yesoulbike::bluetoothName) && !yesoulBike && filter) {
                 this->setLastBluetoothDevice(b);
                 this->stopDiscovery();
@@ -1483,7 +1479,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 // connect(echelonConnectSport, SIGNAL(inclinationChanged(double)), this,
                 // SLOT(inclinationChanged(double)));
                 yesoulBike->deviceDiscovered(b);
-                this->startTemplateManagers(yesoulBike);
+                this->signalBluetoothDeviceConnected(yesoulBike);
             } else if ((b.name().startsWith(QStringLiteral("I_EB")) || b.name().startsWith(QStringLiteral("I_SB"))) &&
                        !proformBike && filter) {
                 this->setLastBluetoothDevice(b);
@@ -1499,7 +1495,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 // connect(proformBike, SIGNAL(speedChanged(double)), this, SLOT(speedChanged(double)));
                 // connect(proformBike, SIGNAL(inclinationChanged(double)), this, SLOT(inclinationChanged(double)));
                 proformBike->deviceDiscovered(b);
-                this->startTemplateManagers(proformBike);
+                this->signalBluetoothDeviceConnected(proformBike);
             } else if ((b.name().startsWith(QStringLiteral("I_TL"))) && !proformTreadmill && filter) {
                 this->setLastBluetoothDevice(b);
                 this->stopDiscovery();
@@ -1514,7 +1510,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 // connect(proformtreadmill, SIGNAL(inclinationChanged(double)), this,
                 // SLOT(inclinationChanged(double)));
                 proformTreadmill->deviceDiscovered(b);
-                this->startTemplateManagers(proformTreadmill);
+                this->signalBluetoothDeviceConnected(proformTreadmill);
             } else if (b.name().toUpper().startsWith(QStringLiteral("ESLINKER")) && !eslinkerTreadmill && filter) {
                 this->setLastBluetoothDevice(b);
                 this->stopDiscovery();
@@ -1529,7 +1525,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 // connect(proformtreadmill, SIGNAL(inclinationChanged(double)), this,
                 // SLOT(inclinationChanged(double)));
                 eslinkerTreadmill->deviceDiscovered(b);
-                this->startTemplateManagers(eslinkerTreadmill);
+                this->signalBluetoothDeviceConnected(eslinkerTreadmill);
             } else if (b.name().toUpper().startsWith(QStringLiteral("PAFERS_")) && !pafersTreadmill &&
                        (pafers_treadmill || pafers_treadmill_bh_iboxster_plus) && filter) {
                 this->setLastBluetoothDevice(b);
@@ -1545,7 +1541,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 // connect(pafersTreadmill, SIGNAL(inclinationChanged(double)), this,
                 // SLOT(inclinationChanged(double)));
                 pafersTreadmill->deviceDiscovered(b);
-                this->startTemplateManagers(pafersTreadmill);
+                this->signalBluetoothDeviceConnected(pafersTreadmill);
             } else if (b.name().toUpper().startsWith(QStringLiteral("BOWFLEX T")) && !bowflexT216Treadmill && filter) {
                 this->setLastBluetoothDevice(b);
                 this->stopDiscovery();
@@ -1560,7 +1556,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 // connect(bowflexTreadmill, SIGNAL(inclinationChanged(double)), this,
                 // SLOT(inclinationChanged(double)));
                 bowflexT216Treadmill->deviceDiscovered(b);
-                this->startTemplateManagers(bowflexT216Treadmill);
+                this->signalBluetoothDeviceConnected(bowflexT216Treadmill);
             } else if (b.name().toUpper().startsWith(QStringLiteral("NAUTILUS T")) && !nautilusTreadmill && filter) {
                 this->setLastBluetoothDevice(b);
                 this->stopDiscovery();
@@ -1575,7 +1571,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 // connect(nautilusTreadmill, SIGNAL(inclinationChanged(double)), this,
                 // SLOT(inclinationChanged(double)));
                 nautilusTreadmill->deviceDiscovered(b);
-                this->startTemplateManagers(nautilusTreadmill);
+                this->signalBluetoothDeviceConnected(nautilusTreadmill);
             } else if ((b.name().startsWith(QStringLiteral("Flywheel")) ||
                         // BIKE 1, BIKE 2, BIKE 3...
                         (b.name().toUpper().startsWith(QStringLiteral("BIKE")) && flywheel_life_fitness_ic8 == true &&
@@ -1594,7 +1590,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 // connect(echelonConnectSport, SIGNAL(inclinationChanged(double)), this,
                 // SLOT(inclinationChanged(double)));
                 flywheelBike->deviceDiscovered(b);
-                this->startTemplateManagers(flywheelBike);
+                this->signalBluetoothDeviceConnected(flywheelBike);
             } else if ((b.name().toUpper().startsWith(QStringLiteral("MCF-"))) && !mcfBike && filter) {
                 this->setLastBluetoothDevice(b);
                 this->stopDiscovery();
@@ -1608,7 +1604,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 // connect(mcfBike, SIGNAL(inclinationChanged(double)), this,
                 // SLOT(inclinationChanged(double)));
                 mcfBike->deviceDiscovered(b);
-                this->startTemplateManagers(mcfBike);
+                this->signalBluetoothDeviceConnected(mcfBike);
             } else if ((b.name().startsWith(QStringLiteral("TRX ROUTE KEY"))) && !toorx && filter) {
                 this->setLastBluetoothDevice(b);
                 this->stopDiscovery();
@@ -1618,7 +1614,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 // connect(toorx, SIGNAL(disconnected()), this, SLOT(restart()));
                 connect(toorx, &toorxtreadmill::debug, this, &bluetooth::debug);
                 toorx->deviceDiscovered(b);
-                this->startTemplateManagers(toorx);
+                this->signalBluetoothDeviceConnected(toorx);
             } else if ((b.name().toUpper().startsWith(QStringLiteral("BH DUALKIT"))) && !iConceptBike && filter) {
                 this->setLastBluetoothDevice(b);
                 this->stopDiscovery();
@@ -1629,7 +1625,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 // connect(toorx, SIGNAL(disconnected()), this, SLOT(restart()));
                 connect(iConceptBike, &iconceptbike::debug, this, &bluetooth::debug);
                 iConceptBike->deviceDiscovered(b);
-                this->startTemplateManagers(iConceptBike);
+                this->signalBluetoothDeviceConnected(iConceptBike);
             } else if ((b.name().toUpper().startsWith(QStringLiteral("XT385")) ||
                         b.name().toUpper().startsWith(QStringLiteral("XT485")) ||
                         b.name().toUpper().startsWith(QStringLiteral("XT800")) ||
@@ -1645,7 +1641,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 connect(spiritTreadmill, &spirittreadmill::debug, this, &bluetooth::debug);
                 connect(spiritTreadmill, &spirittreadmill::inclinationChanged, this, &bluetooth::inclinationChanged);
                 spiritTreadmill->deviceDiscovered(b);
-                this->startTemplateManagers(spiritTreadmill);
+                this->signalBluetoothDeviceConnected(spiritTreadmill);
             } else if (b.name().toUpper().startsWith(QStringLiteral("RUNNERT")) && !activioTreadmill && filter) {
                 this->setLastBluetoothDevice(b);
                 this->stopDiscovery();
@@ -1656,7 +1652,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 // connect(activioTreadmill, SIGNAL(disconnected()), this, SLOT(restart()));
                 connect(activioTreadmill, &activiotreadmill::debug, this, &bluetooth::debug);
                 activioTreadmill->deviceDiscovered(b);
-                this->startTemplateManagers(activioTreadmill);
+                this->signalBluetoothDeviceConnected(activioTreadmill);
             } else if (((b.name().startsWith(QStringLiteral("TOORX"))) ||
                         (b.name().startsWith(QStringLiteral("V-RUN"))) ||
                         (b.name().toUpper().startsWith(QStringLiteral("K80_"))) ||
@@ -1675,7 +1671,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 // connect(trxappgateusb, SIGNAL(disconnected()), this, SLOT(restart()));
                 connect(trxappgateusb, &trxappgateusbtreadmill::debug, this, &bluetooth::debug);
                 trxappgateusb->deviceDiscovered(b);
-                this->startTemplateManagers(trxappgateusb);
+                this->signalBluetoothDeviceConnected(trxappgateusb);
             } else if ((b.name().toUpper().startsWith(QStringLiteral("TUN ")) ||
                         ((b.name().startsWith(QStringLiteral("TOORX")) ||
                           b.name().toUpper().startsWith(QStringLiteral("I-CONSOIE+")) ||
@@ -1697,7 +1693,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 // connect(trxappgateusb, SIGNAL(disconnected()), this, SLOT(restart()));
                 connect(trxappgateusbBike, &trxappgateusbbike::debug, this, &bluetooth::debug);
                 trxappgateusbBike->deviceDiscovered(b);
-                this->startTemplateManagers(trxappgateusbBike);
+                this->signalBluetoothDeviceConnected(trxappgateusbBike);
             } else if ((b.name().toUpper().startsWith(QStringLiteral("X-BIKE"))) && !ultraSportBike && filter) {
                 this->setLastBluetoothDevice(b);
                 this->stopDiscovery();
@@ -1709,7 +1705,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 // connect(ultraSportBike, SIGNAL(disconnected()), this, SLOT(restart()));
                 // connect(ultraSportBike, &solebike::debug, this, &bluetooth::debug);
                 ultraSportBike->deviceDiscovered(b);
-                this->startTemplateManagers(ultraSportBike);
+                this->signalBluetoothDeviceConnected(ultraSportBike);
             } else if ((b.name().toUpper().startsWith(QStringLiteral("KEEP_BIKE_"))) && !keepBike && filter) {
                 this->setLastBluetoothDevice(b);
                 this->stopDiscovery();
@@ -1719,7 +1715,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 // connect(keepBike, SIGNAL(disconnected()), this, SLOT(restart()));
                 // connect(keepBike, &solebike::debug, this, &bluetooth::debug);
                 keepBike->deviceDiscovered(b);
-                this->startTemplateManagers(keepBike);
+                this->signalBluetoothDeviceConnected(keepBike);
             } else if ((b.name().toUpper().startsWith(QStringLiteral("LCB")) ||
                         b.name().toUpper().startsWith(QStringLiteral("R92"))) &&
                        !soleBike && filter) {
@@ -1731,7 +1727,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 // connect(soleBike, SIGNAL(disconnected()), this, SLOT(restart()));
                 // connect(soleBike, &solebike::debug, this, &bluetooth::debug);
                 soleBike->deviceDiscovered(b);
-                this->startTemplateManagers(soleBike);
+                this->signalBluetoothDeviceConnected(soleBike);
             } else if (b.name().toUpper().startsWith(QStringLiteral("BFCP")) && !skandikaWiriBike && filter) {
                 this->setLastBluetoothDevice(b);
                 this->stopDiscovery();
@@ -1743,7 +1739,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 // connect(skandikaWiriBike, SIGNAL(disconnected()), this, SLOT(restart()));
                 connect(skandikaWiriBike, &skandikawiribike::debug, this, &bluetooth::debug);
                 skandikaWiriBike->deviceDiscovered(b);
-                this->startTemplateManagers(skandikaWiriBike);
+                this->signalBluetoothDeviceConnected(skandikaWiriBike);
             } else if (((b.name().toUpper().startsWith("RQ") && b.name().length() == 5) ||
                         (b.name().toUpper().startsWith("SCH130")) || // not a renpho bike an FTMS one
                         ((b.name().startsWith(QStringLiteral("TOORX"))) && toorx_ftms && !toorx_ftms_treadmill)) &&
@@ -1756,7 +1752,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 // connect(trxappgateusb, SIGNAL(disconnected()), this, SLOT(restart()));
                 connect(renphoBike, SIGNAL(debug(QString)), this, SLOT(debug(QString)));
                 renphoBike->deviceDiscovered(b);
-                this->startTemplateManagers(renphoBike);
+                this->signalBluetoothDeviceConnected(renphoBike);
             } else if ((b.name().toUpper().startsWith("PAFERS_")) && !pafersBike && !pafers_treadmill && filter) {
                 this->setLastBluetoothDevice(b);
                 this->stopDiscovery();
@@ -1767,7 +1763,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 // connect(pafersBike, SIGNAL(disconnected()), this, SLOT(restart()));
                 connect(pafersBike, SIGNAL(debug(QString)), this, SLOT(debug(QString)));
                 pafersBike->deviceDiscovered(b);
-                this->startTemplateManagers(pafersBike);
+                this->signalBluetoothDeviceConnected(pafersBike);
             } else if (((b.name().startsWith(QStringLiteral("FS-")) && snode_bike) ||
                         b.name().startsWith(QStringLiteral("TF-"))) && // TF-769DF2
                        !snodeBike &&
@@ -1780,7 +1776,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 // connect(trxappgateusb, SIGNAL(disconnected()), this, SLOT(restart()));
                 connect(snodeBike, &snodebike::debug, this, &bluetooth::debug);
                 snodeBike->deviceDiscovered(b);
-                this->startTemplateManagers(snodeBike);
+                this->signalBluetoothDeviceConnected(snodeBike);
             } else if (((b.name().startsWith(QStringLiteral("FS-")) && fitplus_bike) ||
                         b.name().startsWith(QStringLiteral("MRK-"))) &&
                        !fitPlusBike && !ftmsBike && !snodeBike && filter) {
@@ -1795,7 +1791,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 // NOTE: Commented due to #358
                 // connect(fitPlusBike, SIGNAL(debug(QString)), this, SLOT(debug(QString)));
                 fitPlusBike->deviceDiscovered(b);
-                this->startTemplateManagers(fitPlusBike);
+                this->signalBluetoothDeviceConnected(fitPlusBike);
             } else if (((b.name().startsWith(QStringLiteral("FS-")) && !snode_bike && !fitplus_bike && !ftmsBike) ||
                         (b.name().startsWith(QStringLiteral("SW")) && b.name().length() == 14) ||
                         (b.name().startsWith(QStringLiteral("BF70")))) &&
@@ -1811,7 +1807,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 connect(this, &bluetooth::searchingStop, fitshowTreadmill, &fitshowtreadmill::searchingStop);
                 if (this->discoveryAgent && !this->discoveryAgent->isActive())
                     emit searchingStop();
-                this->startTemplateManagers(fitshowTreadmill);
+                this->signalBluetoothDeviceConnected(fitshowTreadmill);
             } else if (b.name().toUpper().startsWith(QStringLiteral("IC")) && b.name().length() == 8 && !inspireBike &&
                        filter) {
                 this->setLastBluetoothDevice(b);
@@ -1834,7 +1830,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 if (this->discoveryAgent && !this->discoveryAgent->isActive()) {
                     emit searchingStop();
                 }
-                this->startTemplateManagers(inspireBike);
+                this->signalBluetoothDeviceConnected(inspireBike);
             } else if (b.name().toUpper().startsWith(QStringLiteral("CHRONO ")) && !chronoBike && filter) {
                 this->setLastBluetoothDevice(b);
                 this->stopDiscovery();
@@ -1855,7 +1851,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 if (this->discoveryAgent && !this->discoveryAgent->isActive()) {
                     emit searchingStop();
                 }
-                this->startTemplateManagers(chronoBike);
+                this->signalBluetoothDeviceConnected(chronoBike);
             }
         }
     }

--- a/src/bluetooth.h
+++ b/src/bluetooth.h
@@ -269,8 +269,7 @@ private:
      * @param b The bluetooth device info.
      */
     void setLastBluetoothDevice(const QBluetoothDeviceInfo &b);
-    void startTemplateManagers(bluetoothdevice *b);
-    void stopTemplateManagers();
+    void signalBluetoothDeviceConnected(bluetoothdevice *b);
 signals:
     void deviceConnected(QBluetoothDeviceInfo b);
     void deviceFound(QString name);

--- a/src/bluetooth.h
+++ b/src/bluetooth.h
@@ -124,22 +124,16 @@ class bluetooth : public QObject, public SignalHandler {
     explicit bluetooth(bool logs, const QString &deviceName = QLatin1String(""), bool noWriteResistance = false,
                        bool noHeartService = false, uint32_t pollDeviceTime = 200, bool noConsole = false,
                        bool testResistance = false, uint8_t bikeResistanceOffset = 4, double bikeResistanceGain = 1.0,
-                       bool createTemplateManagers=true, bool startDiscovery=true);
+                       bool startDiscovery=true);
     ~bluetooth();
     bluetoothdevice *device();
     bluetoothdevice *externalInclination() { return eliteRizer; }
     bluetoothdevice *heartRateDevice() { return heartRateBelt; }
     QList<QBluetoothDeviceInfo> devices;
     bool onlyDiscover = false;
-    TemplateInfoSenderBuilder *getUserTemplateManager() const { return userTemplateManager; }
-    TemplateInfoSenderBuilder *getInnerTemplateManager() const { return innerTemplateManager; }
-
 
 private:
     bool useDiscovery = false;
-    bool createTemplateManagers =false;
-    TemplateInfoSenderBuilder *userTemplateManager = nullptr;
-    TemplateInfoSenderBuilder *innerTemplateManager = nullptr;
     QFile *debugCommsLog = nullptr;
     QBluetoothDeviceDiscoveryAgent *discoveryAgent = nullptr;
     bhfitnesselliptical *bhFitnessElliptical = nullptr;
@@ -283,6 +277,8 @@ signals:
     void searchingStop();
     void ftmsAccessoryConnected(smartspin2k *d);
 
+    void bluetoothDeviceConnected(bluetoothdevice *b);
+    void bluetoothDeviceDisconnected();
   public slots:
     void restart();
     void debug(const QString &string);

--- a/src/discoveryoptions.h
+++ b/src/discoveryoptions.h
@@ -49,11 +49,6 @@ public:
      * @brief Use to suppress starting discovery in the constructor, e.g. for testing.
      */
     bool startDiscovery = true;
-
-    /**
-     * @brief Used to suppress the creation of the tempalte managers to decouple from the UI.
-     */
-    bool createTemplateManagers = true;
 };
 
 

--- a/src/homeform.cpp
+++ b/src/homeform.cpp
@@ -144,6 +144,21 @@ homeform::homeform(QQmlApplicationEngine *engine, bluetooth *bl) {
     const int valueElapsedFontSize = 30;
     const int valueTimeFontSize = 22;
 #endif
+
+    QString innerId = QStringLiteral("inner");
+    QString sKey = QStringLiteral("template_") + innerId + QStringLiteral("_" TEMPLATE_PRIVATE_WEBSERVER_ID "_");
+
+    QString path = homeform::getWritableAppDir() + QStringLiteral("QZTemplates");
+    this->userTemplateManager = TemplateInfoSenderBuilder::getInstance(
+                QStringLiteral("user"), QStringList({path, QStringLiteral(":/templates/")}), this);
+
+    settings.setValue(sKey + QStringLiteral("enabled"), true);
+    settings.setValue(sKey + QStringLiteral("type"), TEMPLATE_TYPE_WEBSERVER);
+    settings.setValue(sKey + QStringLiteral("port"), 0);
+    this->innerTemplateManager = TemplateInfoSenderBuilder::getInstance(innerId, QStringList({QStringLiteral(":/inner_templates/")}), this);
+
+
+
     speed = new DataObject(QStringLiteral("Speed (") + unit + QStringLiteral("/h)"),
                            QStringLiteral("icons/icons/speed.png"), QStringLiteral("0.0"), true,
                            QStringLiteral("speed"), 48, labelFontSize);
@@ -387,52 +402,54 @@ homeform::homeform(QQmlApplicationEngine *engine, bluetooth *bl) {
 
     this->bluetoothManager = bl;
     this->engine = engine;
+    connect(bluetoothManager, &bluetooth::bluetoothDeviceConnected, this, &homeform::bluetoothDeviceConnected);
+    connect(bluetoothManager, &bluetooth::bluetoothDeviceDisconnected, this, &homeform::bluetoothDeviceDisconnected);
     connect(bluetoothManager, &bluetooth::deviceFound, this, &homeform::deviceFound);
     connect(bluetoothManager, &bluetooth::deviceConnected, this, &homeform::deviceConnected);
     connect(bluetoothManager, &bluetooth::ftmsAccessoryConnected, this, &homeform::ftmsAccessoryConnected);
     connect(bluetoothManager, &bluetooth::deviceConnected, this, &homeform::trainProgramSignals);
-    connect(this, &homeform::workoutNameChanged, bluetoothManager->getUserTemplateManager(),
+    connect(this, &homeform::workoutNameChanged, this->userTemplateManager,
             &TemplateInfoSenderBuilder::onWorkoutNameChanged);
-    connect(this, &homeform::workoutStartDateChanged, bluetoothManager->getUserTemplateManager(),
+    connect(this, &homeform::workoutStartDateChanged, this->userTemplateManager,
             &TemplateInfoSenderBuilder::onWorkoutStartDate);
-    connect(this, &homeform::instructorNameChanged, bluetoothManager->getUserTemplateManager(),
+    connect(this, &homeform::instructorNameChanged, this->userTemplateManager,
             &TemplateInfoSenderBuilder::onInstructorName);
-    connect(this, &homeform::workoutEventStateChanged, bluetoothManager->getUserTemplateManager(),
+    connect(this, &homeform::workoutEventStateChanged, this->userTemplateManager,
             &TemplateInfoSenderBuilder::workoutEventStateChanged);
-    connect(bluetoothManager->getUserTemplateManager(), &TemplateInfoSenderBuilder::activityDescriptionChanged, this,
+    connect(this->userTemplateManager, &TemplateInfoSenderBuilder::activityDescriptionChanged, this,
             &homeform::setActivityDescription);
-    connect(bluetoothManager->getInnerTemplateManager(), &TemplateInfoSenderBuilder::chartSaved, this,
+    connect(this->innerTemplateManager, &TemplateInfoSenderBuilder::chartSaved, this,
             &homeform::chartSaved);
-    connect(bluetoothManager->getInnerTemplateManager(), &TemplateInfoSenderBuilder::lap, this, &homeform::Lap);
-    connect(bluetoothManager->getInnerTemplateManager(), &TemplateInfoSenderBuilder::floatingClose, this,
+    connect(this->innerTemplateManager, &TemplateInfoSenderBuilder::lap, this, &homeform::Lap);
+    connect(this->innerTemplateManager, &TemplateInfoSenderBuilder::floatingClose, this,
             &homeform::floatingOpen);
-    connect(bluetoothManager->getInnerTemplateManager(), &TemplateInfoSenderBuilder::pelotonOffset_Plus, this,
+    connect(this->innerTemplateManager, &TemplateInfoSenderBuilder::pelotonOffset_Plus, this,
             &homeform::pelotonOffset_Plus);
-    connect(bluetoothManager->getInnerTemplateManager(), &TemplateInfoSenderBuilder::pelotonOffset_Minus, this,
+    connect(this->innerTemplateManager, &TemplateInfoSenderBuilder::pelotonOffset_Minus, this,
             &homeform::pelotonOffset_Minus);
-    connect(bluetoothManager->getInnerTemplateManager(), &TemplateInfoSenderBuilder::pelotonOffset, this,
+    connect(this->innerTemplateManager, &TemplateInfoSenderBuilder::pelotonOffset, this,
             &homeform::pelotonOffset);
-    connect(bluetoothManager->getInnerTemplateManager(), &TemplateInfoSenderBuilder::pelotonAskStart, this,
+    connect(this->innerTemplateManager, &TemplateInfoSenderBuilder::pelotonAskStart, this,
             &homeform::pelotonAskStart);
-    connect(bluetoothManager->getInnerTemplateManager(), &TemplateInfoSenderBuilder::peloton_start_workout, this,
+    connect(this->innerTemplateManager, &TemplateInfoSenderBuilder::peloton_start_workout, this,
             &homeform::peloton_start_workout);
-    connect(bluetoothManager->getInnerTemplateManager(), &TemplateInfoSenderBuilder::peloton_abort_workout, this,
+    connect(this->innerTemplateManager, &TemplateInfoSenderBuilder::peloton_abort_workout, this,
             &homeform::peloton_abort_workout);
-    connect(bluetoothManager->getInnerTemplateManager(), &TemplateInfoSenderBuilder::Start, this,
+    connect(this->innerTemplateManager, &TemplateInfoSenderBuilder::Start, this,
             &homeform::Start);
-    connect(bluetoothManager->getInnerTemplateManager(), &TemplateInfoSenderBuilder::Pause, this,
+    connect(this->innerTemplateManager, &TemplateInfoSenderBuilder::Pause, this,
             &homeform::Start);
-    connect(bluetoothManager->getInnerTemplateManager(), &TemplateInfoSenderBuilder::Stop, this,
+    connect(this->innerTemplateManager, &TemplateInfoSenderBuilder::Stop, this,
             &homeform::Stop);
-    connect(this, &homeform::workoutNameChanged, bluetoothManager->getInnerTemplateManager(),
+    connect(this, &homeform::workoutNameChanged, this->innerTemplateManager,
             &TemplateInfoSenderBuilder::onWorkoutNameChanged);
-    connect(this, &homeform::workoutStartDateChanged, bluetoothManager->getInnerTemplateManager(),
+    connect(this, &homeform::workoutStartDateChanged, this->innerTemplateManager,
             &TemplateInfoSenderBuilder::onWorkoutStartDate);
-    connect(this, &homeform::instructorNameChanged, bluetoothManager->getInnerTemplateManager(),
+    connect(this, &homeform::instructorNameChanged, this->innerTemplateManager,
             &TemplateInfoSenderBuilder::onInstructorName);
-    connect(this, &homeform::workoutEventStateChanged, bluetoothManager->getInnerTemplateManager(),
+    connect(this, &homeform::workoutEventStateChanged, this->innerTemplateManager,
             &TemplateInfoSenderBuilder::workoutEventStateChanged);
-    connect(bluetoothManager->getInnerTemplateManager(), &TemplateInfoSenderBuilder::activityDescriptionChanged, this,
+    connect(this->innerTemplateManager, &TemplateInfoSenderBuilder::activityDescriptionChanged, this,
             &homeform::setActivityDescription);
     engine->rootContext()->setContextProperty(QStringLiteral("rootItem"), (QObject *)this);
 
@@ -2643,6 +2660,16 @@ void homeform::pelotonOffset_Plus() { Plus(QStringLiteral("peloton_offset")); }
 
 void homeform::pelotonOffset_Minus() { Minus(QStringLiteral("peloton_offset")); }
 
+void homeform::bluetoothDeviceConnected(bluetoothdevice *b) {
+    this->innerTemplateManager->start(b);
+    this->userTemplateManager->start(b);
+}
+
+void homeform::bluetoothDeviceDisconnected() {
+    this->innerTemplateManager->stop();
+    this->userTemplateManager->stop();
+}
+
 void homeform::Minus(const QString &name) {
     QSettings settings;
     bool miles = settings.value(QZSettings::miles_unit, QZSettings::default_miles_unit).toBool();
@@ -2895,7 +2922,7 @@ void homeform::Start_inner(bool send_event_to_device) {
 
 #ifdef Q_OS_IOS
             // due to #857
-            bluetoothManager->getInnerTemplateManager()->start(bluetoothManager->device());
+            this->innerTemplateManager->start(bluetoothManager->device());
 #endif
 
             if (!pelotonHandler || (pelotonHandler && !pelotonHandler->isWorkoutInProgress())) {
@@ -2943,7 +2970,7 @@ void homeform::Stop() {
 
 #ifdef Q_OS_IOS
     // due to #857
-    bluetoothManager->getInnerTemplateManager()->reinit();
+    this->innerTemplateManager->reinit();
 #endif
 
     if (settings.value(QZSettings::tts_enabled, QZSettings::default_tts_enabled).toBool())

--- a/src/homeform.h
+++ b/src/homeform.h
@@ -502,6 +502,8 @@ class homeform : public QObject {
     }
 
   private:
+    TemplateInfoSenderBuilder *userTemplateManager = nullptr;
+    TemplateInfoSenderBuilder *innerTemplateManager = nullptr;
     QList<QObject *> dataList;
     QList<SessionLine> Session;
     bluetooth *bluetoothManager;
@@ -711,6 +713,8 @@ class homeform : public QObject {
     void pelotonOffset_Plus();
     void pelotonOffset_Minus();
     int pelotonOffset() { return (trainProgram ? trainProgram->offsetElapsedTime() : 0); }
+    void bluetoothDeviceConnected(bluetoothdevice *b);
+    void bluetoothDeviceDisconnected();
 
 #if defined(Q_OS_WIN) || (defined(Q_OS_MAC) && !defined(Q_OS_IOS))
     void licenseReply(QNetworkReply *reply);

--- a/tst/Devices/bluetoothdevicetestsuite.h
+++ b/tst/Devices/bluetoothdevicetestsuite.h
@@ -8,6 +8,7 @@
 
 template <typename T>
 class BluetoothDeviceTestSuite : public testing::Test {
+
 protected:
     T typeParam;
 
@@ -42,8 +43,23 @@ protected:
      * Bascially replaces EXPECT_NO_THROW, for ease of breakpoint placement.
      * @param bt
      * @param deviceInfo
+     * @param expectMatch True if the bluetooth object is expected to detect the bluetoothdevice type for this test.
      */
-    void tryDetectDevice(bluetooth& bt, const QBluetoothDeviceInfo& deviceInfo) const;
+    void tryDetectDevice(bluetooth &bt, const QBluetoothDeviceInfo &deviceInfo) const;
+
+    /**
+     * @brief Tests device detection.
+     * @param testData The test data object for the device to be detected (or not).
+     * @param bt The object that will do the detecting.
+     * @param deviceInfo The device info for the device for which detection will be attempted.
+     * @param expectMatch Indicates if the device is expected to be detected (true) or not (false).
+     * @param restart Indicates if the bluetooth (bt) object should be restarted.
+     * @param failMessage The failure message if the device is not detected when expected to be, or detected when not expected to be.
+     */
+    void testDeviceDetection(BluetoothDeviceTestData * testData, bluetooth& bt, const QBluetoothDeviceInfo& deviceInfo, bool expectMatch, bool restart, const QString& failMessage) const;
+
+    void testDeviceDetection(BluetoothDeviceTestData * testData, bluetooth& bt, const QBluetoothDeviceInfo& deviceInfo, bool expectMatch, bool restart, const std::string& failMessage) const;
+
 public:
     BluetoothDeviceTestSuite() : testSettings("Roberto Viola", "QDomyos-Zwift Testing") {}
 

--- a/tst/Devices/bluetoothdevicetestsuite.h
+++ b/tst/Devices/bluetoothdevicetestsuite.h
@@ -43,7 +43,6 @@ protected:
      * Bascially replaces EXPECT_NO_THROW, for ease of breakpoint placement.
      * @param bt
      * @param deviceInfo
-     * @param expectMatch True if the bluetooth object is expected to detect the bluetoothdevice type for this test.
      */
     void tryDetectDevice(bluetooth &bt, const QBluetoothDeviceInfo &deviceInfo) const;
 
@@ -58,6 +57,15 @@ protected:
      */
     void testDeviceDetection(BluetoothDeviceTestData * testData, bluetooth& bt, const QBluetoothDeviceInfo& deviceInfo, bool expectMatch, bool restart, const QString& failMessage) const;
 
+    /**
+     * @brief Tests device detection.
+     * @param testData The test data object for the device to be detected (or not).
+     * @param bt The object that will do the detecting.
+     * @param deviceInfo The device info for the device for which detection will be attempted.
+     * @param expectMatch Indicates if the device is expected to be detected (true) or not (false).
+     * @param restart Indicates if the bluetooth (bt) object should be restarted.
+     * @param failMessage The failure message if the device is not detected when expected to be, or detected when not expected to be.
+     */
     void testDeviceDetection(BluetoothDeviceTestData * testData, bluetooth& bt, const QBluetoothDeviceInfo& deviceInfo, bool expectMatch, bool restart, const std::string& failMessage) const;
 
 public:

--- a/tst/Devices/bluetoothsignalreceiver.cpp
+++ b/tst/Devices/bluetoothsignalreceiver.cpp
@@ -1,0 +1,16 @@
+#include "bluetoothsignalreceiver.h"
+
+
+BluetoothSignalReceiver::BluetoothSignalReceiver(bluetooth &b, QObject *parent) : QObject(parent) {
+    connect(&b, &bluetooth::bluetoothDeviceConnected, this, &BluetoothSignalReceiver::bluetoothDeviceConnected);
+    connect(&b, &bluetooth::bluetoothDeviceDisconnected, this, &BluetoothSignalReceiver::bluetoothDeviceDisconnected);
+}
+
+BluetoothSignalReceiver::~BluetoothSignalReceiver() {}
+
+bluetoothdevice *BluetoothSignalReceiver::get_device() const { return this->device; }
+
+void BluetoothSignalReceiver::bluetoothDeviceConnected(bluetoothdevice *b) { this->device = b;}
+
+void BluetoothSignalReceiver::bluetoothDeviceDisconnected() { this->device = nullptr; }
+

--- a/tst/Devices/bluetoothsignalreceiver.h
+++ b/tst/Devices/bluetoothsignalreceiver.h
@@ -1,0 +1,30 @@
+#ifndef BLUETOOTHSIGNALRECEIVER_H
+#define BLUETOOTHSIGNALRECEIVER_H
+
+#include <QObject>
+#include "bluetoothdevice.h"
+#include "bluetooth.h"
+
+/**
+ * @brief Catches bluetoothdevice connection signals from a bluetooth object.
+ */
+class BluetoothSignalReceiver : public QObject
+{
+    Q_OBJECT
+
+ private:
+    bluetoothdevice* device = nullptr;
+
+
+public:
+    explicit BluetoothSignalReceiver(bluetooth& b, QObject *parent = nullptr);
+    ~BluetoothSignalReceiver();
+
+    bluetoothdevice * get_device() const;
+
+public Q_SLOTS:
+    void bluetoothDeviceConnected(bluetoothdevice *b);
+    void bluetoothDeviceDisconnected();
+};
+
+#endif // BLUETOOTHSIGNALRECEIVER_H

--- a/tst/qdomyos-zwift-tests.pro
+++ b/tst/qdomyos-zwift-tests.pro
@@ -20,6 +20,7 @@ SOURCES += \
         Devices/TrxAppGateUSBTreadmill/trxappgateusbtreadmilltestdata.cpp \
         Devices/bluetoothdevicetestdata.cpp \
         Devices/bluetoothdevicetestsuite.cpp \
+        Devices/bluetoothsignalreceiver.cpp \
         Devices/devicediscoveryinfo.cpp \
         ToolTests/testsettingstestsuite.cpp \
         Tools/testsettings.cpp \
@@ -121,6 +122,7 @@ HEADERS += \
     Devices/YesoulBike/yesoulbiketestdata.h \
     Devices/bluetoothdevicetestdata.h \
     Devices/bluetoothdevicetestsuite.h \
+    Devices/bluetoothsignalreceiver.h \
     Devices/devicediscoveryinfo.h \
     Devices/devices.h \
     Devices/iConceptBike/iconceptbiketestdata.h \


### PR DESCRIPTION
#1221 

The tests that the signal that replaces the code to start or stop the template managers are signalled are passing. 

I have not tested that the UI is actually receiving these signals, although I did hook it up in homeform. I have some extra work to do before I can test this with a real device, however, I've made this change available as a PR in case you (@cagnulein) see the benefit of what I've done here, are able to test it quickly and easily, and want to merge it before I have a chance to do the UI testing.

This in combination with #1222 is a snag I encountered separating the UI from device logic for an app/lib split that would avoid the strange file sharing setup to build the app as an app and a static lib that I introduced in #911.



