### PR TITLE
Add FTMS treadmill support for TM4800- device

### DIFF
--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -1538,6 +1538,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                         (b.name().toUpper().startsWith(QStringLiteral("XT485"))  && deviceHasService(b, QBluetoothUuid((quint16)0x1826))) ||
                         b.name().toUpper().startsWith(QStringLiteral("MOBVOI TM")) ||                        // FTMS
                         b.name().toUpper().startsWith(QStringLiteral("MOBVOI WMTP")) ||                        // FTMS
+                        b.name().toUpper().startsWith(QStringLiteral("TM4800-")) ||                        // FTMS
                             b.name().toUpper().startsWith(QStringLiteral("LB600")) ||                        // FTMS
                         b.name().toUpper().startsWith(QStringLiteral("TUNTURI T60-")) ||                     // FTMS
                         b.name().toUpper().startsWith(QStringLiteral("TUNTURI T90-")) ||                     // FTMS

--- a/src/devices/horizontreadmill/horizontreadmill.cpp
+++ b/src/devices/horizontreadmill/horizontreadmill.cpp
@@ -1257,6 +1257,12 @@ void horizontreadmill::forceSpeed(double requestSpeed) {
         if(BOWFLEX_T9) {
             requestSpeed *= miles_conversion;   // this treadmill wants the speed in miles, at least seems so!!
         }
+        if(TM4800) {
+            bool miles = settings.value(QZSettings::miles_unit, QZSettings::default_miles_unit).toBool();
+            if(miles) {
+                requestSpeed *= miles_conversion;   // this treadmill wants the speed in miles when miles_unit is enabled
+            }
+        }
         uint16_t speed_int = round(requestSpeed * 100);
         writeS[1] = speed_int & 0xFF;
         writeS[2] = speed_int >> 8;
@@ -2629,6 +2635,9 @@ void horizontreadmill::deviceDiscovered(const QBluetoothDeviceInfo &device) {
         } else if (device.name().toUpper().startsWith(QStringLiteral("TP1")) && device.name().length() == 3) {
             qDebug() << QStringLiteral("TP1 treadmill found");
             TP1 = true;
+        } else if (device.name().toUpper().startsWith(QStringLiteral("TM4800-"))) {
+            qDebug() << QStringLiteral("TM4800 treadmill found");
+            TM4800 = true;
         }
 
         if (device.name().toUpper().startsWith(QStringLiteral("TRX3500"))) {

--- a/src/devices/horizontreadmill/horizontreadmill.h
+++ b/src/devices/horizontreadmill/horizontreadmill.h
@@ -114,6 +114,7 @@ class horizontreadmill : public treadmill {
     bool T3G_ELITE = false;
     bool TP1 = false;
     bool T01 = false;
+    bool TM4800 = false;
 
     void testProfileCRC();
     void updateProfileCRC();


### PR DESCRIPTION
- Added TM4800- device detection in bluetooth.cpp
- Added TM4800 boolean flag to horizontreadmill.h
- Added device name detection in horizontreadmill.cpp
- Implemented miles_unit special case handling in forceSpeed()
  When miles_unit setting is enabled, the TM4800 treadmill
  receives speed commands in miles instead of km/h