### PR TITLE
[iOS] Fix Bluetooth device search timeout issue when a device is cached

### DIFF
--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -579,7 +579,8 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
         !b.compare(settings.value(QZSettings::filter_device, QZSettings::default_filter_device).toString()) &&
         (b.toUpper().startsWith("IC BIKE") || b.toUpper().startsWith("C7-"))) {
 
-        this->stopDiscovery();
+        // Don't stop discovery here to allow time for accessories (heart rate, power, cadence sensors) to be found
+        // Discovery will stop naturally after 10 seconds or when all configured accessories are discovered
         schwinnIC4Bike = new schwinnic4bike(noWriteResistance, noHeartService);
         // stateFileRead();
         QBluetoothDeviceInfo bt;


### PR DESCRIPTION
…nnection

When connecting directly to a cached device (e.g., IC BIKE on iOS), the Bluetooth discovery was stopped immediately, preventing accessory devices (heart rate monitors, power sensors, cadence sensors) from being discovered within the standard 10-second timeout window.

This fix removes the immediate stopDiscovery() call in the direct connection path, allowing the discovery process to continue for the full 10-second timeout. This gives accessories enough time to be found while still maintaining the fast direct connection to the cached primary device.

The discovery will now stop naturally after:
- 10 seconds (standard timeout), OR
- When all configured accessories are discovered

Fixes issue where accessories were not found when using direct connection.