### PR TITLE
Add YS_A6_ FTMS bike support

### DIFF
--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -1716,6 +1716,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                         (b.name().toUpper().startsWith("YS_G1_")) ||                       // Yesoul S3
                         (b.name().toUpper().startsWith("YS_G1MPLUS")) ||                   // Yesoul G1M Plus
                         (b.name().toUpper().startsWith("YS_G1MMAX")) ||                    // Yesoul G1M Max
+                        (b.name().toUpper().startsWith("YS_A6_")) ||                       // Yesoul A6
                         (b.name().toUpper().startsWith("DS25-")) ||                        // Bodytone DS25
                         (b.name().toUpper().startsWith("SCHWINN 510T")) ||
                         (b.name().toUpper().startsWith("3G CARDIO ")) ||


### PR DESCRIPTION
Add Yesoul A6 device detection to FTMS bike list in bluetooth.cpp.
The device name pattern "YS_A6_" will now be recognized as a FTMS bike.