### PR TITLE
Add new service UUID for Nautilus treadmill

### DIFF
--- a/src/devices/nautilustreadmill/nautilustreadmill.cpp
+++ b/src/devices/nautilustreadmill/nautilustreadmill.cpp
@@ -347,7 +347,12 @@ void nautilustreadmill::serviceScanDone(void) {
 
             gattCommunicationChannelService = m_control->createServiceObject(_gattCommunicationChannelServiceId);
             if (!gattCommunicationChannelService) {
-                return;
+                _gattCommunicationChannelServiceId = QBluetoothUuid(QStringLiteral("4b2387a0-be8e-11e3-8039-0002a5d5c51b"));
+
+                gattCommunicationChannelService = m_control->createServiceObject(_gattCommunicationChannelServiceId);
+                if (!gattCommunicationChannelService) {
+                    return;
+                }
             }
         }
     }


### PR DESCRIPTION
Added UUID 4b2387a0-be8e-11e3-8039-0002a5d5c51b to the service discovery chain in nautilustreadmill.cpp to support additional Nautilus treadmill models.