### PR TITLE
Hide QZ files from Android gallery and update UI flags

### DIFF
--- a/src/android/src/CustomQtActivity.java
+++ b/src/android/src/CustomQtActivity.java
@@ -19,14 +19,16 @@ public class CustomQtActivity extends QtActivity {
             getWindow().setDecorFitsSystemWindows(false);
             WindowInsetsController controller = getWindow().getDecorView().getWindowInsetsController();
             if (controller != null) {
-                controller.hide(WindowInsets.Type.statusBars() | WindowInsets.Type.navigationBars());
+                // Hide only navigation bar, keep status bar visible for notifications access
+                controller.hide(WindowInsets.Type.navigationBars());
+                // Allow swipe to show navigation bar temporarily
                 controller.setSystemBarsBehavior(WindowInsetsController.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
             }
         } else {
             // Fallback for older Android versions (API < 30)
             getWindow().getDecorView().setSystemUiVisibility(
                 View.SYSTEM_UI_FLAG_HIDE_NAVIGATION |
-                View.SYSTEM_UI_FLAG_FULLSCREEN |
+                // Remove SYSTEM_UI_FLAG_FULLSCREEN to keep status bar visible
                 View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
             );
         }

--- a/src/homeform.cpp
+++ b/src/homeform.cpp
@@ -779,6 +779,9 @@ homeform::homeform(QQmlApplicationEngine *engine, bluetooth *bl) {
                                               "registerReceiver",
                                               "(Landroid/content/Context;)V",
                                               QtAndroid::androidContext().object());
+    
+    // Create .nomedia files to hide QZ files from Android gallery
+    createNoMediaFiles();
 #endif    
 
     bluetoothManager->homeformLoaded = true;
@@ -8252,6 +8255,33 @@ QString homeform::getAndroidDataAppDir() {
     }
     path = out;
     return out;
+}
+
+void homeform::createNoMediaFiles() {
+    QString rootPath = getWritableAppDir();
+    
+    // Create .nomedia file in root QZ directory
+    QString noMediaPath = rootPath + QStringLiteral(".nomedia");
+    QFile noMediaFile(noMediaPath);
+    if (!noMediaFile.exists()) {
+        noMediaFile.open(QIODevice::WriteOnly);
+        noMediaFile.close();
+    }
+    
+    // Create .nomedia files in all subdirectories
+    QDir rootDir(rootPath);
+    if (rootDir.exists()) {
+        QStringList subDirs = rootDir.entryList(QDir::Dirs | QDir::NoDotAndDotDot);
+        for (const QString &subDir : subDirs) {
+            QString subDirPath = rootPath + subDir + QStringLiteral("/");
+            QString subNoMediaPath = subDirPath + QStringLiteral(".nomedia");
+            QFile subNoMediaFile(subNoMediaPath);
+            if (!subNoMediaFile.exists()) {
+                subNoMediaFile.open(QIODevice::WriteOnly);
+                subNoMediaFile.close();
+            }
+        }
+    }
 }
 #endif
 

--- a/src/homeform.h
+++ b/src/homeform.h
@@ -521,6 +521,10 @@ class homeform : public QObject {
     Q_INVOKABLE static QString getProfileDir();
     Q_INVOKABLE static void clearFiles();
 
+#ifdef Q_OS_ANDROID
+    static void createNoMediaFiles();
+#endif
+
     double wattMaxChart() {
         QSettings settings;
         if (bluetoothManager && bluetoothManager->device() &&


### PR DESCRIPTION
Added createNoMediaFiles() to generate .nomedia files in the QZ directory and its subdirectories, preventing media scanning on Android. Updated CustomQtActivity to keep the status bar visible for notification access while hiding only the navigation bar.