### PR TITLE
How ERG DataPoints collection work? #3949

### DIFF
--- a/src/devices/bike.cpp
+++ b/src/devices/bike.cpp
@@ -15,6 +15,8 @@ void bike::changeResistance(resistance_t resistance) {
         settings.value(QZSettings::zwift_erg_resistance_up, QZSettings::default_zwift_erg_resistance_up).toDouble();
     double zwift_erg_resistance_down =
         settings.value(QZSettings::zwift_erg_resistance_down, QZSettings::default_zwift_erg_resistance_down).toDouble();
+    int max_resistance_change =
+        settings.value(QZSettings::zwift_erg_max_resistance_change, QZSettings::default_zwift_erg_max_resistance_change).toInt();
 
     qDebug() << QStringLiteral("bike::changeResistance") << autoResistanceEnable << resistance;
 
@@ -28,6 +30,20 @@ void bike::changeResistance(resistance_t resistance) {
             qDebug() << "zwift_erg_resistance_down filter enabled!";
             v = (resistance_t)zwift_erg_resistance_down;
         }
+
+        // Apply max resistance change limiter
+        if (max_resistance_change > 0) {
+            double current_resistance = Resistance.value();
+            double delta = v - current_resistance;
+            if (delta > max_resistance_change) {
+                qDebug() << "zwift_erg_max_resistance_change limiter: clamping" << v << "to" << (current_resistance + max_resistance_change);
+                v = current_resistance + max_resistance_change;
+            } else if (delta < -max_resistance_change) {
+                qDebug() << "zwift_erg_max_resistance_change limiter: clamping" << v << "to" << (current_resistance - max_resistance_change);
+                v = current_resistance - max_resistance_change;
+            }
+        }
+
         requestResistance = v;
         emit resistanceChanged(requestResistance);
     }

--- a/src/devices/bluetoothdevice.cpp
+++ b/src/devices/bluetoothdevice.cpp
@@ -247,8 +247,12 @@ void bluetoothdevice::update_metrics(bool watt_calc, const double watts, const b
         !power_as_bike && !power_as_treadmill)
         watt_calc = false;
 
-    if(deviceType() == BIKE && !from_accessory)  // append only if it's coming from the bike, not from the power sensor
-        _ergTable.collectData(Cadence.value(), m_watt.value(), Resistance.value());
+    if(deviceType() == BIKE && !from_accessory) {  // append only if it's coming from the bike, not from the power sensor
+        bool ergtable_locked = settings.value(QZSettings::ergtable_lock, QZSettings::default_ergtable_lock).toBool();
+        if(!ergtable_locked) {
+            _ergTable.collectData(Cadence.value(), m_watt.value(), Resistance.value());
+        }
+    }
 
     if (!_firstUpdate && !paused) {
         if (currentSpeed().value() > 0.0 || settings.value(QZSettings::continuous_moving, true).toBool()) {

--- a/src/qzsettings.cpp
+++ b/src/qzsettings.cpp
@@ -333,6 +333,8 @@ const QString QZSettings::volume_change_gears = QStringLiteral("volume_change_ge
 const QString QZSettings::applewatch_fakedevice = QStringLiteral("applewatch_fakedevice");
 const QString QZSettings::zwift_erg_resistance_down = QStringLiteral("zwift_erg_resistance_down");
 const QString QZSettings::zwift_erg_resistance_up = QStringLiteral("zwift_erg_resistance_up");
+const QString QZSettings::ergtable_lock = QStringLiteral("ergtable_lock");
+const QString QZSettings::zwift_erg_max_resistance_change = QStringLiteral("zwift_erg_max_resistance_change");
 const QString QZSettings::horizon_paragon_x = QStringLiteral("horizon_paragon_x");
 const QString QZSettings::treadmill_step_speed = QStringLiteral("treadmill_step_speed");
 const QString QZSettings::treadmill_step_incline = QStringLiteral("treadmill_step_incline");
@@ -1007,7 +1009,7 @@ const QString QZSettings::proform_csx210 = QStringLiteral("proform_csx210");
 const QString QZSettings::skandika_wiri_x2000_protocol = QStringLiteral("skandika_wiri_x2000_protocol");
 
 
-const uint32_t allSettingsCount = 822;
+const uint32_t allSettingsCount = 824;
 
 QVariant allSettings[allSettingsCount][2] = {
     {QZSettings::cryptoKeySettingsProfiles, QZSettings::default_cryptoKeySettingsProfiles},
@@ -1288,6 +1290,8 @@ QVariant allSettings[allSettingsCount][2] = {
     {QZSettings::applewatch_fakedevice, QZSettings::default_applewatch_fakedevice},
     {QZSettings::zwift_erg_resistance_down, QZSettings::default_zwift_erg_resistance_down},
     {QZSettings::zwift_erg_resistance_up, QZSettings::default_zwift_erg_resistance_up},
+    {QZSettings::ergtable_lock, QZSettings::default_ergtable_lock},
+    {QZSettings::zwift_erg_max_resistance_change, QZSettings::default_zwift_erg_max_resistance_change},
     {QZSettings::horizon_paragon_x, QZSettings::default_horizon_paragon_x},
     {QZSettings::treadmill_step_speed, QZSettings::default_treadmill_step_speed},
     {QZSettings::treadmill_step_incline, QZSettings::default_treadmill_step_incline},

--- a/src/qzsettings.h
+++ b/src/qzsettings.h
@@ -1025,6 +1025,18 @@ class QZSettings {
     static const QString zwift_erg_resistance_up;
     static constexpr float default_zwift_erg_resistance_up = 999.0;
 
+    /**
+     *@brief Lock ergTable from automatic updates to preserve manually entered values.
+     */
+    static const QString ergtable_lock;
+    static constexpr bool default_ergtable_lock = false;
+
+    /**
+     *@brief Maximum resistance change per step in ERG mode (0 = unlimited).
+     */
+    static const QString zwift_erg_max_resistance_change;
+    static constexpr int default_zwift_erg_max_resistance_change = 0;
+
     static const QString horizon_paragon_x;
     static constexpr bool default_horizon_paragon_x = false;
 

--- a/src/settings.qml
+++ b/src/settings.qml
@@ -1227,7 +1227,11 @@ import Qt.labs.platform 1.1
             property string intervalsicu_athlete_id: ""
             property bool intervalsicu_upload_enabled: true
             property string intervalsicu_suffix: "#QZ"
-            property bool intervalsicu_date_prefix: false            
+            property bool intervalsicu_date_prefix: false
+
+            // ERG Table and Resistance Change Settings
+            property bool ergtable_lock: false
+            property int zwift_erg_max_resistance_change: 0
         }
 
 
@@ -2780,6 +2784,72 @@ import Qt.labs.platform 1.1
 
                     Label {
                         text: qsTr("Similar to the above, but sets a maximum target resistance. Default is 999.")
+                        font.bold: true
+                        font.italic: true
+                        font.pixelSize: Qt.application.font.pixelSize - 2
+                        textFormat: Text.PlainText
+                        wrapMode: Text.WordWrap
+                        verticalAlignment: Text.AlignVCenter
+                        Layout.alignment: Qt.AlignLeft | Qt.AlignTop
+                        Layout.fillWidth: true
+                        color: Material.color(Material.Lime)
+                    }
+
+                    RowLayout {
+                        spacing: 10
+                        Label {
+                            id: labelErgTableLock
+                            text: qsTr("Lock ERG Table:")
+                            Layout.fillWidth: true
+                        }
+                        CheckBox {
+                            id: ergTableLockCheckBox
+                            checked: settings.ergtable_lock
+                            Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                            onClicked: settings.ergtable_lock = checked
+                        }
+                    }
+
+                    Label {
+                        text: qsTr("Enable this to prevent automatic updates to the ERG table, preserving manually entered ergDataPoints values. Useful when you've manually calibrated your resistance/power/cadence data.")
+                        font.bold: true
+                        font.italic: true
+                        font.pixelSize: Qt.application.font.pixelSize - 2
+                        textFormat: Text.PlainText
+                        wrapMode: Text.WordWrap
+                        verticalAlignment: Text.AlignVCenter
+                        Layout.alignment: Qt.AlignLeft | Qt.AlignTop
+                        Layout.fillWidth: true
+                        color: Material.color(Material.Lime)
+                    }
+
+                    RowLayout {
+                        spacing: 10
+                        Label {
+                            id: labelZwiftErgMaxResistanceChange
+                            text: qsTr("Max. ERG Resistance Change:")
+                            Layout.fillWidth: true
+                        }
+                        TextField {
+                            id: zwiftErgMaxResistanceChangeTextField
+                            text: settings.zwift_erg_max_resistance_change
+                            horizontalAlignment: Text.AlignRight
+                            Layout.fillHeight: false
+                            Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                            inputMethodHints: Qt.ImhFormattedNumbersOnly
+                            onAccepted: settings.zwift_erg_max_resistance_change = text
+                            onActiveFocusChanged: if(this.focus) this.cursorPosition = this.text.length
+                        }
+                        Button {
+                            id: okzwiftErgMaxResistanceChangeButton
+                            text: "OK"
+                            Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                            onClicked: { settings.zwift_erg_max_resistance_change = zwiftErgMaxResistanceChangeTextField.text; toast.show("Setting saved!"); }
+                        }
+                    }
+
+                    Label {
+                        text: qsTr("Limits the resistance change per step in ERG mode. Set to 0 for unlimited. Use values like 1-5 to smooth out abrupt resistance changes and prevent cadence destabilization. Default is 0 (unlimited).")
                         font.bold: true
                         font.italic: true
                         font.pixelSize: Qt.application.font.pixelSize - 2


### PR DESCRIPTION
Implemented two new features to improve ERG mode stability and preserve manually calibrated ergData values:

1. ERG Table Lock (ergtable_lock):
   - Prevents automatic updates to ergTable
   - Preserves manually entered ergDataPoints
   - Useful for users who manually calibrate their bike resistance/power/cadence

2. Max Resistance Change Limiter (zwift_erg_max_resistance_change):
   - Limits resistance change per step in ERG mode
   - Prevents abrupt resistance changes that destabilize cadence
   - Default: 0 (unlimited), recommended: 1-5 for smooth transitions
   - Gradually approaches target resistance over multiple steps

Changes:
- src/qzsettings.h: Added setting declarations
- src/qzsettings.cpp: Added setting definitions and incremented allSettingsCount
- src/devices/bluetoothdevice.cpp: Added ergtable_lock check before collectData()
- src/devices/bike.cpp: Added resistance change limiter in changeResistance()
- src/settings.qml: Added UI controls in Bike Options section

Both settings are accessible in the Bike Options section of the settings UI.