### PR TITLE
Cadence and Wattage no responding the right way in Zwift (using a Elite Drivo 2) #3767

### DIFF
--- a/src/devices/stagesbike/stagesbike.cpp
+++ b/src/devices/stagesbike/stagesbike.cpp
@@ -78,7 +78,7 @@ void stagesbike::update() {
         Resistance = 0;
         emit resistanceRead(Resistance.value());
         initRequest = false;
-        if(eliteService != nullptr) {
+        if(eliteService != nullptr && !DR) {
             uint8_t init1[] = {0x01, 0xad};
             writeCharacteristic(eliteService, eliteWriteCharacteristic, init1, sizeof(init1), "init", false, false);
             QThread::sleep(2);
@@ -628,6 +628,10 @@ void stagesbike::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                device.address().toString() + ')');
     {
         bluetoothDevice = device;
+        if (bluetoothDevice.name().toUpper().contains("DR")) {
+            qDebug() << QStringLiteral("DR found");
+            DR = true;
+        }
 
         m_control = QLowEnergyController::createCentral(bluetoothDevice, this);
         connect(m_control, &QLowEnergyController::serviceDiscovered, this, &stagesbike::serviceDiscovered);

--- a/src/devices/stagesbike/stagesbike.h
+++ b/src/devices/stagesbike/stagesbike.h
@@ -78,6 +78,7 @@ class stagesbike : public bike {
     bool noWriteResistance = false;
     bool noHeartService = false;
     bool noVirtualDevice = false;
+    bool DR = false;
 
     uint16_t oldLastCrankEventTime = 0;
     uint16_t oldCrankRevs = 0;


### PR DESCRIPTION
[Cadence and Wattage no responding the right way in Zwift (using a Elite Drivo 2)](https://github.com/cagnulein/qdomyos-zwift/issues/3767#top)
#3767