### PR TITLE
Add CYCPLUS BC2 shifter support

### DIFF
--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -3099,6 +3099,25 @@ void bluetooth::connectedAndDiscovered() {
     }
 
     if(settings.value(QZSettings::zwift_play, QZSettings::default_zwift_play).toBool()) {
+        for (const QBluetoothDeviceInfo &b : qAsConst(devices)) {
+            if (((b.name().toUpper().startsWith("CYCPLUS BC2"))) && !cycplusbc2Device && this->device() &&
+                this->device()->deviceType() == BIKE) {
+
+                cycplusbc2Device = new cycplusbc2(this->device());
+                // connect(cycplusbc2Device, SIGNAL(disconnected()), this, SLOT(restart()));
+
+                connect(cycplusbc2Device, &cycplusbc2::debug, this, &bluetooth::debug);
+                connect(cycplusbc2Device, &cycplusbc2::plus, (bike*)this->device(), &bike::gearUp);
+                connect(cycplusbc2Device, &cycplusbc2::minus, (bike*)this->device(), &bike::gearDown);
+                cycplusbc2Device->deviceDiscovered(b);
+                if(homeform::singleton())
+                    homeform::singleton()->setToastRequested("CYCPLUS BC2 Connected!");
+                break;
+            }
+        }
+    }
+
+    if(settings.value(QZSettings::zwift_play, QZSettings::default_zwift_play).toBool()) {
         bool zwiftplay_swap = settings.value(QZSettings::zwiftplay_swap, QZSettings::default_zwiftplay_swap).toBool();
         for (const QBluetoothDeviceInfo &b : qAsConst(devices)) {
             if ((((b.name().toUpper().startsWith("ZWIFT PLAY"))) || b.name().toUpper().startsWith("ZWIFT RIDE") || b.name().toUpper().startsWith("ZWIFT SF2")) && zwiftPlayDevice.size() < 2 && this->device() &&

--- a/src/devices/bluetooth.h
+++ b/src/devices/bluetooth.h
@@ -154,6 +154,7 @@
 
 #include "zwift_play/zwiftPlayDevice.h"
 #include "zwift_play/zwiftclickremote.h"
+#include "zwift_play/cycplusbc2.h"
 
 #ifdef Q_OS_IOS
 #include "ios/lockscreen.h"
@@ -308,6 +309,7 @@ class bluetooth : public QObject, public SignalHandler {
     zwiftclickremote* zwiftClickRemote = nullptr;
     sramaxscontroller* sramAXSController = nullptr;
     elitesquarecontroller* eliteSquareController = nullptr;
+    cycplusbc2* cycplusbc2Device = nullptr;
     QString filterDevice = QLatin1String("");
 
     bool testResistance = false;

--- a/src/qdomyos-zwift.pri
+++ b/src/qdomyos-zwift.pri
@@ -154,6 +154,7 @@ windows_zwift_workout_paddleocr_thread.cpp \
 devices/ypooelliptical/ypooelliptical.cpp \
 devices/ziprotreadmill/ziprotreadmill.cpp \
 zwift_play/zwiftclickremote.cpp \
+zwift_play/cycplusbc2.cpp \
 devices/computrainerbike/Computrainer.cpp \
 devices/kettlerusbbike/KettlerUSB.cpp \
 PathController.cpp \
@@ -442,6 +443,7 @@ zwift_play/zapBleUuids.h \
 zwift_play/zapConstants.h \
 zwift_play/zwiftPlayDevice.h \
 zwift_play/zwiftclickremote.h \
+zwift_play/cycplusbc2.h \
 virtualdevices/virtualdevice.h \
 androidactivityresultreceiver.h \
 androidadblog.h \

--- a/src/zwift_play/cycplusbc2.cpp
+++ b/src/zwift_play/cycplusbc2.cpp
@@ -1,0 +1,304 @@
+#include "homeform.h"
+#include "cycplusbc2.h"
+#include <QBluetoothLocalDevice>
+#include <QDateTime>
+#include <QEventLoop>
+#include <QFile>
+#include <QMetaEnum>
+#include <QSettings>
+#include <QThread>
+
+using namespace std::chrono_literals;
+
+#ifdef Q_OS_IOS
+extern quint8 QZ_EnableDiscoveryCharsAndDescripttors;
+#endif
+
+// Nordic UART Service UUIDs
+static const QBluetoothUuid NORDIC_UART_SERVICE_UUID(QStringLiteral("6e400001-b5a3-f393-e0a9-e50e24dcca9e"));
+static const QBluetoothUuid NORDIC_UART_TX_CHAR_UUID(QStringLiteral("6e400003-b5a3-f393-e0a9-e50e24dcca9e"));  // Device -> App (Notify)
+static const QBluetoothUuid NORDIC_UART_RX_CHAR_UUID(QStringLiteral("6e400002-b5a3-f393-e0a9-e50e24dcca9e"));  // App -> Device (Write, unused)
+
+cycplusbc2::cycplusbc2(bluetoothdevice *parentDevice) {
+#ifdef Q_OS_IOS
+    QZ_EnableDiscoveryCharsAndDescripttors = true;
+#endif
+    this->parentDevice = parentDevice;
+
+    refresh = new QTimer(this);
+    connect(refresh, &QTimer::timeout, this, &cycplusbc2::update);
+    refresh->start(1000ms);
+}
+
+void cycplusbc2::update() {
+    if(initDone) {
+        countRxTimeout++;
+        if(countRxTimeout == 10) {
+            if(homeform::singleton())
+                homeform::singleton()->setToastRequested("CYCPLUS BC2: Connection timeout!");
+        }
+    }
+}
+
+void cycplusbc2::serviceDiscovered(const QBluetoothUuid &gatt) {
+    emit debug(QStringLiteral("serviceDiscovered ") + gatt.toString());
+}
+
+void cycplusbc2::disconnectBluetooth() {
+    qDebug() << QStringLiteral("cycplusbc2::disconnect") << m_control;
+
+    if (m_control) {
+        m_control->disconnectFromDevice();
+    }
+}
+
+void cycplusbc2::characteristicChanged(const QLowEnergyCharacteristic &characteristic,
+                                       const QByteArray &newValue) {
+    handleCharacteristicValueChanged(characteristic.uuid(), newValue);
+}
+
+void cycplusbc2::handleCharacteristicValueChanged(const QBluetoothUuid &uuid, const QByteArray &newValue) {
+    emit packetReceived();
+    countRxTimeout = 0;
+
+    qDebug() << QStringLiteral("CYCPLUS BC2 << ") << newValue.toHex(' ') << uuid.toString();
+
+    // Check if this is the TX characteristic (device -> app)
+    if(uuid == NORDIC_UART_TX_CHAR_UUID) {
+        // Verify packet is 8 bytes as expected
+        if(newValue.length() >= 8) {
+            uint8_t shiftUpState = static_cast<uint8_t>(newValue[6]);
+            uint8_t shiftDownState = static_cast<uint8_t>(newValue[7]);
+
+            // Check for Shift Up state change (pressed to different pressed value)
+            if(shiftUpState != 0x00 && lastShiftUpState != 0x00 && shiftUpState != lastShiftUpState) {
+                qDebug() << "CYCPLUS BC2: Shift UP triggered" << QString::number(shiftUpState, 16);
+                emit plus();
+            }
+
+            // Check for Shift Down state change (pressed to different pressed value)
+            if(shiftDownState != 0x00 && lastShiftDownState != 0x00 && shiftDownState != lastShiftDownState) {
+                qDebug() << "CYCPLUS BC2: Shift DOWN triggered" << QString::number(shiftDownState, 16);
+                emit minus();
+            }
+
+            // Update last states
+            lastShiftUpState = shiftUpState;
+            lastShiftDownState = shiftDownState;
+        } else {
+            qDebug() << "CYCPLUS BC2: Unexpected packet length:" << newValue.length();
+        }
+    }
+}
+
+void cycplusbc2::writeCharacteristic(QLowEnergyService *service, QLowEnergyCharacteristic *writeChar,
+                                     uint8_t *data, uint8_t data_len, const QString &info, bool disable_log,
+                                     bool wait_for_response) {
+#ifdef Q_OS_IOS
+#ifndef IO_UNDER_QT
+    iOS_cycplusbc2->zwiftClickRemote_WriteCharacteristic(data, data_len, this); // Pass 'this' pointer
+    if (!disable_log) {
+        QByteArray buffer((const char *)data, data_len);
+        qDebug() << QStringLiteral(" >> ") + buffer.toHex(' ') + QStringLiteral(" // ") + info;
+    }
+    return;
+#endif
+#endif
+
+    QEventLoop loop;
+    QTimer timeout;
+
+    if (service == nullptr || writeChar->isValid() == false) {
+        qDebug() << QStringLiteral(
+            "cycplusbc2 trying to write before the connection is established");
+        return;
+    }
+
+    if (wait_for_response) {
+        connect(service, &QLowEnergyService::characteristicChanged, &loop, &QEventLoop::quit);
+        timeout.singleShot(300ms, &loop, &QEventLoop::quit);
+    } else {
+        connect(service, &QLowEnergyService::characteristicWritten, &loop, &QEventLoop::quit);
+        timeout.singleShot(300ms, &loop, &QEventLoop::quit);
+    }
+
+    if (service->state() != QLowEnergyService::ServiceState::ServiceDiscovered ||
+        m_control->state() == QLowEnergyController::UnconnectedState) {
+        qDebug() << QStringLiteral("writeCharacteristic error because the connection is closed");
+        return;
+    }
+
+    if (!writeChar->isValid()) {
+        qDebug() << QStringLiteral("gattWriteCharacteristic is invalid");
+        return;
+    }
+
+    if (writeBuffer) {
+        delete writeBuffer;
+    }
+    writeBuffer = new QByteArray((const char *)data, data_len);
+
+    service->writeCharacteristic(*writeChar, *writeBuffer, QLowEnergyService::WriteWithoutResponse);
+
+    if (!disable_log) {
+        qDebug() << QStringLiteral(" >> ") + writeBuffer->toHex(' ') + QStringLiteral(" // ") + info;
+    }
+
+    if(wait_for_response)
+        loop.exec();
+}
+
+void cycplusbc2::stateChanged(QLowEnergyService::ServiceState state) {
+    QMetaEnum metaEnum = QMetaEnum::fromType<QLowEnergyService::ServiceState>();
+    emit debug(QStringLiteral("BTLE stateChanged ") + QString::fromLocal8Bit(metaEnum.valueToKey(state)));
+
+#ifndef Q_OS_IOS
+    for (QLowEnergyService *s : qAsConst(gattCommunicationChannelService)) {
+        qDebug() << QStringLiteral("stateChanged") << s->serviceUuid() << state;
+        if (s->serviceUuid() == NORDIC_UART_SERVICE_UUID) {
+            qDebug() << QStringLiteral("cycplusbc2 service discovered");
+
+            if (state != QLowEnergyService::ServiceDiscovered) {
+                qDebug() << QStringLiteral("cycplusbc2 service not yet discovered");
+                return;
+            }
+
+            gattService = s;
+
+            // Get TX characteristic (device -> app, notifications)
+            gattNotifyCharacteristic = gattService->characteristic(NORDIC_UART_TX_CHAR_UUID);
+            if (!gattNotifyCharacteristic.isValid()) {
+                qDebug() << QStringLiteral("cycplusbc2 TX characteristic not found");
+                return;
+            }
+
+            // Get RX characteristic (app -> device, write - unused for button reading)
+            gattWriteCharacteristic = gattService->characteristic(NORDIC_UART_RX_CHAR_UUID);
+
+            connect(gattService, &QLowEnergyService::characteristicChanged, this, &cycplusbc2::characteristicChanged);
+            connect(gattService, &QLowEnergyService::characteristicWritten, this, &cycplusbc2::characteristicWritten);
+            connect(gattService, &QLowEnergyService::error, this, &cycplusbc2::errorService);
+            connect(gattService, &QLowEnergyService::descriptorWritten, this, &cycplusbc2::descriptorWritten);
+
+            // Enable notifications on TX characteristic
+            QByteArray descriptor;
+            descriptor.append((char)0x01);
+            descriptor.append((char)0x00);
+            gattService->writeDescriptor(
+                gattNotifyCharacteristic.descriptor(QBluetoothUuid::ClientCharacteristicConfiguration),
+                descriptor);
+
+            initDone = true;
+            emit debug(QStringLiteral("cycplusbc2 initialized and listening for button presses"));
+        }
+    }
+#endif
+}
+
+void cycplusbc2::descriptorWritten(const QLowEnergyDescriptor &descriptor, const QByteArray &newValue) {
+    emit debug(QStringLiteral("descriptorWritten ") + descriptor.name() + QStringLiteral(" ") + newValue.toHex(' '));
+    emit packetReceived();
+
+    initRequest = false;
+}
+
+void cycplusbc2::characteristicWritten(const QLowEnergyCharacteristic &characteristic, const QByteArray &newValue) {
+    Q_UNUSED(characteristic);
+    emit debug(QStringLiteral("characteristicWritten ") + newValue.toHex(' '));
+}
+
+void cycplusbc2::serviceScanDone(void) {
+    emit debug(QStringLiteral("serviceScanDone"));
+
+#ifdef Q_OS_ANDROID
+    QLowEnergyConnectionParameters c;
+    c.setIntervalRange(24, 40);
+    c.setLatency(0);
+    c.setSupervisionTimeout(420);
+    m_control->requestConnectionUpdate(c);
+#endif
+
+    if (gattCommunicationChannelService.isEmpty()) {
+        qDebug() << QStringLiteral("cycplusbc2 service not found");
+        return;
+    }
+
+    for (QLowEnergyService *s : qAsConst(gattCommunicationChannelService)) {
+        if (s)
+            s->discoverDetails();
+    }
+}
+
+void cycplusbc2::errorService(QLowEnergyService::ServiceError err) {
+    QMetaEnum metaEnum = QMetaEnum::fromType<QLowEnergyService::ServiceError>();
+    emit debug(QStringLiteral("cycplusbc2::errorService") + QString::fromLocal8Bit(metaEnum.valueToKey(err)) +
+               m_control->errorString());
+}
+
+void cycplusbc2::error(QLowEnergyController::Error err) {
+    QMetaEnum metaEnum = QMetaEnum::fromType<QLowEnergyController::Error>();
+    emit debug(QStringLiteral("cycplusbc2::error") + QString::fromLocal8Bit(metaEnum.valueToKey(err)) +
+               m_control->errorString());
+
+    if(err == QLowEnergyController::ConnectionError) {
+        emit disconnected();
+    }
+}
+
+void cycplusbc2::deviceDiscovered(const QBluetoothDeviceInfo &device) {
+    emit debug(QStringLiteral("Found device: ") + device.name());
+
+    if (device.name().startsWith(QStringLiteral("CYCPLUS BC2"))) {
+        qDebug() << QStringLiteral("CYCPLUS BC2 device found");
+
+        bluetoothDevice = device;
+
+        m_control = QLowEnergyController::createCentral(bluetoothDevice, this);
+        connect(m_control, &QLowEnergyController::serviceDiscovered, this, &cycplusbc2::serviceDiscovered);
+        connect(m_control, &QLowEnergyController::discoveryFinished, this, &cycplusbc2::serviceScanDone);
+        connect(m_control,
+                static_cast<void (QLowEnergyController::*)(QLowEnergyController::Error)>(&QLowEnergyController::error),
+                this, &cycplusbc2::error);
+        connect(m_control, &QLowEnergyController::stateChanged, this, &cycplusbc2::controllerStateChanged);
+        connect(m_control,
+                static_cast<void (QLowEnergyController::*)(QLowEnergyController::Error)>(&QLowEnergyController::error),
+                this, [this](QLowEnergyController::Error error) {
+                    Q_UNUSED(error);
+                    Q_UNUSED(this);
+                    emit disconnected();
+                });
+
+        m_control->connectToDevice();
+    }
+}
+
+bool cycplusbc2::connected() {
+    if (!m_control) {
+        return false;
+    }
+    return m_control->state() == QLowEnergyController::DiscoveredState;
+}
+
+void cycplusbc2::controllerStateChanged(QLowEnergyController::ControllerState state) {
+    qDebug() << QStringLiteral("controllerStateChanged") << state;
+    if (state == QLowEnergyController::UnconnectedState && m_control) {
+        qDebug() << QStringLiteral("trying to connect back again...");
+
+        initDone = false;
+        initRequest = false;
+
+        m_control->connectToDevice();
+    } else if (state == QLowEnergyController::ConnectedState) {
+        emit debug(QStringLiteral("connected to the CYCPLUS BC2"));
+    } else if (state == QLowEnergyController::DiscoveredState) {
+        qDebug() << QStringLiteral("cycplusbc2 services discovered");
+
+        // Nordic UART Service
+        if (!gattCommunicationChannelService.contains(m_control->createServiceObject(NORDIC_UART_SERVICE_UUID))) {
+            gattCommunicationChannelService.append(m_control->createServiceObject(NORDIC_UART_SERVICE_UUID));
+            connect(gattCommunicationChannelService.constLast(), &QLowEnergyService::stateChanged, this,
+                    &cycplusbc2::stateChanged);
+            gattCommunicationChannelService.constLast()->discoverDetails();
+        }
+    }
+}

--- a/src/zwift_play/cycplusbc2.cpp
+++ b/src/zwift_play/cycplusbc2.cpp
@@ -177,7 +177,8 @@ void cycplusbc2::stateChanged(QLowEnergyService::ServiceState state) {
 
             connect(gattService, &QLowEnergyService::characteristicChanged, this, &cycplusbc2::characteristicChanged);
             connect(gattService, &QLowEnergyService::characteristicWritten, this, &cycplusbc2::characteristicWritten);
-            connect(gattService, &QLowEnergyService::error, this, &cycplusbc2::errorService);
+            connect(gattService, static_cast<void (QLowEnergyService::*)(QLowEnergyService::ServiceError)>(&QLowEnergyService::error),
+                    this, &cycplusbc2::errorService);
             connect(gattService, &QLowEnergyService::descriptorWritten, this, &cycplusbc2::descriptorWritten);
 
             // Enable notifications on TX characteristic

--- a/src/zwift_play/cycplusbc2.cpp
+++ b/src/zwift_play/cycplusbc2.cpp
@@ -7,6 +7,9 @@
 #include <QMetaEnum>
 #include <QSettings>
 #include <QThread>
+#ifdef Q_OS_ANDROID
+#include <QLowEnergyConnectionParameters>
+#endif
 
 using namespace std::chrono_literals;
 

--- a/src/zwift_play/cycplusbc2.h
+++ b/src/zwift_play/cycplusbc2.h
@@ -1,0 +1,95 @@
+#ifndef CYCPLUSBC2_H
+#define CYCPLUSBC2_H
+
+#include <QBluetoothDeviceDiscoveryAgent>
+#include <QtBluetooth/qlowenergyadvertisingdata.h>
+#include <QtBluetooth/qlowenergyadvertisingparameters.h>
+#include <QtBluetooth/qlowenergycharacteristic.h>
+#include <QtBluetooth/qlowenergycharacteristicdata.h>
+#include <QtBluetooth/qlowenergycontroller.h>
+#include <QtBluetooth/qlowenergydescriptordata.h>
+#include <QtBluetooth/qlowenergyservice.h>
+#include <QtBluetooth/qlowenergyservicedata.h>
+#include <QtCore/qbytearray.h>
+
+#ifndef Q_OS_ANDROID
+#include <QtCore/qcoreapplication.h>
+#else
+#include <QtGui/qguiapplication.h>
+#endif
+#include <QtCore/qlist.h>
+#include <QtCore/qmutex.h>
+#include <QtCore/qscopedpointer.h>
+#include <QtCore/qtimer.h>
+
+#include <QObject>
+#include <QTime>
+
+#include "devices/bluetoothdevice.h"
+
+#ifdef Q_OS_IOS
+#include "ios/lockscreen.h"
+#endif
+
+class cycplusbc2 : public bluetoothdevice {
+    Q_OBJECT
+  public:
+
+    cycplusbc2(bluetoothdevice *parentDevice);
+    bool connected() override;
+
+    // Wrapper per characteristicChanged che accetta direttamente QBluetoothUuid
+    void handleCharacteristicValueChanged(const QBluetoothUuid &uuid, const QByteArray &newValue);
+
+  private:
+    QList<QLowEnergyService *> gattCommunicationChannelService;
+    QLowEnergyCharacteristic gattNotifyCharacteristic;  // TX characteristic (device -> app)
+    QLowEnergyCharacteristic gattWriteCharacteristic;   // RX characteristic (app -> device, unused)
+    QLowEnergyService *gattService;
+
+    void writeCharacteristic(QLowEnergyService *service, QLowEnergyCharacteristic *writeChar, uint8_t *data,
+                             uint8_t data_len, const QString &info, bool disable_log = false,
+                             bool wait_for_response = false);
+
+    bluetoothdevice *parentDevice = nullptr;
+
+    bool initDone = false;
+    bool initRequest = false;
+
+    QTimer *refresh;
+
+    uint32_t countRxTimeout = 0;
+
+    // State tracking for shift buttons
+    uint8_t lastShiftUpState = 0x00;
+    uint8_t lastShiftDownState = 0x00;
+
+#ifdef Q_OS_IOS
+    lockscreen* iOS_cycplusbc2 = nullptr;
+#endif
+
+  signals:
+    void disconnected();
+    void debug(QString string);
+    void packetReceived();
+    void plus();   // Shift up
+    void minus();  // Shift down
+
+  public slots:
+    void deviceDiscovered(const QBluetoothDeviceInfo &device);
+    void disconnectBluetooth();
+    void serviceDiscovered(const QBluetoothUuid &gatt);
+    void serviceScanDone(void);
+    void characteristicChanged(const QLowEnergyCharacteristic &characteristic, const QByteArray &newValue);
+    void stateChanged(QLowEnergyService::ServiceState state);
+    void descriptorWritten(const QLowEnergyDescriptor &descriptor, const QByteArray &newValue);
+    void controllerStateChanged(QLowEnergyController::ControllerState state);
+
+  private slots:
+    void characteristicWritten(const QLowEnergyCharacteristic &characteristic, const QByteArray &newValue);
+    void update();
+    void error(QLowEnergyController::Error err);
+    void errorService(QLowEnergyService::ServiceError);
+};
+
+#endif // CYCPLUSBC2_H


### PR DESCRIPTION
Implements support for the CYCPLUS BC2 Bluetooth shifter device following the same pattern as Zwift Click and Elite Square controllers.

Features:
- Uses Nordic UART Service for communication
- Monitors 8-byte packets for shift up/down button states (bytes 6 and 7)
- Triggers gear changes when button state transitions between pressed values
- Integrates with bike gear control system
- Enabled via zwift_play setting

Files changed:
- src/zwift_play/cycplusbc2.h: Header with Nordic UART UUIDs and class definition
- src/zwift_play/cycplusbc2.cpp: Implementation with button state tracking
- src/devices/bluetooth.h: Added cycplusbc2Device pointer
- src/devices/bluetooth.cpp: Added device discovery and signal connections
- src/qdomyos-zwift.pri: Added new source files to build

The device name is "CYCPLUS BC2" and follows the reference implementation from https://github.com/jonasbark/swiftcontrol