### PR TITLE
Fix port on csafe rower

### DIFF
--- a/src/devices/csaferower/csaferower.cpp
+++ b/src/devices/csaferower/csaferower.cpp
@@ -90,7 +90,7 @@ void csaferower::onDistance(double distance) {
 
 }
 
-void csaferower::onStatus(uint16_t status) {
+void csaferower::onStatus(char status) {
     qDebug() << "Current Status received:" << status;
 }
 
@@ -98,8 +98,7 @@ csaferowerThread::csaferowerThread() {}
 
 void csaferowerThread::run() {
     QSettings settings;
-    /*devicePort =
-        settings.value(QZSettings::computrainer_serialport, QZSettings::default_computrainer_serialport).toString();*/
+    deviceFilename = settings.value(QZSettings::csafe_rower, QZSettings::default_csafe_rower).toString();
 
     openPort();
     csafe *aa = new csafe();
@@ -144,7 +143,8 @@ void csaferowerThread::run() {
             emit onDistance(f["CSAFE_PM_GET_WORKDISTANCE"].value<QVariantList>()[0].toDouble());
         }
         if (f["CSAFE_GETSTATUS_CMD"].isValid()) {
-            emit onStatus(f["CSAFE_GETSTATUS_CMD"].value<QVariantList>()[0].toUInt());
+            char statusChar = static_cast<char>(f["CSAFE_GETSTATUS_CMD"].value<QVariantList>()[0].toUInt() & 0x0f);
+            emit onStatus(statusChar);
         }
 
         memset(rx, 0x00, sizeof(rx));
@@ -163,6 +163,9 @@ int csaferowerThread::closePort() {
 }
 
 int csaferowerThread::openPort() {
+
+qDebug() << "Opening serial port " << deviceFilename.toLatin1();
+
 #ifdef Q_OS_ANDROID
     QAndroidJniObject::callStaticMethod<void>("org/cagnulen/qdomyoszwift/CSafeRowerUSBHID", "open",
                                               "(Landroid/content/Context;)V", QtAndroid::androidContext().object());

--- a/src/devices/csaferower/csaferower.h
+++ b/src/devices/csaferower/csaferower.h
@@ -87,7 +87,7 @@ class csaferowerThread : public QThread {
     void onCalories(double calories);
     void onDistance(double distance);
     void onPace(double pace);
-    void onStatus(uint16_t status);
+    void onStatus(char status);
 
   private:
     // Utility and BG Thread functions
@@ -165,7 +165,7 @@ class csaferower : public rower {
     void onCalories(double calories);
     void onDistance(double distance);
     void onPace(double pace);
-    void onStatus(uint16_t status);
+    void onStatus(char status);
 
   public slots:
     void deviceDiscovered(const QBluetoothDeviceInfo &device);


### PR DESCRIPTION
Fixes 2 issues in the csafe rower..  

* the deviceFilename variable is not updated, hence a blank port is being opened
* metatype issue: because of void onStatus(uint16_t status);
```
(Make sure 'uint16_t' is registered using qRegisterMetaType().)
QObject::connect: Cannot queue arguments of type 'uint16_t'
(Make sure 'uint16_t' is registered using qRegisterMetaType().)
```