### PR TITLE
Add GPIO gear control support for Raspberry Pi

### DIFF
--- a/src/homeform.cpp
+++ b/src/homeform.cpp
@@ -795,6 +795,10 @@ homeform::homeform(QQmlApplicationEngine *engine, bluetooth *bl) {
 }
 
 homeform::~homeform() {
+
+    gpx_save_clicked();
+    fit_save_clicked();
+
     // Cleanup GPIO gear worker
     if (gpioGearWorker) {
         gpioGearWorker->stop();
@@ -1161,11 +1165,6 @@ void homeform::refresh_bluetooth_devices_clicked() {
 
     bluetoothManager->onlyDiscover = true;
     bluetoothManager->restart();
-}
-
-homeform::~homeform() {
-    gpx_save_clicked();
-    fit_save_clicked();
 }
 
 void homeform::aboutToQuit() {

--- a/src/homeform.h
+++ b/src/homeform.h
@@ -34,10 +34,10 @@
 #define HIGH 1
 #define LOW 0
 #define PUD_UP 2
-int digitalRead(int pin) { return HIGH; }
-void pinMode(int pin, int mode) { Q_UNUSED(pin); Q_UNUSED(mode); }
-void pullUpDnControl(int pin, int pud) { Q_UNUSED(pin); Q_UNUSED(pud); }
-int wiringPiSetup() { return 0; }
+inline int digitalRead(int pin) { Q_UNUSED(pin); return HIGH; }
+inline void pinMode(int pin, int mode) { Q_UNUSED(pin); Q_UNUSED(mode); }
+inline void pullUpDnControl(int pin, int pud) { Q_UNUSED(pin); Q_UNUSED(pud); }
+inline int wiringPiSetup() { return 0; }
 #endif
 
 #ifdef Q_OS_ANDROID

--- a/src/qzsettings.cpp
+++ b/src/qzsettings.cpp
@@ -943,6 +943,7 @@ const QString QZSettings::inclinationResistancePoints = QStringLiteral("inclinat
 const QString QZSettings::default_inclinationResistancePoints = QStringLiteral("");
 
 const QString QZSettings::floatingwindow_type = QStringLiteral("floatingwindow_type");
+const QString QZSettings::gpio_gears_enabled = QStringLiteral("gpio_gears_enabled");
 
 
 const uint32_t allSettingsCount = 772;
@@ -1737,6 +1738,7 @@ QVariant allSettings[allSettingsCount][2] = {
     {QZSettings::nordictrack_elite_800, QZSettings::default_nordictrack_elite_800},
     {QZSettings::inclinationResistancePoints, QZSettings::default_inclinationResistancePoints},
     {QZSettings::floatingwindow_type, QZSettings::default_floatingwindow_type},
+    {QZSettings::gpio_gears_enabled, QZSettings::default_gpio_gears_enabled},
     {QZSettings::rogue_echo_bike, QZSettings::default_rogue_echo_bike},
 };
 

--- a/src/qzsettings.h
+++ b/src/qzsettings.h
@@ -2516,6 +2516,9 @@ class QZSettings {
     static const QString floatingwindow_type;
     static constexpr int default_floatingwindow_type = 0;
 
+    static const QString gpio_gears_enabled;
+    static constexpr bool default_gpio_gears_enabled = false;
+
     /**
      * @brief Write the QSettings values using the constants from this namespace.
      * @param showDefaults Optionally indicates if the default should be shown with the key.

--- a/src/settings.qml
+++ b/src/settings.qml
@@ -1167,6 +1167,7 @@ import Qt.labs.platform 1.1
             // 2.19.2
             property bool tile_hr_time_in_zone_individual_mode: false
             property bool wahoo_without_wheel_diameter: false
+            property bool gpio_gears_enabled: false
         }
 
         function paddingZeros(text, limit) {
@@ -12056,6 +12057,45 @@ import Qt.labs.platform 1.1
                         Layout.fillWidth: true
                         color: Material.color(Material.Lime)
                     }
+                }
+            }
+        }
+
+        AccordionElement {
+            id: hardwareControlAccordion
+            title: qsTr("Hardware Control")
+            indicatRectColor: Material.color(Material.Grey)
+            textColor: Material.color(Material.Yellow)
+            color: Material.backgroundColor
+            accordionContent: ColumnLayout {
+                spacing: 0
+                
+                IndicatorOnlySwitch {
+                    id: gpioGearsEnabledDelegate
+                    text: qsTr("GPIO Gears Control")
+                    spacing: 0
+                    bottomPadding: 0
+                    topPadding: 0
+                    rightPadding: 0
+                    leftPadding: 0
+                    clip: false
+                    checked: settings.gpio_gears_enabled
+                    Layout.alignment: Qt.AlignLeft | Qt.AlignTop
+                    Layout.fillWidth: true
+                    onClicked: { settings.gpio_gears_enabled = checked; window.settings_restart_to_apply = true; }
+                }
+                
+                Label {
+                    text: qsTr("Enable GPIO-based gear shifting on Raspberry Pi (GPIO 17 for up, GPIO 27 for down)")
+                    font.bold: true
+                    font.italic: true
+                    font.pixelSize: Qt.application.font.pixelSize - 2
+                    textFormat: Text.PlainText
+                    wrapMode: Text.WordWrap
+                    verticalAlignment: Text.AlignVCenter
+                    Layout.alignment: Qt.AlignLeft | Qt.AlignTop
+                    Layout.fillWidth: true
+                    color: Material.color(Material.Lime)
                 }
             }
         }


### PR DESCRIPTION
Introduces GPIO-based gear shifting functionality using GPIO 17 (up) and GPIO 27 (down) for Raspberry Pi. Adds a worker thread to monitor GPIO pins, emits signals for gear changes, and integrates with the homeform class. Includes new settings key and UI option to enable or disable this feature.