### PR TITLE
Fix issue #3765

### DIFF
--- a/src/devices/ftmsbike/ftmsbike.cpp
+++ b/src/devices/ftmsbike/ftmsbike.cpp
@@ -355,7 +355,7 @@ void ftmsbike::update() {
             
             double current_ratio = ((double)g.crankset / (double)g.rearCog);
             
-            uint32_t gear_value = static_cast<uint32_t>(10000.0 * (current_ratio/original_ratio) * (42.0/14.0));
+            uint32_t gear_value = static_cast<uint32_t>(10000.0 * current_ratio);
             
             qDebug() << "zwift hub gear current ratio" << current_ratio << g.crankset << g.rearCog << "gear_value" << gear_value << "original_ratio" << original_ratio;
  


### PR DESCRIPTION
Removed attempts at scaling gearing based on chainring. Gearing is a ratio from the gearing table applied directly to the resistance, thus independent on gearing on physical bike. Zwift does not know chainring size either. Physical gearing is relevant only to calculate speed based on cadence