### PR TITLE
Skandika Morpheus: calc speed based on watts fixed

### DIFF
--- a/src/devices/skandikawiribike/skandikawiribike.cpp
+++ b/src/devices/skandikawiribike/skandikawiribike.cpp
@@ -484,7 +484,7 @@ uint16_t skandikawiribike::watts() {
     // ref
     // https://translate.google.com/translate?hl=it&sl=en&u=https://support.wattbike.com/hc/en-us/articles/115001881825-Power-Resistance-and-Cadence-Tables&prev=search&pto=aue
 
-    if (currentSpeed().value() <= 0) {
+    if (currentCadence().value() == 0) { // only update watts if pedaling
         return 0;
     }
 


### PR DESCRIPTION
The speed could not be calculated based on watt, because the code was in an unsolvable if query. I have changed the if query to "cadence", like on the Schwinn bike (and others). Now the speed is calculated correctly as soon as you pedal. Before this fix the option "calculate speed based on watt" had be turned off to get speed values.

This is a screenshot taken with "calculate speed based on watt" turned on. And as expected, the speed on bike display and the speed on qdomyos-zwift ​​differ greatly.

![speed_on_watt](https://github.com/user-attachments/assets/be11cbb6-c508-4cce-b64d-da8a2b996e29)
