### PR TITLE
[BUGFIX] Gearing off #3765

### DIFF
--- a/src/devices/ftmsbike/ftmsbike.cpp
+++ b/src/devices/ftmsbike/ftmsbike.cpp
@@ -354,8 +354,9 @@ void ftmsbike::update() {
             ((double)settings.value(QZSettings::gear_cog_size, QZSettings::default_gear_cog_size).toDouble());
             
             double current_ratio = ((double)g.crankset / (double)g.rearCog);
-            
-            uint32_t gear_value = static_cast<uint32_t>(10000.0 * (current_ratio/original_ratio) * (42.0/14.0));
+
+            // Scale gear ratio based on users chainring:cog ratio (original_ratio) relative to default Zwift 42 teet front, 14 rear.
+            uint32_t gear_value = static_cast<uint32_t>(10000.0 * 10000 * current_ratio * ( original_ratio / (42.0/14.0)));
             
             qDebug() << "zwift hub gear current ratio" << current_ratio << g.crankset << g.rearCog << "gear_value" << gear_value << "original_ratio" << original_ratio;
  


### PR DESCRIPTION
Behavior change for existing users.

Fixed gear ratio for non-standard ratios. Before it was reversed, so small front gear = larger value.  So a 22 chainring (like MTB) would have very steep gearing, like 20% per step.

This changes behavior for users who already used gear gain to compensate for non-standard ratio. They will likely have to reset gear gain to 1.0 and fine tune from there.