### PR TITLE
Add generic Bluetooth device fallback dialog

### DIFF
--- a/src/GenericDeviceDialog.qml
+++ b/src/GenericDeviceDialog.qml
@@ -1,0 +1,206 @@
+import QtQuick 2.12
+import QtQuick.Controls 2.5
+import QtQuick.Controls.Material 2.12
+import QtQuick.Dialogs 1.0
+import QtQuick.Layouts 1.12
+
+Dialog {
+    id: genericDeviceDialog
+
+    property var deviceNames: []
+    property var deviceAddresses: []
+    property var deviceServiceTypes: []
+    property int selectedDeviceIndex: 0
+
+    title: "Unknown Bluetooth Device Found"
+    modal: true
+    standardButtons: Dialog.Ok | Dialog.Cancel
+
+    width: Math.min(parent.width * 0.9, 500)
+    x: Math.round((parent.width - width) / 2)
+    y: Math.round((parent.height - height) / 2)
+
+    // Get current selected device info
+    function getSelectedDeviceName() {
+        return deviceNames[selectedDeviceIndex] || "";
+    }
+
+    function getSelectedDeviceAddress() {
+        return deviceAddresses[selectedDeviceIndex] || "";
+    }
+
+    function getSelectedServiceType() {
+        return deviceServiceTypes[selectedDeviceIndex] || "";
+    }
+
+    function getServiceDisplayName() {
+        var serviceType = getSelectedServiceType();
+        if (serviceType === "power") {
+            return "Cycling Power Service";
+        } else if (serviceType === "ftms") {
+            return "Fitness Machine Service (FTMS)";
+        }
+        return "Unknown";
+    }
+
+    function isFTMSDevice() {
+        return getSelectedServiceType() === "ftms";
+    }
+
+    contentItem: ColumnLayout {
+        spacing: 15
+
+        Label {
+            text: "QZ found a Bluetooth device that is not recognized:"
+            wrapMode: Text.WordWrap
+            Layout.fillWidth: true
+            font.bold: true
+        }
+
+        // Device selection
+        RowLayout {
+            Layout.fillWidth: true
+            visible: deviceNames.length > 1
+
+            Label {
+                text: "Select Device:"
+            }
+
+            ComboBox {
+                id: deviceComboBox
+                Layout.fillWidth: true
+                model: deviceNames
+                currentIndex: selectedDeviceIndex
+                onCurrentIndexChanged: {
+                    selectedDeviceIndex = currentIndex;
+                }
+            }
+        }
+
+        // Show selected device name if only one device
+        Label {
+            text: "Device: " + getSelectedDeviceName()
+            visible: deviceNames.length === 1
+            font.bold: true
+        }
+
+        Label {
+            text: "Service Type: " + getServiceDisplayName()
+            wrapMode: Text.WordWrap
+            Layout.fillWidth: true
+        }
+
+        Rectangle {
+            Layout.fillWidth: true
+            height: 1
+            color: "#cccccc"
+        }
+
+        // Device type selection (only for FTMS)
+        Label {
+            text: "Please select the device type:"
+            visible: isFTMSDevice()
+            font.bold: true
+        }
+
+        ColumnLayout {
+            spacing: 8
+            visible: isFTMSDevice()
+            Layout.leftMargin: 20
+
+            RadioButton {
+                id: bikeRadio
+                text: "Bike"
+                checked: true
+            }
+
+            RadioButton {
+                id: treadmillRadio
+                text: "Treadmill"
+            }
+
+            RadioButton {
+                id: ellipticalRadio
+                text: "Elliptical"
+            }
+
+            RadioButton {
+                id: rowerRadio
+                text: "Rower"
+            }
+        }
+
+        // Info for Power Sensor
+        Label {
+            text: "This device will be configured as a Power Sensor Bike."
+            visible: !isFTMSDevice()
+            wrapMode: Text.WordWrap
+            Layout.fillWidth: true
+            font.italic: true
+        }
+
+        Rectangle {
+            Layout.fillWidth: true
+            height: 1
+            color: "#cccccc"
+        }
+
+        Label {
+            text: "Note: If you click Cancel, this dialog will not appear again until you restart the app."
+            wrapMode: Text.WordWrap
+            Layout.fillWidth: true
+            font.pixelSize: 12
+            color: "#666666"
+        }
+    }
+
+    onAccepted: {
+        // Determine device type selection
+        var deviceType = "";
+        if (isFTMSDevice()) {
+            if (bikeRadio.checked) deviceType = "bike";
+            else if (treadmillRadio.checked) deviceType = "treadmill";
+            else if (ellipticalRadio.checked) deviceType = "elliptical";
+            else if (rowerRadio.checked) deviceType = "rower";
+        }
+
+        // Show confirmation dialog asking if user wants to report to team
+        reportConfirmDialog.deviceName = getSelectedDeviceName();
+        reportConfirmDialog.deviceAddress = getSelectedDeviceAddress();
+        reportConfirmDialog.serviceType = getSelectedServiceType();
+        reportConfirmDialog.deviceType = deviceType;
+        reportConfirmDialog.open();
+    }
+
+    onRejected: {
+        // User clicked Cancel - restart discovery without showing dialog again
+        rootItem.bluetoothManager.genericDeviceDialogShownThisSession = true;
+        rootItem.bluetoothManager.restart();
+    }
+
+    // Report confirmation dialog
+    MessageDialog {
+        id: reportConfirmDialog
+
+        property string deviceName: ""
+        property string deviceAddress: ""
+        property string serviceType: ""
+        property string deviceType: ""
+
+        title: "Report Device to Team"
+        text: "Would you like to report this device to the QZ team?"
+        informativeText: "This will help us add native support for your device in future releases.\n\n" +
+                         "An email will be opened with device information (no personal data or MAC address will be included)."
+        buttons: MessageDialog.Yes | MessageDialog.No
+
+        onYesClicked: {
+            // Confirm with report to team
+            rootItem.bluetoothManager.confirmGenericDevice(deviceName, deviceType, true, deviceAddress, serviceType);
+        }
+
+        onNoClicked: {
+            // Confirm without report
+            rootItem.bluetoothManager.confirmGenericDevice(deviceName, deviceType, false, deviceAddress, serviceType);
+        }
+    }
+}

--- a/src/GenericDeviceDialog.qml
+++ b/src/GenericDeviceDialog.qml
@@ -37,6 +37,8 @@ Dialog {
         var serviceType = getSelectedServiceType();
         if (serviceType === "power") {
             return "Cycling Power Service";
+        } else if (serviceType === "cadence") {
+            return "Cycling Speed and Cadence Service";
         } else if (serviceType === "ftms") {
             return "Fitness Machine Service (FTMS)";
         }
@@ -45,6 +47,16 @@ Dialog {
 
     function isFTMSDevice() {
         return getSelectedServiceType() === "ftms";
+    }
+
+    function getAutoConfigMessage() {
+        var serviceType = getSelectedServiceType();
+        if (serviceType === "power") {
+            return "This device will be configured as a Power Sensor Bike.";
+        } else if (serviceType === "cadence") {
+            return "This device will be configured as a Cadence Sensor Bike.";
+        }
+        return "";
     }
 
     contentItem: ColumnLayout {
@@ -130,9 +142,9 @@ Dialog {
             }
         }
 
-        // Info for Power Sensor
+        // Info for Power Sensor or Cadence Sensor
         Label {
-            text: "This device will be configured as a Power Sensor Bike."
+            text: getAutoConfigMessage()
             visible: !isFTMSDevice()
             wrapMode: Text.WordWrap
             Layout.fillWidth: true

--- a/src/android/src/BleServiceScanner.java
+++ b/src/android/src/BleServiceScanner.java
@@ -1,0 +1,180 @@
+package org.cagnulen.qdomyoszwift;
+
+import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothDevice;
+import android.bluetooth.BluetoothManager;
+import android.bluetooth.le.BluetoothLeScanner;
+import android.bluetooth.le.ScanCallback;
+import android.bluetooth.le.ScanFilter;
+import android.bluetooth.le.ScanResult;
+import android.bluetooth.le.ScanSettings;
+import android.content.Context;
+import android.os.ParcelUuid;
+import android.util.Log;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Native Android BLE scanner to discover all advertised services.
+ * Qt Bluetooth has a limitation on Android/iOS where it doesn't report
+ * services discovered progressively. This scanner uses native Android APIs
+ * to collect all advertised service UUIDs for each device.
+ */
+public class BleServiceScanner {
+    private static final String TAG = "BleServiceScanner";
+
+    // Store discovered services for each device (keyed by MAC address)
+    private static final Map<String, List<String>> deviceServices = new HashMap<>();
+
+    private static BluetoothLeScanner scanner = null;
+    private static ScanCallback scanCallback = null;
+    private static boolean isScanning = false;
+
+    /**
+     * Start native BLE scanning in the background.
+     * This runs in parallel with Qt's Bluetooth scanning.
+     */
+    public static void startScan(Context context) {
+        Log.d(TAG, "Starting native BLE scan");
+
+        BluetoothManager bluetoothManager = (BluetoothManager) context.getSystemService(Context.BLUETOOTH_SERVICE);
+        if (bluetoothManager == null) {
+            Log.e(TAG, "BluetoothManager is null");
+            return;
+        }
+
+        BluetoothAdapter adapter = bluetoothManager.getAdapter();
+        if (adapter == null || !adapter.isEnabled()) {
+            Log.e(TAG, "Bluetooth adapter is null or not enabled");
+            return;
+        }
+
+        scanner = adapter.getBluetoothLeScanner();
+        if (scanner == null) {
+            Log.e(TAG, "BluetoothLeScanner is null");
+            return;
+        }
+
+        // Clear previous scan results
+        deviceServices.clear();
+
+        // Create scan callback
+        scanCallback = new ScanCallback() {
+            @Override
+            public void onScanResult(int callbackType, ScanResult result) {
+                super.onScanResult(callbackType, result);
+                processScanResult(result);
+            }
+
+            @Override
+            public void onBatchScanResults(List<ScanResult> results) {
+                super.onBatchScanResults(results);
+                for (ScanResult result : results) {
+                    processScanResult(result);
+                }
+            }
+
+            @Override
+            public void onScanFailed(int errorCode) {
+                super.onScanFailed(errorCode);
+                Log.e(TAG, "Scan failed with error code: " + errorCode);
+            }
+        };
+
+        // Scan settings for maximum performance
+        ScanSettings settings = new ScanSettings.Builder()
+                .setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)
+                .setReportDelay(0) // Report immediately
+                .build();
+
+        // Start scanning (no filters = all devices)
+        try {
+            scanner.startScan(null, settings, scanCallback);
+            isScanning = true;
+            Log.d(TAG, "Native BLE scan started successfully");
+        } catch (SecurityException e) {
+            Log.e(TAG, "SecurityException starting scan: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Stop native BLE scanning.
+     */
+    public static void stopScan() {
+        if (scanner != null && scanCallback != null && isScanning) {
+            Log.d(TAG, "Stopping native BLE scan");
+            try {
+                scanner.stopScan(scanCallback);
+                isScanning = false;
+                Log.d(TAG, "Native BLE scan stopped");
+            } catch (SecurityException e) {
+                Log.e(TAG, "SecurityException stopping scan: " + e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Process a scan result and extract all advertised service UUIDs.
+     */
+    private static void processScanResult(ScanResult result) {
+        BluetoothDevice device = result.getDevice();
+        String address = device.getAddress();
+
+        // Get service UUIDs from scan record
+        List<ParcelUuid> serviceUuids = result.getScanRecord() != null ?
+                                        result.getScanRecord().getServiceUuids() : null;
+
+        if (serviceUuids != null && !serviceUuids.isEmpty()) {
+            List<String> uuidStrings = new ArrayList<>();
+            for (ParcelUuid uuid : serviceUuids) {
+                uuidStrings.add(uuid.getUuid().toString());
+            }
+
+            // Store or update services for this device
+            List<String> existingServices = deviceServices.get(address);
+            if (existingServices == null) {
+                deviceServices.put(address, uuidStrings);
+                Log.d(TAG, "New device " + address + " with " + uuidStrings.size() + " services: " + uuidStrings);
+            } else {
+                // Merge services (some might be discovered progressively)
+                for (String uuid : uuidStrings) {
+                    if (!existingServices.contains(uuid)) {
+                        existingServices.add(uuid);
+                        Log.d(TAG, "Device " + address + " added service: " + uuid);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Get all discovered service UUIDs for a specific device.
+     * Called from Qt C++ via JNI.
+     *
+     * @param macAddress Device MAC address (e.g., "AA:BB:CC:DD:EE:FF")
+     * @return Comma-separated list of service UUIDs, or empty string if not found
+     */
+    public static String getDeviceServices(String macAddress) {
+        List<String> services = deviceServices.get(macAddress);
+        if (services == null || services.isEmpty()) {
+            Log.d(TAG, "No services found for device: " + macAddress);
+            return "";
+        }
+
+        // Return as comma-separated string for easy JNI transfer
+        String result = String.join(",", services);
+        Log.d(TAG, "Returning services for " + macAddress + ": " + result);
+        return result;
+    }
+
+    /**
+     * Get all discovered device addresses.
+     * Useful for debugging.
+     */
+    public static String getAllDevices() {
+        return String.join(",", deviceServices.keySet());
+    }
+}

--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -242,6 +242,20 @@ void bluetooth::finished() {
         QBluetoothUuid cyclingPowerUuid((quint16)0x1818);
         QBluetoothUuid ftmsUuid((quint16)0x1826);
 
+        // First, log all devices and their services for debugging
+        for (const QBluetoothDeviceInfo &b : qAsConst(devices)) {
+            if (!b.name().isEmpty()) {
+                QStringList servicesList;
+                foreach(QBluetoothUuid uuid, b.serviceUuids()) {
+                    servicesList.append(uuid.toString());
+                }
+                debug(QStringLiteral("Device '%1' has %2 services: %3")
+                    .arg(b.name())
+                    .arg(b.serviceUuids().size())
+                    .arg(servicesList.join(", ")));
+            }
+        }
+
         // Scan all discovered devices for generic services
         // Priority: 1826 (FTMS) first, then 1818 (Cycling Power), then 1816 (Cadence)
         for (const QBluetoothDeviceInfo &b : qAsConst(devices)) {

--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -739,12 +739,40 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
             QBluetoothDeviceInfo b = i.next();
             if (SAME_BLUETOOTH_DEVICE(b, device) && !b.name().isEmpty()) {
 
+                // Log service changes when updating existing device
+                QStringList oldServices, newServices;
+                foreach(QBluetoothUuid uuid, b.serviceUuids()) {
+                    oldServices.append(uuid.toString());
+                }
+                foreach(QBluetoothUuid uuid, device.serviceUuids()) {
+                    newServices.append(uuid.toString());
+                }
+                debug(QStringLiteral("Updating existing device '%1': %2 -> %3 services")
+                    .arg(device.name())
+                    .arg(b.serviceUuids().size())
+                    .arg(device.serviceUuids().size()));
+                if (oldServices != newServices) {
+                    debug(QStringLiteral("  Services changed!"));
+                    debug(QStringLiteral("    Old: %1").arg(oldServices.join(", ")));
+                    debug(QStringLiteral("    New: %1").arg(newServices.join(", ")));
+                } else {
+                    debug(QStringLiteral("  Services unchanged: %1").arg(newServices.join(", ")));
+                }
+
                 i.setValue(device); // in order to keep the freshest copy of this struct
                 found = true;
                 break;
             }
         }
         if (!found) {
+            QStringList services;
+            foreach(QBluetoothUuid uuid, device.serviceUuids()) {
+                services.append(uuid.toString());
+            }
+            debug(QStringLiteral("Adding new device '%1' with %2 services: %3")
+                .arg(device.name())
+                .arg(device.serviceUuids().size())
+                .arg(services.join(", ")));
             devices.append(device);
         }
     }

--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -216,7 +216,11 @@ void bluetooth::finished() {
 
     // Check for generic devices with UUID 1818 (Cycling Power) or 1826 (FTMS)
     // Only if no known device was connected and filter is disabled and dialog not shown this session
-    if (!device() && homeformLoaded && !genericDeviceDialogShownThisSession &&
+    // Also skip if wizard is active (firstRun check via bluetooth_lastdevice_name)
+    QString lastDeviceName = settings.value(QZSettings::bluetooth_lastdevice_name, QZSettings::default_bluetooth_lastdevice_name).toString();
+    bool wizardActive = lastDeviceName.isEmpty();
+
+    if (!device() && homeformLoaded && !genericDeviceDialogShownThisSession && !wizardActive &&
         (filterDevice.isEmpty() || filterDevice.startsWith(QStringLiteral("Disabled")))) {
 
         QStringList genericDeviceNames;

--- a/src/devices/bluetooth.h
+++ b/src/devices/bluetooth.h
@@ -343,6 +343,9 @@ class bluetooth : public QObject, public SignalHandler {
     bool sramDeviceAvaiable();
     bool fitmetria_fanfit_isconnected(QString name);
 
+    // Flag to prevent showing generic device dialog multiple times in same session
+    bool genericDeviceDialogShownThisSession = false;
+
 #ifdef Q_OS_WIN
     QTimer discoveryTimeout;
 #endif
@@ -365,11 +368,17 @@ class bluetooth : public QObject, public SignalHandler {
 
     void bluetoothDeviceConnected(bluetoothdevice *b);
     void bluetoothDeviceDisconnected();
+
+    // Signals for generic device fallback dialog
+    void genericDevicesFound(QStringList deviceNames, QStringList deviceAddresses, QStringList deviceServiceTypes);
   public slots:
     void restart();
     void debug(const QString &string);
     void heartRate(uint8_t heart);
     void deviceDiscovered(const QBluetoothDeviceInfo &device);
+
+    // Public slots for generic device configuration
+    void confirmGenericDevice(QString deviceName, QString deviceType, bool reportToTeam, QString deviceAddress, QString serviceType);
   private slots:
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 12, 0))
     void deviceUpdated(const QBluetoothDeviceInfo &device, QBluetoothDeviceInfo::Fields updateFields);

--- a/src/ios/BleScanner.swift
+++ b/src/ios/BleScanner.swift
@@ -1,0 +1,124 @@
+import Foundation
+import CoreBluetooth
+
+@objc class BleScanner: NSObject, CBCentralManagerDelegate {
+    private var centralManager: CBCentralManager!
+    private var deviceServices: [String: [String]] = [:]  // MAC address -> service UUIDs
+    private var isScanning = false
+
+    static let shared = BleScanner()
+
+    private override init() {
+        super.init()
+        centralManager = CBCentralManager(delegate: self, queue: nil)
+    }
+
+    // MARK: - Public Methods
+
+    @objc func startScan() {
+        guard centralManager.state == .poweredOn else {
+            print("BleScanner: Bluetooth not powered on, state: \(centralManager.state.rawValue)")
+            return
+        }
+
+        if !isScanning {
+            // Clear previous scan results
+            deviceServices.removeAll()
+
+            // Start scanning for all devices (nil = discover all)
+            centralManager.scanForPeripherals(withServices: nil, options: [
+                CBCentralManagerScanOptionAllowDuplicatesKey: true  // Allow duplicates to catch progressive service updates
+            ])
+            isScanning = true
+            print("BleScanner: Started scanning for BLE devices")
+        }
+    }
+
+    @objc func stopScan() {
+        if isScanning {
+            centralManager.stopScan()
+            isScanning = false
+            print("BleScanner: Stopped scanning, found \(deviceServices.count) devices")
+        }
+    }
+
+    @objc func getDeviceServices(macAddress: String) -> String {
+        // iOS doesn't expose MAC addresses directly, so we use peripheral identifiers
+        // The C++ code will need to use peripheral.identifier.uuidString as the "MAC address"
+        guard let services = deviceServices[macAddress] else {
+            return ""
+        }
+
+        // Return comma-separated list of service UUIDs in full 128-bit format
+        return services.joined(separator: ",")
+    }
+
+    // MARK: - CBCentralManagerDelegate
+
+    func centralManagerDidUpdateState(_ central: CBCentralManager) {
+        switch central.state {
+        case .poweredOn:
+            print("BleScanner: Bluetooth is powered on")
+        case .poweredOff:
+            print("BleScanner: Bluetooth is powered off")
+        case .resetting:
+            print("BleScanner: Bluetooth is resetting")
+        case .unauthorized:
+            print("BleScanner: Bluetooth is unauthorized")
+        case .unsupported:
+            print("BleScanner: Bluetooth is unsupported")
+        case .unknown:
+            print("BleScanner: Bluetooth state is unknown")
+        @unknown default:
+            print("BleScanner: Unknown Bluetooth state")
+        }
+    }
+
+    func centralManager(_ central: CBCentralManager, didDiscover peripheral: CBPeripheral,
+                       advertisementData: [String: Any], rssi RSSI: NSNumber) {
+
+        // Use peripheral identifier as unique key (iOS doesn't expose MAC addresses)
+        let deviceId = peripheral.identifier.uuidString
+
+        // Extract service UUIDs from advertisement data
+        var serviceUUIDs: [String] = []
+
+        // Get advertised service UUIDs
+        if let services = advertisementData[CBAdvertisementDataServiceUUIDsKey] as? [CBUUID] {
+            serviceUUIDs.append(contentsOf: services.map { $0.uuidString.lowercased() })
+        }
+
+        // Get overflow service UUIDs (services that couldn't fit in advertisement packet)
+        if let overflowServices = advertisementData[CBAdvertisementDataOverflowServiceUUIDsKey] as? [CBUUID] {
+            serviceUUIDs.append(contentsOf: overflowServices.map { $0.uuidString.lowercased() })
+        }
+
+        // Get solicited service UUIDs
+        if let solicitedServices = advertisementData[CBAdvertisementDataSolicitedServiceUUIDsKey] as? [CBUUID] {
+            serviceUUIDs.append(contentsOf: solicitedServices.map { $0.uuidString.lowercased() })
+        }
+
+        // Merge services with existing ones for this device
+        if var existingServices = deviceServices[deviceId] {
+            // Add new services that aren't already in the list
+            for service in serviceUUIDs {
+                if !existingServices.contains(service) {
+                    existingServices.append(service)
+                }
+            }
+            deviceServices[deviceId] = existingServices
+        } else {
+            // First time seeing this device
+            deviceServices[deviceId] = serviceUUIDs
+        }
+
+        // Debug logging
+        let name = peripheral.name ?? "Unknown"
+        if !serviceUUIDs.isEmpty {
+            print("BleScanner: Device '\(name)' (\(deviceId)) advertises services: \(serviceUUIDs.joined(separator: ", "))")
+            if let allServices = deviceServices[deviceId], allServices.count > serviceUUIDs.count {
+                print("BleScanner: Device '\(name)' total services collected: \(allServices.joined(separator: ", "))")
+            }
+        }
+    }
+}

--- a/src/ios/ios_blescanner.h
+++ b/src/ios/ios_blescanner.h
@@ -1,0 +1,13 @@
+#ifndef IOS_BLESCANNER_H
+#define IOS_BLESCANNER_H
+
+#include <QString>
+
+class ios_blescanner {
+public:
+    static void startScan();
+    static void stopScan();
+    static QString getDeviceServices(const QString& deviceId);
+};
+
+#endif // IOS_BLESCANNER_H

--- a/src/ios/ios_blescanner.mm
+++ b/src/ios/ios_blescanner.mm
@@ -1,0 +1,40 @@
+#ifndef IO_UNDER_QT
+#import <Foundation/Foundation.h>
+#import <CoreBluetooth/CoreBluetooth.h>
+#import "qdomyoszwift-Swift2.h"
+#include "ios/ios_blescanner.h"
+#include <QDebug>
+
+static BleScanner* _bleScanner = nil;
+
+void ios_blescanner::startScan() {
+    if (_bleScanner == nil) {
+        _bleScanner = [BleScanner shared];
+    }
+    [_bleScanner startScan];
+    qDebug() << "iOS BLE scanner started for generic device detection";
+}
+
+void ios_blescanner::stopScan() {
+    if (_bleScanner != nil) {
+        [_bleScanner stopScan];
+        qDebug() << "iOS BLE scanner stopped";
+    }
+}
+
+QString ios_blescanner::getDeviceServices(const QString& deviceId) {
+    if (_bleScanner == nil) {
+        return QString();
+    }
+
+    NSString *nsDeviceId = deviceId.toNSString();
+    NSString *services = [_bleScanner getDeviceServicesWithMacAddress:nsDeviceId];
+
+    if (services != nil && services.length > 0) {
+        return QString::fromNSString(services);
+    }
+
+    return QString();
+}
+
+#endif

--- a/src/main.qml
+++ b/src/main.qml
@@ -107,6 +107,34 @@ ApplicationWindow {
       onLoaded: { console.log("googleMapUI loaded"); stackView.push(googleMapUI.item); }
     }
 
+    // Generic Device Dialog for unknown Bluetooth devices
+    Loader {
+        id: genericDeviceDialogLoader
+        source: "GenericDeviceDialog.qml"
+        active: true
+        onLoaded: {
+            console.log("GenericDeviceDialog loaded");
+        }
+    }
+
+    // Connections to handle generic device discovery
+    Connections {
+        target: rootItem.bluetoothManager
+
+        function onGenericDevicesFound(deviceNames, deviceAddresses, deviceServiceTypes) {
+            console.log("Generic devices found:", deviceNames);
+            if (genericDeviceDialogLoader.status === Loader.Ready && genericDeviceDialogLoader.item) {
+                genericDeviceDialogLoader.item.deviceNames = deviceNames;
+                genericDeviceDialogLoader.item.deviceAddresses = deviceAddresses;
+                genericDeviceDialogLoader.item.deviceServiceTypes = deviceServiceTypes;
+                genericDeviceDialogLoader.item.selectedDeviceIndex = 0;
+                genericDeviceDialogLoader.item.open();
+            } else {
+                console.error("GenericDeviceDialog not ready");
+            }
+        }
+    }
+
     // here in order to cache everything for the SwagBagView
     Product {
         id: productUnlockVowels

--- a/src/qdomyos-zwift.pri
+++ b/src/qdomyos-zwift.pri
@@ -940,6 +940,7 @@ DISTFILES += \
 	android/src/org/qtproject/qt/android/purchasing/Base64DecoderException.java \
 	ios/AppDelegate.swift \
 	ios/BLEPeripheralManager.swift \
+	ios/BleScanner.swift \
 	ios/LiveActivityManager.swift
 
 win32: DISTFILES += \
@@ -958,6 +959,7 @@ ios {
     ios/ios_eliteariafan.mm \
     ios/ios_app_delegate.mm \
     ios/ios_liveactivity.mm \
+    ios/ios_blescanner.mm \
 	 fit-sdk/FitDecode.mm \
 	 fit-sdk/FitDeveloperField.mm \
 	 fit-sdk/FitEncode.mm \
@@ -970,7 +972,8 @@ ios {
     SOURCES += ios/M3iNSQT.cpp
 
     OBJECTIVE_HEADERS += ios/M3iNS.h \
-    ios/ios_liveactivity.h
+    ios/ios_liveactivity.h \
+    ios/ios_blescanner.h
 
     QMAKE_INFO_PLIST = ios/Info.plist
 	 QMAKE_ASSET_CATALOGS = $$PWD/ios/Images.xcassets

--- a/src/qml.qrc
+++ b/src/qml.qrc
@@ -84,6 +84,7 @@
         <file>gpx/Richmond Park.gpx</file>
         <file>gpx/St Andrews to Pittenweem.gpx</file>
         <file>GPXList.qml</file>
+        <file>GenericDeviceDialog.qml</file>
         <file>WorkoutsHistory.qml</file>
         <file>WorkoutTypeTag.qml</file>
         <file>inner_templates/previewchart/ajax-loader.gif</file>


### PR DESCRIPTION
This feature adds support for automatically detecting and configuring
unknown Bluetooth devices with Cycling Power Service (UUID 0x1818) or
Fitness Machine Service (UUID 0x1826).

Changes:
- Added new signal `genericDevicesFound()` in bluetooth.h to notify UI
  of discovered generic devices
- Added slot `confirmGenericDevice()` to handle user's device configuration
- Added flag `genericDeviceDialogShownThisSession` to prevent showing dialog
  multiple times in the same session
- Implemented logic in bluetooth.cpp::finished() to detect devices with
  UUID 1818 or 1826 when no known device is connected
- Created GenericDeviceDialog.qml with support for:
  * Multiple device selection via ComboBox
  * Device type selection (bike/treadmill/elliptical/rower) for FTMS
  * Automatic configuration as Power Sensor Bike for UUID 1818
  * Optional device reporting to team via email (without MAC address)
- Integrated dialog in main.qml with Connections to bluetooth signals
- Devices are configured using existing settings (power_sensor_name,
  power_sensor_as_bike, ftms_bike, ftms_treadmill, ftms_elliptical, ftms_rower)
- Discovery automatically restarts after configuration

Priority order: FTMS (0x1826) devices shown first, then Cycling Power (0x1818)
Cancel button prevents dialog from appearing again until app restart