### PR TITLE
Implement threaded FIT backup file writing

### DIFF
--- a/src/fitbackupwriter.cpp
+++ b/src/fitbackupwriter.cpp
@@ -1,0 +1,27 @@
+#include "fitbackupwriter.h"
+#include <QDebug>
+
+FitBackupWriter::FitBackupWriter(QObject *parent) : QObject(parent) {
+}
+
+FitBackupWriter::~FitBackupWriter() {
+}
+
+void FitBackupWriter::writeFitBackup(const QString &filename, 
+                                    const QList<SessionLine> &session,
+                                    bluetoothdevice::BLUETOOTH_TYPE deviceType,
+                                    QFIT_PROCESS_TYPE processType,
+                                    FIT_SPORT workoutType,
+                                    const QString &workoutName,
+                                    const QString &deviceName) {
+    qDebug() << QStringLiteral("Writing FIT backup file in background thread: ") << filename;
+    
+    // Remove existing file
+    QFile::remove(filename);
+    
+    // Save FIT file using the same logic as the original backup() method
+    qfit::save(filename, session, deviceType, processType, workoutType, 
+               workoutName, deviceName, "", "", "", "");
+    
+    qDebug() << QStringLiteral("FIT backup file written successfully: ") << filename;
+}

--- a/src/fitbackupwriter.h
+++ b/src/fitbackupwriter.h
@@ -1,0 +1,28 @@
+// fitbackupwriter.h
+#ifndef FITBACKUPWRITER_H
+#define FITBACKUPWRITER_H
+
+#include <QObject>
+#include <QFile>
+#include "sessionline.h"
+#include "fit_profile.hpp"
+#include "qfit.h"
+#include "bluetoothdevice.h"
+
+class FitBackupWriter : public QObject {
+    Q_OBJECT
+public:
+    explicit FitBackupWriter(QObject *parent = nullptr);
+    virtual ~FitBackupWriter();
+
+public slots:
+    void writeFitBackup(const QString &filename, 
+                       const QList<SessionLine> &session,
+                       bluetoothdevice::BLUETOOTH_TYPE deviceType,
+                       QFIT_PROCESS_TYPE processType,
+                       FIT_SPORT workoutType,
+                       const QString &workoutName,
+                       const QString &deviceName);
+};
+
+#endif // FITBACKUPWRITER_H

--- a/src/homeform.cpp
+++ b/src/homeform.cpp
@@ -577,6 +577,12 @@ homeform::homeform(QQmlApplicationEngine *engine, bluetooth *bl) {
         automaticShiftingTimer->start(100); // 100ms = 10Hz
     }
 
+    // Initialize FIT backup thread
+    fitBackupThread = new QThread(this);
+    fitBackupWriter = new FitBackupWriter();
+    fitBackupWriter->moveToThread(fitBackupThread);
+    fitBackupThread->start();
+
     QObject *rootObject = engine->rootObjects().constFirst();
     QObject *home = rootObject->findChild<QObject *>(QStringLiteral("home"));
     QObject *stack = rootObject;
@@ -1170,18 +1176,24 @@ QString homeform::getWritableAppDir() {
 void homeform::backup() {
 
     static uint8_t index = 0;
-    qDebug() << QStringLiteral("saving fit file backup...");
+    qDebug() << QStringLiteral("scheduling fit file backup...");
 
     QString path = getWritableAppDir();
     bluetoothdevice *dev = bluetoothManager->device();
     if (dev) {
 
         QString filename = path + QString::number(index) + backupFitFileName;
-        QFile::remove(filename);
-        qfit::save(filename, Session, dev->deviceType(),
-                   qobject_cast<m3ibike *>(dev) ? QFIT_PROCESS_DISTANCENOISE : QFIT_PROCESS_NONE,
-                   stravaPelotonWorkoutType, workoutName(), dev->bluetoothDevice.name(),
-                   "", "", "", "");
+        
+        // Use thread to write FIT backup file
+        QMetaObject::invokeMethod(fitBackupWriter, "writeFitBackup",
+                                 Qt::QueuedConnection,
+                                 Q_ARG(QString, filename),
+                                 Q_ARG(QList<SessionLine>, Session),
+                                 Q_ARG(bluetoothdevice::BLUETOOTH_TYPE, dev->deviceType()),
+                                 Q_ARG(QFIT_PROCESS_TYPE, qobject_cast<m3ibike *>(dev) ? QFIT_PROCESS_DISTANCENOISE : QFIT_PROCESS_NONE),
+                                 Q_ARG(FIT_SPORT, stravaPelotonWorkoutType),
+                                 Q_ARG(QString, workoutName()),
+                                 Q_ARG(QString, dev->bluetoothDevice.name()));
 
         index++;
         if (index > 1) {
@@ -1304,6 +1316,15 @@ void homeform::refresh_bluetooth_devices_clicked() {
 }
 
 homeform::~homeform() {
+    // Cleanup FIT backup thread
+    if (fitBackupThread && fitBackupThread->isRunning()) {
+        fitBackupThread->quit();
+        fitBackupThread->wait();
+    }
+    if (fitBackupWriter) {
+        delete fitBackupWriter;
+    }
+    
     gpx_save_clicked();
     fit_save_clicked();
 }

--- a/src/homeform.h
+++ b/src/homeform.h
@@ -16,6 +16,7 @@
 #include "smtpclient/src/SmtpMime"
 #include "trainprogram.h"
 #include "workoutmodel.h"
+#include "fitbackupwriter.h"
 #include <QChart>
 #include <QColor>
 #include <QGraphicsScene>
@@ -26,6 +27,7 @@
 #include <QQuickItem>
 #include <QQuickItemGrabResult>
 #include <QTextToSpeech>
+#include <QThread>
 
 #ifdef Q_OS_IOS
 #include "ios/lockscreen.h"
@@ -791,6 +793,10 @@ class homeform : public QObject {
     QTimer *timer;
     QTimer *backupTimer;
     QTimer *automaticShiftingTimer;
+
+    // FIT backup threading
+    QThread *fitBackupThread;
+    FitBackupWriter *fitBackupWriter;
 
     QString strava_code;
     QOAuth2AuthorizationCodeFlow *strava_connect();

--- a/src/qdomyos-zwift.pri
+++ b/src/qdomyos-zwift.pri
@@ -110,6 +110,7 @@ SOURCES += \
     $$PWD/fitdatabaseprocessor.cpp \
     $$PWD/devices/trxappgateusbrower/trxappgateusbrower.cpp \
     $$PWD/logwriter.cpp \
+    $$PWD/fitbackupwriter.cpp \
     $$PWD/mqtt/qmqttauthenticationproperties.cpp \
     $$PWD/mqtt/qmqttclient.cpp \
     $$PWD/mqtt/qmqttconnection.cpp \
@@ -384,6 +385,7 @@ HEADERS += \
     $$PWD/fitdatabaseprocessor.h \
     $$PWD/inclinationresistancetable.h \
     $$PWD/logwriter.h \
+    $$PWD/fitbackupwriter.h \
     $$PWD/osc.h \
     $$PWD/oscpp/client.hpp \
     $$PWD/oscpp/detail/endian.hpp \


### PR DESCRIPTION
- Add FitBackupWriter class to handle FIT file saving in background thread
- Move FIT backup writing from main thread to dedicated worker thread
- Use Qt's signal/slot mechanism with QueuedConnection for thread safety
- Similar implementation pattern to existing LogWriter threading
- Prevents UI blocking during FIT file saves every minute

🤖 Generated with [Claude Code](https://claude.ai/code)