### PR TITLE
Octane Treadmill ZR8: Remove redundant speed reset condition

### DIFF
--- a/src/devices/octanetreadmill/octanetreadmill.cpp
+++ b/src/devices/octanetreadmill/octanetreadmill.cpp
@@ -367,9 +367,9 @@ void octanetreadmill::characteristicChanged(const QLowEnergyCharacteristic &char
     if ((uint8_t)newValue[0] == 0xa5 && newValue[1] == 0x17)
         return;
 
-    // Filter out invalid packets: valid speed packets must have 0xa5 at byte[1]
-    // This prevents spurious speed readings from packets like "20 02 23" or "20 00 00 00"
-    if ((uint8_t)newValue[1] != 0xa5)
+    // Filter out invalid packets: valid speed packets must have 0xa5 at byte[0]
+    // This prevents spurious speed readings from packets starting with 0x02, 0x00, 0x01, etc.
+    if ((uint8_t)newValue[0] != 0xa5)
         return;
 
     if (!newValue.contains(actualPaceSign) && !newValue.contains(actualPace2Sign))


### PR DESCRIPTION
Eliminated an extra condition that reset Speed and Cadence after 15 seconds when ZR8 is true, simplifying the characteristicChanged logic.