### PR TITLE
Added HR for Skandika Morpheus issue #2566

### DIFF
--- a/src/devices/skandikawiribike/skandikawiribike.cpp
+++ b/src/devices/skandikawiribike/skandikawiribike.cpp
@@ -247,8 +247,8 @@ void skandikawiribike::characteristicChanged(const QLowEnergyCharacteristic &cha
 #endif
     {
         if (heartRateBeltName.startsWith(QStringLiteral("Disabled"))) {
-            if (X2000) {
-                Heart = newValue.at(8);
+            if (X2000 || delightechBike) {
+                Heart = newValue.at(8); // X-2000 or delightech app/protocol compatible bike (e.g. Skandika Morpheus)
             } else {
                 Heart = 0;
             }
@@ -427,8 +427,13 @@ void skandikawiribike::deviceDiscovered(const QBluetoothDeviceInfo &device) {
         bluetoothDevice = device;
 
         if (device.name().toUpper().startsWith(QLatin1String("HT"))) {
-            X2000 = true;
-            qDebug() << "X-2000 WORKAROUND!";
+            if (device.name().length() == 11) { // Bikes like the Skandika X-2000 Foldaway Bike
+                X2000 = true; 
+                qDebug() << "X-2000 WORKAROUND!";
+            } else if (device.name().length() == 12) // Bikes compatible with delightech app/protocol, for example Skandika Morpheus
+            {
+                delightechBike = true; 
+            }
         }
 
         m_control = QLowEnergyController::createCentral(bluetoothDevice, this);

--- a/src/devices/skandikawiribike/skandikawiribike.h
+++ b/src/devices/skandikawiribike/skandikawiribike.h
@@ -75,6 +75,7 @@ class skandikawiribike : public bike {
     bool noHeartService = false;
 
     bool X2000 = false;
+    bool delightechBike = false;
 
 #ifdef Q_OS_IOS
     lockscreen *h = 0;


### PR DESCRIPTION
Because the morpheus behaves like a mixture of the x-2000 and the wiry, I have introduced a new variable. Speed, watts and rpm are read out like the wiry, but the heart rate is read out like the x-2000. With this code the morpheus works for me. I have attached a screenshot in the issue #2566. to distinguish an x-2000 from a Morpheus it seems to be enough to pay attention to the number of characters of the bluetooth name