### PR TITLE
Fix: Apply volume gear patch only when volume_change_gears is enabled

### DIFF
--- a/src/homeform.cpp
+++ b/src/homeform.cpp
@@ -840,10 +840,14 @@ homeform::homeform(QQmlApplicationEngine *engine, bluetooth *bl) {
     QAndroidJniObject::callStaticMethod<void>("org/cagnulen/qdomyoszwift/Shortcuts", "createShortcutsForFiles",
                                                 "(Ljava/lang/String;Landroid/content/Context;)V", javaPath.object<jstring>(), QtAndroid::androidContext().object());
 
-    QAndroidJniObject::callStaticMethod<void>("org/cagnulen/qdomyoszwift/MediaButtonReceiver",
-                                              "registerReceiver",
-                                              "(Landroid/content/Context;)V",
-                                              QtAndroid::androidContext().object());
+    // Only register MediaButtonReceiver if volume_change_gears is enabled
+    if (settings.value(QZSettings::volume_change_gears, QZSettings::default_volume_change_gears).toBool()) {
+        qDebug() << "Registering MediaButtonReceiver for volume gear control";
+        QAndroidJniObject::callStaticMethod<void>("org/cagnulen/qdomyoszwift/MediaButtonReceiver",
+                                                  "registerReceiver",
+                                                  "(Landroid/content/Context;)V",
+                                                  QtAndroid::androidContext().object());
+    }
 #endif    
 
     bluetoothManager->homeformLoaded = true;


### PR DESCRIPTION
The PR #3779 patch was applying volume restoration logic unconditionally,
even when the volume_change_gears setting was disabled. This caused the
MediaButtonReceiver to modify system volume regardless of user preference.

Changes:
- Added conditional check before registering MediaButtonReceiver
- MediaButtonReceiver now only registers when volume_change_gears is enabled
- Prevents unwanted volume manipulation when feature is disabled

Fixes issue where volume would be auto-reset to level 7 even with the
feature disabled.