### PR TITLE
feat: Add elapsed time to FTMS virtual treadmill characteristic

### DIFF
--- a/src/characteristics/characteristicnotifier2acd.cpp
+++ b/src/characteristics/characteristicnotifier2acd.cpp
@@ -1,6 +1,7 @@
 #include "characteristicnotifier2acd.h"
 #include "devices/treadmill.h"
 #include <qmath.h>
+#include <QTime> // Include QTime for Bike->elapsedTime()
 
 CharacteristicNotifier2ACD::CharacteristicNotifier2ACD(bluetoothdevice *Bike, QObject *parent)
     : CharacteristicNotifier(0x2acd, parent), Bike(Bike) {}
@@ -9,7 +10,8 @@ int CharacteristicNotifier2ACD::notify(QByteArray &value) {
     bluetoothdevice::BLUETOOTH_TYPE dt = Bike->deviceType();
     if (dt == bluetoothdevice::TREADMILL || dt == bluetoothdevice::ELLIPTICAL) {
         value.append(0x0C);       // Inclination available and distance for peloton
-        value.append((char)0x01); // heart rate available
+        //value.append((char)0x01); // heart rate available
+        value.append((char)0x05); // HeartRate(8) | ElapsedTime(10)
 
         uint16_t normalizeSpeed = (uint16_t)qRound(Bike->currentSpeed().value() * 100);
         char a = (normalizeSpeed >> 8) & 0XFF;
@@ -61,6 +63,18 @@ int CharacteristicNotifier2ACD::notify(QByteArray &value) {
         rampBytes.append(b);
         rampBytes.append(a);
 
+        // Get session elapsed time - makes Runna calculations work
+        QTime sessionElapsedTime = Bike->elapsedTime();
+        double elapsed_time_seconds =
+            (double)sessionElapsedTime.hour() * 3600.0 +
+            (double)sessionElapsedTime.minute() * 60.0 +
+            (double)sessionElapsedTime.second() +
+            (double)sessionElapsedTime.msec() / 1000.0;
+        uint16_t ftms_elapsed_time_field = (uint16_t)qRound(elapsed_time_seconds);
+        QByteArray elapsedBytes;
+        elapsedBytes.append(static_cast<char>(ftms_elapsed_time_field & 0xFF));
+        elapsedBytes.append(static_cast<char>((ftms_elapsed_time_field >> 8) & 0xFF));
+
         value.append(speedBytes); // Actual value.
         
         value.append(distanceBytes); // Actual value.
@@ -70,6 +84,9 @@ int CharacteristicNotifier2ACD::notify(QByteArray &value) {
         value.append(rampBytes); // ramp angle
 
         value.append(Bike->currentHeart().value()); // current heart rate
+
+        value.append(elapsedBytes); // Elapsed Time
+
         return CN_OK;
     } else
         return CN_INVALID;


### PR DESCRIPTION
### **The Problem**
Currently, qDomyos-zwift's virtual treadmill, when connected via Bluetooth FTMS, **doesn't send "elapsed time" data**. This causes problems for fitness apps like Runna. Without elapsed time, these apps can't correctly calculate metrics leading to **incomplete or "rogue" workout sessions**. Users need to use inconvenient workarounds, like simultaneously recording on a Garmin watch and manually linking the data later.

### **The Solution**
qDomyos-zwift **starts transmitting "elapsed time"** as part of its Bluetooth FTMS (Fitness Machine Service) data for the virtual treadmill. This means calculating and sending the session's elapsed time during the FTMS broadcast.

### **Why This Matters (Benefits)**
* **Better App Compatibility:** Greatly improves how qDomyos-zwift works with third-party fitness apps (like Runna) that rely on FTMS for accurate workout tracking.
* **Accurate Workout Data:** Apps will correctly track and save workout metrics, eliminating the need for manual workarounds.
* **Meets Industry Standards:** Aligns qDomyos-zwift's FTMS implementation with common "must-have" metrics (Time, Distance, Speed, Incline) expected by fitness platforms, as highlighted by resources like Noble Pro.
* **Seamless User Experience:** Provides a smoother and more reliable experience for anyone using fitness apps to control and record their treadmill workouts through qDomyos-zwift.

### **Alternatives We've Tried**
Currently, the only workaround is to **record your workout simultaneously on another device, like a Garmin watch**, then manually link that data to the incomplete session in the fitness app. This is inconvenient and breaks the smooth flow of your workout. We haven't found any other software solutions within qDomyos-zwift itself.

### **Why This Fix Makes Sense**
I've already investigated this thoroughly and found a straightforward solution: **modifying `characteristicnotifier2acd.cpp` to include the elapsed time calculation resolves the issue.**

This change is minimal and aligns with what seems to be the original intent, as `virtualtreadmill.cpp` already sets the elapsed time flag. Adding this will help qDomyos-zwift's FTMS implementation meet fitness industry standards for third-party app compatibility, ensuring all "must-have" metrics like Time, Distance, Speed, and Incline are properly transmitted.