### PR TITLE
Add Shimano Di2 Bluetooth support for gear shifting

### DIFF
--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -3090,25 +3090,13 @@ void bluetooth::connectedAndDiscovered() {
     }
 
     if(settings.value(QZSettings::shimano_di2, QZSettings::default_shimano_di2).toBool()) {
-        // Shimano Di2 Service UUIDs (from swiftcontrol Dart implementation)
-        QBluetoothUuid shimanoDi2ServiceUuid1(QStringLiteral("000018ef-5348-494d-414e-4f5f424c4500"));
-        QBluetoothUuid shimanoDi2ServiceUuid2(QStringLiteral("000018ff-5348-494d-414e-4f5f424c4500"));
-
         for (const QBluetoothDeviceInfo &b : qAsConst(devices)) {
-            // Detect Shimano Di2 by checking advertised service UUIDs
-            // Device name can vary (WU111, R9250, R8150, or custom user name)
-            QList<QBluetoothUuid> serviceUuids = b.serviceUuids();
-            bool isShimanoDi2 = false;
+            // Shimano Di2 device names: WU111 (11-speed wireless unit), R9250/R8150 (12-speed built-in)
+            QString deviceName = b.name().toUpper();
+            if ((deviceName.contains("WU111") || deviceName.contains("R9250") || deviceName.contains("R8150")) &&
+                !shimanoDi2 && this->device() && this->device()->deviceType() == BIKE) {
 
-            for(const QBluetoothUuid &uuid : serviceUuids) {
-                if(uuid == shimanoDi2ServiceUuid1 || uuid == shimanoDi2ServiceUuid2) {
-                    isShimanoDi2 = true;
-                    break;
-                }
-            }
-
-            if (isShimanoDi2 && !shimanoDi2 && this->device() && this->device()->deviceType() == BIKE) {
-                qDebug() << "Shimano Di2 device found:" << b.name() << "Service UUIDs:" << serviceUuids;
+                qDebug() << "Shimano Di2 device found:" << b.name();
 
                 shimanoDi2 = new shimano_di2(this->device());
 

--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -3089,6 +3089,27 @@ void bluetooth::connectedAndDiscovered() {
         }
     }
 
+    if(settings.value(QZSettings::shimano_di2, QZSettings::default_shimano_di2).toBool()) {
+        for (const QBluetoothDeviceInfo &b : qAsConst(devices)) {
+            // Shimano Di2 devices typically advertise as "DI2" or contain "SHIMANO" in the name
+            if ((b.name().toUpper().contains("DI2") || b.name().toUpper().contains("SHIMANO")) &&
+                !shimanoDi2 && this->device() && this->device()->deviceType() == BIKE) {
+
+                qDebug() << "Shimano Di2 device found:" << b.name();
+
+                shimanoDi2 = new shimano_di2(this->device());
+
+                connect(shimanoDi2, &shimano_di2::debug, this, &bluetooth::debug);
+                connect(shimanoDi2, &shimano_di2::plus, (bike*)this->device(), &bike::gearUp);
+                connect(shimanoDi2, &shimano_di2::minus, (bike*)this->device(), &bike::gearDown);
+                shimanoDi2->deviceDiscovered(b);
+                if(homeform::singleton())
+                    homeform::singleton()->setToastRequested("Shimano Di2 Connected!");
+                break;
+            }
+        }
+    }
+
     if(settings.value(QZSettings::zwift_play, QZSettings::default_zwift_play).toBool()) {
         for (const QBluetoothDeviceInfo &b : qAsConst(devices)) {
             if (((b.name().toUpper().startsWith("SQUARE"))) && !eliteSquareController && this->device() &&

--- a/src/devices/bluetooth.h
+++ b/src/devices/bluetooth.h
@@ -154,6 +154,7 @@
 
 #include "zwift_play/zwiftPlayDevice.h"
 #include "zwift_play/zwiftclickremote.h"
+#include "shimano_di2/shimano_di2.h"
 
 #ifdef Q_OS_IOS
 #include "ios/lockscreen.h"
@@ -306,6 +307,7 @@ class bluetooth : public QObject, public SignalHandler {
     QList<eliteariafan *> eliteAriaFan;
     QList<zwiftclickremote* > zwiftPlayDevice;
     zwiftclickremote* zwiftClickRemote = nullptr;
+    shimano_di2* shimanoDi2 = nullptr;
     sramaxscontroller* sramAXSController = nullptr;
     elitesquarecontroller* eliteSquareController = nullptr;
     QString filterDevice = QLatin1String("");

--- a/src/qdomyos-zwift.pri
+++ b/src/qdomyos-zwift.pri
@@ -154,6 +154,7 @@ windows_zwift_workout_paddleocr_thread.cpp \
 devices/ypooelliptical/ypooelliptical.cpp \
 devices/ziprotreadmill/ziprotreadmill.cpp \
 zwift_play/zwiftclickremote.cpp \
+shimano_di2/shimano_di2.cpp \
 devices/computrainerbike/Computrainer.cpp \
 devices/kettlerusbbike/KettlerUSB.cpp \
 PathController.cpp \
@@ -443,6 +444,7 @@ zwift_play/zapBleUuids.h \
 zwift_play/zapConstants.h \
 zwift_play/zwiftPlayDevice.h \
 zwift_play/zwiftclickremote.h \
+shimano_di2/shimano_di2.h \
 virtualdevices/virtualdevice.h \
 androidactivityresultreceiver.h \
 androidadblog.h \

--- a/src/qzsettings.cpp
+++ b/src/qzsettings.cpp
@@ -767,6 +767,7 @@ const QString QZSettings::zwift_click = QStringLiteral("zwift_click");
 const QString QZSettings::hop_sport_hs_090h_bike = QStringLiteral("hop_sport_hs_090h_bike");
 const QString QZSettings::zwift_play = QStringLiteral("zwift_play");
 const QString QZSettings::zwift_play_vibration = QStringLiteral("zwift_play_vibration");
+const QString QZSettings::shimano_di2 = QStringLiteral("shimano_di2");
 const QString QZSettings::nordictrack_treadmill_x14i = QStringLiteral("nordictrack_treadmill_x14i");
 const QString QZSettings::zwift_api_poll = QStringLiteral("zwift_api_poll");
 const QString QZSettings::tile_step_count_enabled = QStringLiteral("tile_step_count_enabled");
@@ -1030,7 +1031,7 @@ const QString QZSettings::proform_csx210 = QStringLiteral("proform_csx210");
 const QString QZSettings::skandika_wiri_x2000_protocol = QStringLiteral("skandika_wiri_x2000_protocol");
 
 
-const uint32_t allSettingsCount = 838;
+const uint32_t allSettingsCount = 839;
 
 QVariant allSettings[allSettingsCount][2] = {
     {QZSettings::cryptoKeySettingsProfiles, QZSettings::default_cryptoKeySettingsProfiles},
@@ -1671,6 +1672,7 @@ QVariant allSettings[allSettingsCount][2] = {
     {QZSettings::hop_sport_hs_090h_bike, QZSettings::default_hop_sport_hs_090h_bike},
     {QZSettings::zwift_play, QZSettings::default_zwift_play},
     {QZSettings::zwift_play_vibration, QZSettings::default_zwift_play_vibration},
+    {QZSettings::shimano_di2, QZSettings::default_shimano_di2},
     {QZSettings::nordictrack_treadmill_x14i, QZSettings::default_nordictrack_treadmill_x14i},
     {QZSettings::zwift_api_poll, QZSettings::default_zwift_api_poll},
     {QZSettings::tile_step_count_enabled, QZSettings::default_tile_step_count_enabled},

--- a/src/qzsettings.h
+++ b/src/qzsettings.h
@@ -2122,6 +2122,9 @@ class QZSettings {
     static const QString zwift_play_vibration;
     static constexpr bool default_zwift_play_vibration = true;
 
+    static const QString shimano_di2;
+    static constexpr bool default_shimano_di2 = false;
+
     static const QString nordictrack_treadmill_x14i;
     static constexpr bool default_nordictrack_treadmill_x14i = false;
 

--- a/src/settings.qml
+++ b/src/settings.qml
@@ -1247,6 +1247,7 @@ import Qt.labs.platform 1.1
             property var garmin_refresh_token_expires_at: 0
             property string garmin_domain: "garmin.com"
             property string garmin_last_refresh: ""
+            property bool shimano_di2: false
         }
 
 
@@ -6116,11 +6117,12 @@ import Qt.labs.platform 1.1
                     MessageDialog {
                         id: zwiftPlaySettingsDialog
                         text: "Zwift Play & Click Settings"
-                        informativeText: "Would you like to disable Zwift Play and Zwift Click settings? Having them enabled together with 'Get gears from Zwift' may cause conflicts."
+                        informativeText: "Would you like to disable Zwift Play, Zwift Click and Shimano Di2 settings? Having them enabled together with 'Get gears from Zwift' may cause conflicts."
                         buttons: (MessageDialog.Yes | MessageDialog.No)
                         onYesClicked: {
                             settings.zwift_play = false;
                             settings.zwift_click = false;
+                            settings.shimano_di2 = false;
                             settings.zwift_play_emulator = true;
                             window.settings_restart_to_apply = true;
                         }
@@ -6140,7 +6142,7 @@ import Qt.labs.platform 1.1
                         Layout.fillWidth: true
                         onClicked: {
                              if (checked && !settings.zwift_play_emulator) {  // Only show dialog when enabling
-                                 if (settings.zwift_play || settings.zwift_click) {
+                                 if (settings.zwift_play || settings.zwift_click || settings.shimano_di2) {
                                      zwiftPlaySettingsDialog.visible = true;
                                  }
                                  settings.watt_bike_emulator = false;
@@ -12156,6 +12158,33 @@ import Qt.labs.platform 1.1
 
                             Label {
                                 text: qsTr("Enable vibration feedback on Zwift Play controllers when changing gears. Default: enabled.")
+                                font.bold: true
+                                font.italic: true
+                                font.pixelSize: Qt.application.font.pixelSize - 2
+                                textFormat: Text.PlainText
+                                wrapMode: Text.WordWrap
+                                verticalAlignment: Text.AlignVCenter
+                                Layout.alignment: Qt.AlignLeft | Qt.AlignTop
+                                Layout.fillWidth: true
+                                color: Material.color(Material.Lime)
+                            }
+
+                            IndicatorOnlySwitch {
+                                text: qsTr("Shimano Di2")
+                                spacing: 0
+                                bottomPadding: 0
+                                topPadding: 0
+                                rightPadding: 0
+                                leftPadding: 0
+                                clip: false
+                                checked: settings.shimano_di2
+                                Layout.alignment: Qt.AlignLeft | Qt.AlignTop
+                                Layout.fillWidth: true
+                                onClicked: { settings.shimano_di2 = checked; window.settings_restart_to_apply = true; }
+                            }
+
+                            Label {
+                                text: qsTr("Use Shimano Di2 electronic shifting to change gears on QZ. Make sure to configure your Di2 buttons to D-Fly channels in the Shimano E-TUBE app!")
                                 font.bold: true
                                 font.italic: true
                                 font.pixelSize: Qt.application.font.pixelSize - 2

--- a/src/shimano_di2/shimano_di2.cpp
+++ b/src/shimano_di2/shimano_di2.cpp
@@ -1,0 +1,310 @@
+#include "homeform.h"
+#include "shimano_di2.h"
+#include <QBluetoothLocalDevice>
+#include <QDateTime>
+#include <QEventLoop>
+#include <QFile>
+#include <QMetaEnum>
+#include <QSettings>
+#include <QThread>
+
+using namespace std::chrono_literals;
+
+#ifdef Q_OS_IOS
+extern quint8 QZ_EnableDiscoveryCharsAndDescripttors;
+#endif
+
+shimano_di2::shimano_di2(bluetoothdevice *parentDevice) {
+#ifdef Q_OS_IOS
+    QZ_EnableDiscoveryCharsAndDescripttors = true;
+#endif
+    this->parentDevice = parentDevice;
+
+    refresh = new QTimer(this);
+    connect(refresh, &QTimer::timeout, this, &shimano_di2::update);
+    refresh->start(1000ms);
+}
+
+void shimano_di2::update() {
+    // Periodic update function - currently not needed for Shimano Di2
+    // The device works via characteristic notifications
+}
+
+void shimano_di2::serviceDiscovered(const QBluetoothUuid &gatt) {
+    emit debug(QStringLiteral("serviceDiscovered ") + gatt.toString());
+}
+
+void shimano_di2::disconnectBluetooth() {
+    qDebug() << QStringLiteral("shimano_di2::disconnect") << m_control;
+
+    if (m_control) {
+        m_control->disconnectFromDevice();
+    }
+}
+
+void shimano_di2::characteristicChanged(const QLowEnergyCharacteristic &characteristic,
+                                        const QByteArray &newValue) {
+    emit packetReceived();
+
+    QSettings settings;
+    bool gears_volume_debouncing = settings.value(QZSettings::gears_volume_debouncing, QZSettings::default_gears_volume_debouncing).toBool();
+    bool zwiftplay_swap = settings.value(QZSettings::zwiftplay_swap, QZSettings::default_zwiftplay_swap).toBool();
+
+    qDebug() << QStringLiteral(" << ") << newValue.toHex(' ') << characteristic.uuid().toString();
+
+    // D-Fly Channel UUID
+    QBluetoothUuid dFlyChannelUuid(QStringLiteral("00002ac2-5348-494d-414e-4f5f424c4500"));
+
+    if(characteristic.uuid() == dFlyChannelUuid && newValue.length() > 1) {
+        // Skip first byte as per Dart implementation
+        QByteArray channelData = newValue.mid(1);
+
+        if(!initDone) {
+            // First data reception - just initialize state
+            for(int i = 0; i < channelData.length(); i++) {
+                lastButtons[i] = (uint8_t)channelData.at(i);
+            }
+            initDone = true;
+            qDebug() << "Shimano Di2 initialized with" << channelData.length() << "channels";
+            return;
+        }
+
+        // Process channel changes
+        for(int i = 0; i < channelData.length(); i++) {
+            uint8_t currentValue = (uint8_t)channelData.at(i);
+
+            // Check if this channel changed
+            if(lastButtons.contains(i) && lastButtons[i] != currentValue) {
+                int channelNumber = i + 1; // Channel number is index + 1
+                qDebug() << "Shimano Di2 channel" << channelNumber << "changed from"
+                         << lastButtons[i] << "to" << currentValue;
+
+                // Determine if this is a gear up or down
+                // Channel 1 is typically configured for gear up, Channel 2 for gear down
+                // But users can configure any channel in E-TUBE app
+                // For now, we'll use a simple convention: odd channels = up, even = down
+                // Users can swap behavior using the zwiftplay_swap setting
+
+                bool isUpChannel = (channelNumber % 2 == 1);
+
+                if(!gears_volume_debouncing || currentValue > 0) {
+                    if((isUpChannel && !zwiftplay_swap) || (!isUpChannel && zwiftplay_swap)) {
+                        emit plus();
+                        qDebug() << "Shimano Di2 gear UP";
+                    } else {
+                        emit minus();
+                        qDebug() << "Shimano Di2 gear DOWN";
+                    }
+                }
+            }
+
+            // Update last state
+            lastButtons[i] = currentValue;
+        }
+    }
+}
+
+void shimano_di2::stateChanged(QLowEnergyService::ServiceState state) {
+    QBluetoothUuid dFlyChannelUuid(QStringLiteral("00002ac2-5348-494d-414e-4f5f424c4500"));
+
+    QMetaEnum metaEnum = QMetaEnum::fromType<QLowEnergyService::ServiceState>();
+    emit debug(QStringLiteral("BTLE stateChanged ") + QString::fromLocal8Bit(metaEnum.valueToKey(state)));
+
+#ifndef Q_OS_IOS
+    for (QLowEnergyService *s : qAsConst(gattCommunicationChannelService)) {
+        qDebug() << QStringLiteral("stateChanged") << s->serviceUuid() << s->state();
+        if (s->state() != QLowEnergyService::ServiceDiscovered && s->state() != QLowEnergyService::InvalidService) {
+            qDebug() << QStringLiteral("not all services discovered");
+            return;
+        }
+    }
+
+    if (state != QLowEnergyService::ServiceState::ServiceDiscovered) {
+        qDebug() << QStringLiteral("ignoring this state");
+        return;
+    }
+
+    qDebug() << QStringLiteral("all services discovered!");
+
+    for (QLowEnergyService *s : qAsConst(gattCommunicationChannelService)) {
+        if (s->state() == QLowEnergyService::ServiceDiscovered) {
+            // establish hook into notifications
+            connect(s, &QLowEnergyService::characteristicChanged, this, &shimano_di2::characteristicChanged);
+            connect(s, &QLowEnergyService::characteristicRead, this, &shimano_di2::characteristicChanged);
+            connect(s, &QLowEnergyService::characteristicWritten, this, &shimano_di2::characteristicWritten);
+            connect(
+                s, static_cast<void (QLowEnergyService::*)(QLowEnergyService::ServiceError)>(&QLowEnergyService::error),
+                this, &shimano_di2::errorService);
+            connect(s, &QLowEnergyService::descriptorWritten, this, &shimano_di2::descriptorWritten);
+
+            qDebug() << s->serviceUuid() << QStringLiteral("connected!");
+
+            auto characteristics_list = s->characteristics();
+            for (const QLowEnergyCharacteristic &c : qAsConst(characteristics_list)) {
+                qDebug() << QStringLiteral("char uuid") << c.uuid() << QStringLiteral("handle") << c.handle();
+                auto descriptors_list = c.descriptors();
+                for (const QLowEnergyDescriptor &d : qAsConst(descriptors_list)) {
+                    qDebug() << QStringLiteral("descriptor uuid") << d.uuid() << QStringLiteral("handle") << d.handle();
+                }
+
+                // Subscribe to D-Fly Channel notifications
+                if (c.uuid() == dFlyChannelUuid) {
+                    qDebug() << QStringLiteral("D-Fly Channel found, subscribing to indications");
+                    gattNotifyCharacteristic = c;
+
+                    if ((c.properties() & QLowEnergyCharacteristic::Indicate) == QLowEnergyCharacteristic::Indicate) {
+                        QByteArray descriptor;
+                        descriptor.append((char)0x02);
+                        descriptor.append((char)0x00);
+                        if (c.descriptor(QBluetoothUuid::ClientCharacteristicConfiguration).isValid()) {
+                            s->writeDescriptor(c.descriptor(QBluetoothUuid::ClientCharacteristicConfiguration), descriptor);
+                        } else {
+                            qDebug() << QStringLiteral("ClientCharacteristicConfiguration") << c.uuid()
+                                     << c.descriptor(QBluetoothUuid::ClientCharacteristicConfiguration).uuid()
+                                     << c.descriptor(QBluetoothUuid::ClientCharacteristicConfiguration).handle()
+                                     << QStringLiteral(" is not valid");
+                        }
+                        qDebug() << s->serviceUuid() << c.uuid() << QStringLiteral("indication subscribed!");
+                    } else if ((c.properties() & QLowEnergyCharacteristic::Notify) == QLowEnergyCharacteristic::Notify) {
+                        QByteArray descriptor;
+                        descriptor.append((char)0x01);
+                        descriptor.append((char)0x00);
+                        if (c.descriptor(QBluetoothUuid::ClientCharacteristicConfiguration).isValid()) {
+                            s->writeDescriptor(c.descriptor(QBluetoothUuid::ClientCharacteristicConfiguration), descriptor);
+                        } else {
+                            qDebug() << QStringLiteral("ClientCharacteristicConfiguration") << c.uuid()
+                                     << c.descriptor(QBluetoothUuid::ClientCharacteristicConfiguration).uuid()
+                                     << c.descriptor(QBluetoothUuid::ClientCharacteristicConfiguration).handle()
+                                     << QStringLiteral(" is not valid");
+                        }
+                        qDebug() << s->serviceUuid() << c.uuid() << QStringLiteral("notification subscribed!");
+                    }
+                }
+            }
+        }
+    }
+#endif
+}
+
+void shimano_di2::descriptorWritten(const QLowEnergyDescriptor &descriptor, const QByteArray &newValue) {
+    emit debug(QStringLiteral("descriptorWritten ") + descriptor.name() + " " + newValue.toHex(' '));
+    initRequest = true;
+}
+
+void shimano_di2::characteristicWritten(const QLowEnergyCharacteristic &characteristic,
+                                        const QByteArray &newValue) {
+    Q_UNUSED(characteristic);
+    emit debug(QStringLiteral("characteristicWritten ") + newValue.toHex(' '));
+}
+
+void shimano_di2::serviceScanDone(void) {
+    emit debug(QStringLiteral("serviceScanDone"));
+
+    initRequest = false;
+
+#ifndef Q_OS_IOS
+    // Shimano Di2 service UUIDs
+    QBluetoothUuid serviceUuid1(QStringLiteral("000018ef-5348-494d-414e-4f5f424c4500"));
+    QBluetoothUuid serviceUuid2(QStringLiteral("000018ff-5348-494d-414e-4f5f424c4500"));
+
+    auto services_list = m_control->services();
+    for (const QBluetoothUuid &s : qAsConst(services_list)) {
+        // Look for Shimano Di2 services
+        if(s == serviceUuid1 || s == serviceUuid2) {
+            qDebug() << "Found Shimano Di2 service:" << s.toString();
+            gattCommunicationChannelService.append(m_control->createServiceObject(s));
+            if (gattCommunicationChannelService.constLast()) {
+                connect(gattCommunicationChannelService.constLast(), &QLowEnergyService::stateChanged, this,
+                        &shimano_di2::stateChanged);
+                gattCommunicationChannelService.constLast()->discoverDetails();
+            } else {
+                m_control->disconnectFromDevice();
+            }
+        }
+    }
+#endif
+}
+
+void shimano_di2::errorService(QLowEnergyService::ServiceError err) {
+    QMetaEnum metaEnum = QMetaEnum::fromType<QLowEnergyService::ServiceError>();
+    emit debug(QStringLiteral("shimano_di2::errorService") + QString::fromLocal8Bit(metaEnum.valueToKey(err)) +
+               m_control->errorString());
+}
+
+void shimano_di2::error(QLowEnergyController::Error err) {
+    QMetaEnum metaEnum = QMetaEnum::fromType<QLowEnergyController::Error>();
+    emit debug(QStringLiteral("shimano_di2::error") + QString::fromLocal8Bit(metaEnum.valueToKey(err)) +
+               m_control->errorString());
+}
+
+void shimano_di2::deviceDiscovered(const QBluetoothDeviceInfo &device) {
+    QSettings settings;
+    emit debug(QStringLiteral("Found new device: ") + device.name() + QStringLiteral(" (") +
+               device.address().toString() + ')');
+
+#ifdef Q_OS_IOS
+#ifndef IO_UNDER_QT
+    iOS_shimanoDi2 = new lockscreen();
+    // iOS implementation would go here if needed
+    // For now, we'll use the standard Qt implementation
+#endif
+#endif
+
+    {
+        bluetoothDevice = device;
+        m_control = QLowEnergyController::createCentral(bluetoothDevice, this);
+        connect(m_control, &QLowEnergyController::serviceDiscovered, this, &shimano_di2::serviceDiscovered);
+        connect(m_control, &QLowEnergyController::discoveryFinished, this, &shimano_di2::serviceScanDone);
+        connect(m_control,
+                static_cast<void (QLowEnergyController::*)(QLowEnergyController::Error)>(&QLowEnergyController::error),
+                this, &shimano_di2::error);
+        connect(m_control, &QLowEnergyController::stateChanged, this, &shimano_di2::controllerStateChanged);
+
+        connect(m_control,
+                static_cast<void (QLowEnergyController::*)(QLowEnergyController::Error)>(&QLowEnergyController::error),
+                this, [this](QLowEnergyController::Error error) {
+                    Q_UNUSED(error);
+                    Q_UNUSED(this);
+                    emit debug(QStringLiteral("Cannot connect to remote device."));
+                    emit disconnected();
+                });
+        connect(m_control, &QLowEnergyController::connected, this, [this]() {
+            Q_UNUSED(this);
+            emit debug(QStringLiteral("Controller connected. Search services..."));
+            m_control->discoverServices();
+        });
+        connect(m_control, &QLowEnergyController::disconnected, this, [this]() {
+            Q_UNUSED(this);
+            emit debug(QStringLiteral("LowEnergy controller disconnected"));
+            emit disconnected();
+        });
+
+        // Connect
+        m_control->connectToDevice();
+        return;
+    }
+}
+
+bool shimano_di2::connected() {
+#ifdef Q_OS_IOS
+    return true;
+#endif
+
+    if (!m_control) {
+        return false;
+    }
+    return m_control->state() == QLowEnergyController::DiscoveredState;
+}
+
+void shimano_di2::controllerStateChanged(QLowEnergyController::ControllerState state) {
+    qDebug() << QStringLiteral("controllerStateChanged") << state;
+    if (state == QLowEnergyController::UnconnectedState) {
+        qDebug() << QStringLiteral("trying to connect back again...");
+        initRequest = false;
+        initDone = false;
+        lastButtons.clear();
+
+        if(m_control)
+            m_control->connectToDevice();
+    }
+}

--- a/src/shimano_di2/shimano_di2.h
+++ b/src/shimano_di2/shimano_di2.h
@@ -1,0 +1,83 @@
+#ifndef SHIMANO_DI2_H
+#define SHIMANO_DI2_H
+
+#include <QBluetoothDeviceDiscoveryAgent>
+#include <QtBluetooth/qlowenergyadvertisingdata.h>
+#include <QtBluetooth/qlowenergyadvertisingparameters.h>
+#include <QtBluetooth/qlowenergycharacteristic.h>
+#include <QtBluetooth/qlowenergycharacteristicdata.h>
+#include <QtBluetooth/qlowenergycontroller.h>
+#include <QtBluetooth/qlowenergydescriptordata.h>
+#include <QtBluetooth/qlowenergyservice.h>
+#include <QtBluetooth/qlowenergyservicedata.h>
+#include <QtCore/qbytearray.h>
+
+#ifndef Q_OS_ANDROID
+#include <QtCore/qcoreapplication.h>
+#else
+#include <QtGui/qguiapplication.h>
+#endif
+#include <QtCore/qlist.h>
+#include <QtCore/qmutex.h>
+#include <QtCore/qscopedpointer.h>
+#include <QtCore/qtimer.h>
+
+#include <QObject>
+#include <QTime>
+
+#include "devices/bluetoothdevice.h"
+
+#ifdef Q_OS_IOS
+#include "ios/lockscreen.h"
+#endif
+
+class shimano_di2 : public bluetoothdevice {
+    Q_OBJECT
+  public:
+
+    shimano_di2(bluetoothdevice *parentDevice);
+    bool connected() override;
+
+  private:
+    QList<QLowEnergyService *> gattCommunicationChannelService;
+    QLowEnergyCharacteristic gattNotifyCharacteristic;
+
+    bluetoothdevice *parentDevice = nullptr;
+
+    bool initDone = false;
+    bool initRequest = false;
+
+    QTimer *refresh;
+
+    // Store last button states for change detection
+    QMap<int, uint8_t> lastButtons;
+
+#ifdef Q_OS_IOS
+    lockscreen* iOS_shimanoDi2 = nullptr;
+#endif
+
+  signals:
+    void disconnected();
+    void debug(QString string);
+    void packetReceived();
+    void plus();
+    void minus();
+
+  public slots:
+    void deviceDiscovered(const QBluetoothDeviceInfo &device);
+    void disconnectBluetooth();
+    void serviceDiscovered(const QBluetoothUuid &gatt);
+    void serviceScanDone(void);
+    void characteristicChanged(const QLowEnergyCharacteristic &characteristic, const QByteArray &newValue);
+    void stateChanged(QLowEnergyService::ServiceState state);
+    void descriptorWritten(const QLowEnergyDescriptor &descriptor, const QByteArray &newValue);
+    void controllerStateChanged(QLowEnergyController::ControllerState state);
+
+  private slots:
+    void characteristicWritten(const QLowEnergyCharacteristic &characteristic, const QByteArray &newValue);
+    void update();
+    void error(QLowEnergyController::Error err);
+    void errorService(QLowEnergyService::ServiceError);
+};
+
+#endif // SHIMANO_DI2_H


### PR DESCRIPTION
Implemented Shimano Di2 electronic shifting integration following the
Zwift Click pattern. This allows users to control virtual gears in QZ
using their Shimano Di2 shifters via D-Fly channels.

Key changes:
- Created shimano_di2 class for handling Bluetooth communication
- Added D-Fly channel monitoring (UUID: 00002ac2-5348-494d-414e-4f5f424c4500)
- Implemented gear up/down signals compatible with existing click devices
- Added shimano_di2 setting to enable/disable the feature
- Updated UI with Shimano Di2 toggle in Zwift Devices Options
- Integrated with existing gears_volume_debouncing and zwiftplay_swap settings

Technical details:
- Service UUIDs: 000018ef-5348-494d-414e-4f5f424c4500 and 000018ff-5348-494d-414e-4f5f424c4500
- Channel state change detection for button press events
- First data reception initializes state without triggering events
- Odd channels trigger gear up, even channels trigger gear down (configurable via swap setting)

Users must configure Di2 buttons to D-Fly channels in Shimano E-TUBE app.