### PR TITLE
Add VirtualRower support to SmartRower

### DIFF
--- a/src/devices/smartrowrower/smartrowrower.cpp
+++ b/src/devices/smartrowrower/smartrowrower.cpp
@@ -3,7 +3,6 @@
 #ifdef Q_OS_ANDROID
 #include "keepawakehelper.h"
 #endif
-#include "virtualdevices/virtualbike.h"
 #include <QBluetoothLocalDevice>
 #include <QDateTime>
 #include <QFile>
@@ -364,6 +363,8 @@ void smartrowrower::stateChanged(QLowEnergyService::ServiceState state) {
             QSettings settings;
             bool virtual_device_enabled =
                 settings.value(QZSettings::virtual_device_enabled, QZSettings::default_virtual_device_enabled).toBool();
+            bool virtual_device_rower =
+                settings.value(QZSettings::virtual_device_rower, QZSettings::default_virtual_device_rower).toBool();
 #ifdef Q_OS_IOS
 #ifndef IO_UNDER_QT
             bool cadence =
@@ -378,11 +379,18 @@ void smartrowrower::stateChanged(QLowEnergyService::ServiceState state) {
 #endif
 #endif
                 if (virtual_device_enabled) {
-                qDebug() << QStringLiteral("creating virtual bike interface...");
-                auto virtualBike =
-                    new virtualbike(this, noWriteResistance, noHeartService, bikeResistanceOffset, bikeResistanceGain);
-                // connect(virtualBike,&virtualbike::debug ,this,&smartrowrower::debug);
-                this->setVirtualDevice(virtualBike, VIRTUAL_DEVICE_MODE::PRIMARY);
+                if (!virtual_device_rower) {
+                    qDebug() << QStringLiteral("creating virtual bike interface...");
+                    auto virtualBike =
+                        new virtualbike(this, noWriteResistance, noHeartService, bikeResistanceOffset, bikeResistanceGain);
+                    // connect(virtualBike,&virtualbike::debug ,this,&smartrowrower::debug);
+                    this->setVirtualDevice(virtualBike, VIRTUAL_DEVICE_MODE::PRIMARY);
+                } else {
+                    qDebug() << QStringLiteral("creating virtual rower interface...");
+                    auto virtualRower = new virtualrower(this, noWriteResistance, noHeartService);
+                    // connect(virtualRower,&virtualrower::debug ,this,&smartrowrower::debug);
+                    this->setVirtualDevice(virtualRower, VIRTUAL_DEVICE_MODE::PRIMARY);
+                }
             }
         }
         firstStateChanged = 1;

--- a/src/devices/smartrowrower/smartrowrower.h
+++ b/src/devices/smartrowrower/smartrowrower.h
@@ -27,6 +27,8 @@
 #include <QString>
 
 #include "rower.h"
+#include "virtualdevices/virtualbike.h"
+#include "virtualdevices/virtualrower.h"
 
 #ifdef Q_OS_IOS
 #include "ios/lockscreen.h"


### PR DESCRIPTION
This change adds virtualrower support to the smartrowrower device, following the same pattern implemented in ftmsrower. This allows users to use the smartrowrower as a virtual rower device in apps like Zwift.

Changes:
- Added virtualrower.h include to smartrowrower.h header file
- Added virtual_device_rower setting check in smartrowrower.cpp
- Implemented virtualrower initialization logic in stateChanged() method
- Users can now choose between virtualbike and virtualrower modes