### PR TITLE
Fix Android header positioning under status bar

### DIFF
--- a/src/android/src/CustomQtActivity.java
+++ b/src/android/src/CustomQtActivity.java
@@ -13,22 +13,6 @@ public class CustomQtActivity extends QtActivity {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         
-        // Handle Android 16 API 36 WindowInsetsController for fullscreen support
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            // Android 11 (API 30) and above - use WindowInsetsController
-            getWindow().setDecorFitsSystemWindows(false);
-            WindowInsetsController controller = getWindow().getDecorView().getWindowInsetsController();
-            if (controller != null) {
-                controller.hide(WindowInsets.Type.statusBars() | WindowInsets.Type.navigationBars());
-                controller.setSystemBarsBehavior(WindowInsetsController.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
-            }
-        } else {
-            // Fallback for older Android versions (API < 30)
-            getWindow().getDecorView().setSystemUiVisibility(
-                View.SYSTEM_UI_FLAG_HIDE_NAVIGATION |
-                View.SYSTEM_UI_FLAG_FULLSCREEN |
-                View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
-            );
-        }
+        // Normal window mode - no fullscreen flags
     }
 }

--- a/src/main.qml
+++ b/src/main.qml
@@ -472,6 +472,7 @@ ApplicationWindow {
         contentHeight: toolButton.implicitHeight
         Material.primary: settings.theme_status_bar_background_color
         id: headerToolbar
+        topPadding: Qt.platform.os === "android" ? Math.max(0, Screen.height - Screen.desktopAvailableHeight) : 0
 
         ToolButton {
             id: toolButton


### PR DESCRIPTION
- Remove fullscreen flags from CustomQtActivity to allow normal window mode
- Add dynamic top padding to main.qml header toolbar for Android
- Use Screen.height - Screen.desktopAvailableHeight for proper status bar compensation
- Maintains fullscreen QML visibility while preventing header overlap

🤖 Generated with [Claude Code](https://claude.ai/code)