### PR TITLE
Fix Echelon Connect Sport to use power pedal sensor value

### DIFF
--- a/src/devices/echelonconnectsport/echelonconnectsport.cpp
+++ b/src/devices/echelonconnectsport/echelonconnectsport.cpp
@@ -209,6 +209,16 @@ resistance_t echelonconnectsport::pelotonToBikeResistance(int pelotonResistance)
 resistance_t echelonconnectsport::resistanceFromPowerRequest(uint16_t power) {
     qDebug() << QStringLiteral("resistanceFromPowerRequest") << Cadence.value();
 
+    QSettings settings;
+    bool powerSensorEnabled =
+        !settings.value(QZSettings::power_sensor_name, QZSettings::default_power_sensor_name)
+             .toString()
+             .startsWith(QStringLiteral("Disabled"));
+
+    if (powerSensorEnabled) {
+        return _ergTable.resistanceFromPowerRequest(power, Cadence.value(), maxResistance());
+    }
+
     if (Cadence.value() == 0)
         return 1;
 


### PR DESCRIPTION
When power sensor/pedal is enabled, the Echelon Connect Sport was
incorrectly reading from the erg table instead of using the actual
power value from the power pedal sensor. This fix ensures that when
a power sensor is enabled, the watts() method returns the actual
power value from m_watt (populated by the power pedal) instead of
calculating from the erg table.