### PR TITLE
Support single core Raspberry Pi (like zero W)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1298,7 +1298,7 @@ jobs:
           cd ..
 
       - name: Build for Raspberry Pi
-        uses: docker://arm32v7/debian:bullseye-20241016
+        uses: docker://arm32v5/debian:bookworm-20250929
         with:
           args: >
             bash -c "


### PR DESCRIPTION
Changed Raspberry Pi from arm32v7 to arm32v5 to get support for Pi Zero W and other single core Raspberries. Went from bullseye to bookworm to get a distro listed at docker.com