### PR TITLE
Change Kettler USB baudrate from 9600 to 57600

### DIFF
--- a/src/devices/kettlerusbbike/KettlerUSB.h
+++ b/src/devices/kettlerusbbike/KettlerUSB.h
@@ -64,11 +64,11 @@
 class KettlerUSB : public QThread {
 
   public:
-    KettlerUSB(QObject *parent = 0, QString deviceFilename = 0, bool use57600Baud = true);
+    KettlerUSB(QObject *parent = 0, QString deviceFilename = 0, int baudrate = 9600);
     ~KettlerUSB();
 
     QObject *parent;
-    bool use57600Baud = true;
+    int baudrate = 9600;
 
     // HIGH-LEVEL FUNCTIONS
     int start();                           // Calls QThread to start

--- a/src/devices/kettlerusbbike/kettlerusbbike.cpp
+++ b/src/devices/kettlerusbbike/kettlerusbbike.cpp
@@ -48,10 +48,10 @@ kettlerusbbike::kettlerusbbike(bool noWriteResistance, bool noHeartService, int8
 
     QString kettlerSerialPort =
         settings.value(QZSettings::kettler_usb_serialport, QZSettings::default_kettler_usb_serialport).toString();
-    bool kettlerBaud57600 =
-        settings.value(QZSettings::kettler_usb_baud_57600, QZSettings::default_kettler_usb_baud_57600).toBool();
+    int kettlerBaudrate =
+        settings.value(QZSettings::kettler_usb_baudrate, QZSettings::default_kettler_usb_baudrate).toInt();
 
-    myKettler = new KettlerUSB(this, kettlerSerialPort, kettlerBaud57600);
+    myKettler = new KettlerUSB(this, kettlerSerialPort, kettlerBaudrate);
     myKettler->start();
 
     ergModeSupported = true; // ERG mode supported

--- a/src/qzsettings.cpp
+++ b/src/qzsettings.cpp
@@ -573,7 +573,7 @@ const QString QZSettings::computrainer_serialport = QStringLiteral("computrainer
 const QString QZSettings::default_computrainer_serialport = QStringLiteral("");
 const QString QZSettings::kettler_usb_serialport = QStringLiteral("kettler_usb_serialport");
 const QString QZSettings::default_kettler_usb_serialport = QStringLiteral("");
-const QString QZSettings::kettler_usb_baud_57600 = QStringLiteral("kettler_usb_baud_57600");
+const QString QZSettings::kettler_usb_baudrate = QStringLiteral("kettler_usb_baudrate");
 const QString QZSettings::strava_virtual_activity = QStringLiteral("strava_virtual_activity");
 const QString QZSettings::powr_sensor_running_cadence_half_on_strava =
     QStringLiteral("powr_sensor_running_cadence_half_on_strava");
@@ -1468,7 +1468,7 @@ QVariant allSettings[allSettingsCount][2] = {
     {QZSettings::ss2k_peloton, QZSettings::default_ss2k_peloton},
     {QZSettings::computrainer_serialport, QZSettings::default_computrainer_serialport},
     {QZSettings::kettler_usb_serialport, QZSettings::default_kettler_usb_serialport},
-    {QZSettings::kettler_usb_baud_57600, QZSettings::default_kettler_usb_baud_57600},
+    {QZSettings::kettler_usb_baudrate, QZSettings::default_kettler_usb_baudrate},
     {QZSettings::strava_virtual_activity, QZSettings::default_strava_virtual_activity},
     {QZSettings::powr_sensor_running_cadence_half_on_strava,
      QZSettings::default_powr_sensor_running_cadence_half_on_strava},

--- a/src/qzsettings.h
+++ b/src/qzsettings.h
@@ -1640,8 +1640,8 @@ class QZSettings {
 
     static const QString kettler_usb_serialport;
     static const QString default_kettler_usb_serialport;
-    static const QString kettler_usb_baud_57600;
-    static constexpr bool default_kettler_usb_baud_57600 = true;
+    static const QString kettler_usb_baudrate;
+    static constexpr int default_kettler_usb_baudrate = 9600;
 
     static const QString strava_virtual_activity;
     static constexpr bool default_strava_virtual_activity = true;

--- a/src/settings.qml
+++ b/src/settings.qml
@@ -1215,7 +1215,7 @@ import Qt.labs.platform 1.1
             property bool skandika_wiri_x2000_protocol: true
             property bool nordictrack_series_7: false
             property string kettler_usb_serialport: ""
-            property bool kettler_usb_baud_57600: true
+            property int kettler_usb_baudrate: 9600
         }
 
 
@@ -4347,7 +4347,7 @@ import Qt.labs.platform 1.1
                             ComboBox {
                                 id: kettlerUsbBaudrateComboBox
                                 model: [ "9600", "57600" ]
-                                displayText: settings.kettler_usb_baud_57600 ? "57600" : "9600"
+                                displayText: settings.kettler_usb_baudrate.toString()
                                 Layout.fillHeight: false
                                 Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
                                 onActivated: {
@@ -4360,7 +4360,7 @@ import Qt.labs.platform 1.1
                                 text: "OK"
                                 Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
                                 onClicked: {
-                                    settings.kettler_usb_baud_57600 = (kettlerUsbBaudrateComboBox.displayText === "57600");
+                                    settings.kettler_usb_baudrate = parseInt(kettlerUsbBaudrateComboBox.displayText);
                                     window.settings_restart_to_apply = true;
                                     toast.show("Setting saved!");
                                 }


### PR DESCRIPTION
Update baudrate configuration for Kettler USB bike support across all platforms:
- Android: Update JNI call parameter to 57600
- Linux/Mac: Change cfsetspeed to B57600
- Windows: Change BaudRate to CBR_57600