### PR TITLE
Add communication timeout detection to Solebike

### DIFF
--- a/src/devices/solebike/solebike.h
+++ b/src/devices/solebike/solebike.h
@@ -68,8 +68,10 @@ class solebike : public bike {
     uint8_t sec1Update = 0;
     QByteArray lastPacket;
     QDateTime lastRefreshCharacteristicChanged = QDateTime::currentDateTime();
+    QDateTime lastMetricUpdate = QDateTime::currentDateTime();
     uint8_t firstStateChanged = 0;
     resistance_t lastResistanceBeforeDisconnection = -1;
+    bool communicationTimeout = false;
 
     bool initDone = false;
     bool initRequest = false;


### PR DESCRIPTION
Introduces logic to detect when no metrics are received for 3 seconds, triggering a reinitialization request. Adds tracking of the last metric update time and a communication timeout flag to improve device reliability.