### PR TITLE
Add heart_ignore_builtin support to Schwinn bikes

### DIFF
--- a/src/devices/schwinn170bike/schwinn170bike.cpp
+++ b/src/devices/schwinn170bike/schwinn170bike.cpp
@@ -248,8 +248,11 @@ void schwinn170bike::characteristicChanged(const QLowEnergyCharacteristic &chara
 
     lastRefreshCharacteristicChanged = now;
 
+    bool disable_hr_frommachinery =
+        settings.value(QZSettings::heart_ignore_builtin, QZSettings::default_heart_ignore_builtin).toBool();
+
     if (heartRateBeltName.startsWith(QStringLiteral("Disabled"))) {
-        if (heart == 0.0) {
+        if (heart == 0.0 || disable_hr_frommachinery) {
             update_hr_from_external();
         } else {
             Heart = heart;

--- a/src/devices/schwinnic4bike/schwinnic4bike.cpp
+++ b/src/devices/schwinnic4bike/schwinnic4bike.cpp
@@ -355,8 +355,11 @@ void schwinnic4bike::characteristicChanged(const QLowEnergyCharacteristic &chara
 
     lastRefreshCharacteristicChanged = now;
 
+    bool disable_hr_frommachinery =
+        settings.value(QZSettings::heart_ignore_builtin, QZSettings::default_heart_ignore_builtin).toBool();
+
     if (heartRateBeltName.startsWith(QStringLiteral("Disabled"))) {
-        if (heart == 0.0) {
+        if (heart == 0.0 || disable_hr_frommachinery) {
             update_hr_from_external();
         } else {
             Heart = heart;


### PR DESCRIPTION
Added support for the heart_ignore_builtin setting to both Schwinn IC4 and Schwinn 170 bikes. This allows users to ignore the built-in heart rate sensor and use external sources like Apple Watch instead.

Related to: Counting Heart Rate using Apple Watch (Issue #3954)