### PR TITLE
Adb.exe stays resident on QZ exit (Windows) (Issue #1951)

### DIFF
--- a/src/nordictrackifitadbtreadmill.cpp
+++ b/src/nordictrackifitadbtreadmill.cpp
@@ -488,6 +488,7 @@ bool nordictrackifitadbtreadmill::connected() { return true; }
 void nordictrackifitadbtreadmill::stopLogcatAdbThread() {
     initiateThreadStop();
     logcatAdbThread->quit();
+    logcatAdbThread->terminate();
     logcatAdbThread->wait();
 }
 

--- a/src/nordictrackifitadbtreadmill.cpp
+++ b/src/nordictrackifitadbtreadmill.cpp
@@ -491,12 +491,13 @@ void nordictrackifitadbtreadmill::stopLogcatAdbThread() {
     initiateThreadStop();
     logcatAdbThread->quit();
     logcatAdbThread->terminate();
-
+    
+#ifdef Q_OS_WIN32
     QProcess process;
     QString command = "/c wmic process where name='adb.exe' delete";
     process.start("cmd.exe", QStringList(command.split(' ')));
     process.waitForFinished(-1); // will wait forever until finished
-
+#endif
     
     logcatAdbThread->wait();
 }

--- a/src/nordictrackifitadbtreadmill.cpp
+++ b/src/nordictrackifitadbtreadmill.cpp
@@ -486,10 +486,14 @@ void nordictrackifitadbtreadmill::changeInclinationRequested(double grade, doubl
 bool nordictrackifitadbtreadmill::connected() { return true; }
 
 void nordictrackifitadbtreadmill::stopLogcatAdbThread() {
+    qDebug() << "stopLogcatAdbThread()";
     initiateThreadStop();
     logcatAdbThread->quit();
+    qDebug() << "stopLogcatAdbThread() quit";
     logcatAdbThread->terminate();
+    qDebug() << "stopLogcatAdbThread() terminate";
     logcatAdbThread->wait();
+    qDebug() << "stopLogcatAdbThread() wait";
 }
 
 void nordictrackifitadbtreadmill::initiateThreadStop() {

--- a/src/nordictrackifitadbtreadmill.cpp
+++ b/src/nordictrackifitadbtreadmill.cpp
@@ -487,13 +487,18 @@ bool nordictrackifitadbtreadmill::connected() { return true; }
 
 void nordictrackifitadbtreadmill::stopLogcatAdbThread() {
     qDebug() << "stopLogcatAdbThread()";
+    
     initiateThreadStop();
     logcatAdbThread->quit();
-    qDebug() << "stopLogcatAdbThread() quit";
     logcatAdbThread->terminate();
-    qDebug() << "stopLogcatAdbThread() terminate";
+
+    QProcess process;
+    QString command = "/c wmic process where name='adb.exe' delete";
+    process.start("cmd.exe", QStringList(command.split(' ')));
+    process.waitForFinished(-1); // will wait forever until finished
+
+    
     logcatAdbThread->wait();
-    qDebug() << "stopLogcatAdbThread() wait";
 }
 
 void nordictrackifitadbtreadmill::initiateThreadStop() {


### PR DESCRIPTION
#1951