### PR TITLE
QZ silently loses connection with Taurus FX9.9 elliptical (Issue #3933)

### DIFF
--- a/src/devices/trxappgateusbelliptical/trxappgateusbelliptical.h
+++ b/src/devices/trxappgateusbelliptical/trxappgateusbelliptical.h
@@ -70,6 +70,9 @@ class trxappgateusbelliptical : public elliptical {
     bool initDone = false;
     bool initRequest = false;
 
+    resistance_t lastResistanceBeforeDisconnection = -1;
+    bool needsResistanceRestore = false;
+
     bool noWriteResistance = false;
     bool noHeartService = false;
 


### PR DESCRIPTION
QZ silently loses connection with Taurus FX9.9 elliptical (Issue #3933)
