### PR TITLE
skillbike: allow 3-digit bikes

### DIFF
--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -1677,7 +1677,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 connect(wahooKickrSnapBike, &wahookickrsnapbike::debug, this, &bluetooth::debug);
                 wahooKickrSnapBike->deviceDiscovered(b);
                 this->signalBluetoothDeviceConnected(wahooKickrSnapBike);
-            } else if (b.name().toUpper().startsWith("BIKE ") && b.name().length() == 9 &&
+            } else if (b.name().toUpper().startsWith("BIKE ") && b.name().midRef(5).toInt() > 0 &&
                        !technogymBike && filter) {
                 this->setLastBluetoothDevice(b);
                 this->stopDiscovery();


### PR DESCRIPTION
My TechnoGym Skillbike is called "BIKE 861" and QZ wouldn't detect it previously because it assumed all such bikes have 4-digit names.

The fix is to relax requirement and detect any /BIKE \d+/ as technogymBike.
