### PR TITLE
Cadence calculated from trainer speed

### DIFF
--- a/src/devices/ftmsbike/ftmsbike.cpp
+++ b/src/devices/ftmsbike/ftmsbike.cpp
@@ -534,6 +534,14 @@ void ftmsbike::characteristicChanged(const QLowEnergyCharacteristic &characteris
             }
             index += 2;
             emit debug(QStringLiteral("Current Cadence: ") + QString::number(Cadence.value()));
+        } else if(VANRYSEL_HT && newValue.length() > 7) {
+            if (settings.value(QZSettings::cadence_sensor_name, QZSettings::default_cadence_sensor_name)
+                    .toString()
+                    .startsWith(QStringLiteral("Disabled"))) {
+                Cadence = Speed.value() *
+                settings.value(QZSettings::cadence_sensor_speed_ratio, QZSettings::default_cadence_sensor_speed_ratio)
+                    .toDouble();
+            }
         }
 
         if (Flags.avgCadence) {
@@ -1298,6 +1306,9 @@ void ftmsbike::deviceDiscovered(const QBluetoothDeviceInfo &device) {
         } else if ((bluetoothDevice.name().toUpper().startsWith("LYDSTO"))) {
             qDebug() << QStringLiteral("LYDSTO found");
             LYDSTO = true;
+        } else if ((bluetoothDevice.name().toUpper().startsWith("VANRYSEL-HT"))) {
+            qDebug() << QStringLiteral("VANRYSEL-HT found");
+            VANRYSEL_HT = true;
         }
         
         if(settings.value(QZSettings::force_resistance_instead_inclination, QZSettings::default_force_resistance_instead_inclination).toBool()) {

--- a/src/devices/ftmsbike/ftmsbike.cpp
+++ b/src/devices/ftmsbike/ftmsbike.cpp
@@ -534,14 +534,6 @@ void ftmsbike::characteristicChanged(const QLowEnergyCharacteristic &characteris
             }
             index += 2;
             emit debug(QStringLiteral("Current Cadence: ") + QString::number(Cadence.value()));
-        } else if(VANRYSEL_HT && newValue.length() > 7) {
-            if (settings.value(QZSettings::cadence_sensor_name, QZSettings::default_cadence_sensor_name)
-                    .toString()
-                    .startsWith(QStringLiteral("Disabled"))) {
-                Cadence = ((double)(((uint16_t)((uint8_t)newValue.at(7)) << 8) |
-                                    (uint16_t)((uint8_t)newValue.at(6)))) /
-                          10.0;
-            }
         }
 
         if (Flags.avgCadence) {
@@ -1306,9 +1298,6 @@ void ftmsbike::deviceDiscovered(const QBluetoothDeviceInfo &device) {
         } else if ((bluetoothDevice.name().toUpper().startsWith("LYDSTO"))) {
             qDebug() << QStringLiteral("LYDSTO found");
             LYDSTO = true;
-        } else if ((bluetoothDevice.name().toUpper().startsWith("VANRYSEL-HT"))) {
-            qDebug() << QStringLiteral("VANRYSEL-HT found");
-            VANRYSEL_HT = true;
         }
         
         if(settings.value(QZSettings::force_resistance_instead_inclination, QZSettings::default_force_resistance_instead_inclination).toBool()) {

--- a/src/devices/ftmsbike/ftmsbike.cpp
+++ b/src/devices/ftmsbike/ftmsbike.cpp
@@ -534,6 +534,14 @@ void ftmsbike::characteristicChanged(const QLowEnergyCharacteristic &characteris
             }
             index += 2;
             emit debug(QStringLiteral("Current Cadence: ") + QString::number(Cadence.value()));
+        } else if(VANRYSEL_HT && newValue.length() > 7) {
+            if (settings.value(QZSettings::cadence_sensor_name, QZSettings::default_cadence_sensor_name)
+                    .toString()
+                    .startsWith(QStringLiteral("Disabled"))) {
+                Cadence = ((double)(((uint16_t)((uint8_t)newValue.at(7)) << 8) |
+                                    (uint16_t)((uint8_t)newValue.at(6)))) /
+                          10.0;
+            }
         }
 
         if (Flags.avgCadence) {
@@ -1298,6 +1306,9 @@ void ftmsbike::deviceDiscovered(const QBluetoothDeviceInfo &device) {
         } else if ((bluetoothDevice.name().toUpper().startsWith("LYDSTO"))) {
             qDebug() << QStringLiteral("LYDSTO found");
             LYDSTO = true;
+        } else if ((bluetoothDevice.name().toUpper().startsWith("VANRYSEL-HT"))) {
+            qDebug() << QStringLiteral("VANRYSEL-HT found");
+            VANRYSEL_HT = true;
         }
         
         if(settings.value(QZSettings::force_resistance_instead_inclination, QZSettings::default_force_resistance_instead_inclination).toBool()) {

--- a/src/devices/ftmsbike/ftmsbike.h
+++ b/src/devices/ftmsbike/ftmsbike.h
@@ -137,7 +137,6 @@ class ftmsbike : public bike {
     bool BIKE_ = false;
     bool SMB1 = false;
     bool LYDSTO = false;
-    bool VANRYSEL_HT = false;
 
     uint8_t battery_level = 0;
 

--- a/src/devices/ftmsbike/ftmsbike.h
+++ b/src/devices/ftmsbike/ftmsbike.h
@@ -137,6 +137,7 @@ class ftmsbike : public bike {
     bool BIKE_ = false;
     bool SMB1 = false;
     bool LYDSTO = false;
+    bool VANRYSEL_HT = false;
 
     uint8_t battery_level = 0;
 

--- a/src/devices/tacxneo2/tacxneo2.cpp
+++ b/src/devices/tacxneo2/tacxneo2.cpp
@@ -557,6 +557,15 @@ void tacxneo2::characteristicChanged(const QLowEnergyCharacteristic &characteris
             }
             index += 2;
             emit debug(QStringLiteral("Current Cadence: ") + QString::number(Cadence.value()));
+        } else if(VANRYSEL_HT && newValue.length() > 7) {
+            if (settings.value(QZSettings::cadence_sensor_name, QZSettings::default_cadence_sensor_name)
+                    .toString()
+                    .startsWith(QStringLiteral("Disabled"))) {
+                Cadence = ((double)(((uint16_t)((uint8_t)newValue.at(7)) << 8) |
+                                    (uint16_t)((uint8_t)newValue.at(6)))) /
+                          10.0;
+            }
+            emit debug(QStringLiteral("Current Cadence: ") + QString::number(Cadence.value()));
         }
 
         if (Flags.avgCadence) {
@@ -912,6 +921,9 @@ void tacxneo2::deviceDiscovered(const QBluetoothDeviceInfo &device) {
         if(device.name().toUpper().startsWith(QStringLiteral("THINK X"))) {
             THINK_X = true;
             qDebug() << "THINK X workaround enabled!";
+        } else if ((bluetoothDevice.name().toUpper().startsWith("VANRYSEL-HT"))) {
+            qDebug() << QStringLiteral("VANRYSEL-HT found");
+            VANRYSEL_HT = true;
         }
 
         m_control = QLowEnergyController::createCentral(bluetoothDevice, this);

--- a/src/devices/tacxneo2/tacxneo2.cpp
+++ b/src/devices/tacxneo2/tacxneo2.cpp
@@ -561,9 +561,9 @@ void tacxneo2::characteristicChanged(const QLowEnergyCharacteristic &characteris
             if (settings.value(QZSettings::cadence_sensor_name, QZSettings::default_cadence_sensor_name)
                     .toString()
                     .startsWith(QStringLiteral("Disabled"))) {
-                Cadence = ((double)(((uint16_t)((uint8_t)newValue.at(7)) << 8) |
-                                    (uint16_t)((uint8_t)newValue.at(6)))) /
-                          10.0;
+                Cadence = Speed.value() *
+                settings.value(QZSettings::cadence_sensor_speed_ratio, QZSettings::default_cadence_sensor_speed_ratio)
+                    .toDouble();
             }
             emit debug(QStringLiteral("Current Cadence: ") + QString::number(Cadence.value()));
         }

--- a/src/devices/tacxneo2/tacxneo2.h
+++ b/src/devices/tacxneo2/tacxneo2.h
@@ -82,6 +82,7 @@ class tacxneo2 : public bike {
     bool resistance_received = false;
 
     bool THINK_X = false;
+    bool VANRYSEL_HT = false;
 
 #ifdef Q_OS_IOS
     lockscreen *h = 0;


### PR DESCRIPTION
This will give the possibility to activate the automatic calculation of the cadence by ratio from the speed transmitted by the trainer. Obviously it can only work if you use a fixed ratio with virtual shifting or ERG.
For now is still a draft. I'm working on a Decathlon D100 (it does not have the cadence sensor).
This will not close #3282, but will help.