### PR TITLE
Fix Horizon treadmill FTMS notifications to subscribe only to standard characteristics

### DIFF
--- a/src/devices/horizontreadmill/horizontreadmill.cpp
+++ b/src/devices/horizontreadmill/horizontreadmill.cpp
@@ -2361,7 +2361,10 @@ void horizontreadmill::stateChanged(QLowEnergyService::ServiceState state) {
 
                 if ((c.properties() & QLowEnergyCharacteristic::Notify) == QLowEnergyCharacteristic::Notify &&
                     // if it's a FTMS treadmill and has FTMS and/or RSC service too
-                    ((((gattFTMSService && s->serviceUuid() == gattFTMSService->serviceUuid())
+                    ((((gattFTMSService && s->serviceUuid() == gattFTMSService->serviceUuid() &&
+                       (c.uuid() == QBluetoothUuid((quint16)0x2ACD) ||  // Treadmill Data
+                        c.uuid() == QBluetoothUuid((quint16)0x2ACE) ||  // Cross Trainer Data
+                        c.uuid() == QBluetoothUuid((quint16)0x2AD2)))   // Indoor Bike Data
                        || (s->serviceUuid() == QBluetoothUuid::RunningSpeedAndCadence))
                       && !gattCustomService) ||
                      (gattCustomService && s->serviceUuid() == gattCustomService->serviceUuid()))) {
@@ -2381,7 +2384,8 @@ void horizontreadmill::stateChanged(QLowEnergyService::ServiceState state) {
                     qDebug() << s->serviceUuid() << c.uuid() << QStringLiteral("notification subscribed!");
                 } else if ((c.properties() & QLowEnergyCharacteristic::Indicate) == QLowEnergyCharacteristic::Indicate &&
                                                                                                                       // if it's a FTMS treadmill and has FTMS and/or RSC service too
-                           ((((gattFTMSService && s->serviceUuid() == gattFTMSService->serviceUuid()))
+                           ((((gattFTMSService && s->serviceUuid() == gattFTMSService->serviceUuid() &&
+                               c.uuid() == QBluetoothUuid((quint16)0x2AD9)))  // Fitness Machine Control Point
                              && !gattCustomService))) {
                     QByteArray descriptor;
                     descriptor.append((char)0x02);


### PR DESCRIPTION
When horizon_treadmill_force_ftms is enabled, the device should only subscribe
to standard FTMS characteristics, not all characteristics in the FTMS service.

Changes:
- Filter Notify characteristics to only: 0x2ACD (Treadmill Data), 0x2ACE (Cross Trainer Data), 0x2AD2 (Indoor Bike Data)
- Filter Indicate characteristics to only: 0x2AD9 (Fitness Machine Control Point)
- Maintain existing behavior for RSC service and custom service

This prevents subscribing to proprietary/custom characteristics that may exist
in the FTMS service when force_ftms mode is enabled.