### PR TITLE
Fix MRK-R06- rower FTMS subscription to send data to Peloton

### DIFF
--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -1958,6 +1958,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                         b.name().toUpper().startsWith(QStringLiteral("KS-WLT")) || // KS-WLT-W1
                         b.name().toUpper().startsWith(QStringLiteral("I-ROWER")) ||
                         b.name().toUpper().startsWith(QStringLiteral("MRK-CRYDN-")) ||
+                        b.name().toUpper().startsWith(QStringLiteral("MRK-R06-")) ||
                         b.name().toUpper().startsWith(QStringLiteral("YOROTO-RW-")) ||
                         b.name().toUpper().startsWith(QStringLiteral("SF-RW")) ||
                         b.name().toUpper().startsWith(QStringLiteral("SMARTROWER")) || // Chaoke 107a magnetic rowing machine (Discussion #4029)

--- a/src/devices/ftmsrower/ftmsrower.cpp
+++ b/src/devices/ftmsrower/ftmsrower.cpp
@@ -78,7 +78,7 @@ void ftmsrower::update() {
     }
 
     if (initRequest) {
-        if(I_ROWER || ROWER) {
+        if(I_ROWER || ROWER || MRK_R06) {
             uint8_t write[] = {FTMS_REQUEST_CONTROL};
             writeCharacteristic(write, sizeof(write), "start", false, true);
 
@@ -583,10 +583,10 @@ void ftmsrower::stateChanged(QLowEnergyService::ServiceState state) {
             connect(s, &QLowEnergyService::descriptorWritten, this, &ftmsrower::descriptorWritten);
             connect(s, &QLowEnergyService::descriptorRead, this, &ftmsrower::descriptorRead);
 
-            if (I_ROWER || ROWER) {
+            if (I_ROWER || ROWER || MRK_R06) {
                 QBluetoothUuid ftmsService((quint16)0x1826);
                 if (s->serviceUuid() != ftmsService) {
-                    qDebug() << QStringLiteral("I-ROWER wants to be subscribed only to FTMS service in order to send metrics")
+                    qDebug() << QStringLiteral("I-ROWER/ROWER/MRK-R06 wants to be subscribed only to FTMS service in order to send metrics")
                              << s->serviceUuid();
                     continue;
                 }
@@ -825,6 +825,9 @@ void ftmsrower::deviceDiscovered(const QBluetoothDeviceInfo &device) {
         } else if (device.name().toUpper().startsWith(QStringLiteral("IROWER "))) {
             ROWER = true;
             qDebug() << "ROWER found!";
+        } else if (device.name().toUpper().startsWith(QStringLiteral("MRK-R06-"))) {
+            MRK_R06 = true;
+            qDebug() << "MRK_R06 found!";
         } else if (device.name().toUpper().startsWith(QStringLiteral("PM5"))) {
             PM5 = true;
             qDebug() << "PM5 found!";

--- a/src/devices/ftmsrower/ftmsrower.h
+++ b/src/devices/ftmsrower/ftmsrower.h
@@ -78,6 +78,7 @@ class ftmsrower : public rower {
     bool DFIT_L_R = false;
     bool I_ROWER = false;
     bool ROWER = false;
+    bool MRK_R06 = false;
     QDateTime lastStroke = QDateTime::currentDateTime();
     double lastStrokesCount = 0;
     


### PR DESCRIPTION
Treat MRK-R06- rowers the same as I-ROWER devices by subscribing
only to FTMS notifications. This resolves the issue where QZ was
not sending data to Peloton for these devices.

Changes:
- Added MRK-R06- detection in bluetooth.cpp ftmsrower device list
- Added MRK_R06 boolean flag in ftmsrower.h
- Added MRK-R06- device detection in ftmsrower.cpp deviceDiscovered()
- Updated I_ROWER conditions to include MRK_R06 in update() method
- Updated I_ROWER conditions to include MRK_R06 in stateChanged() method
  to subscribe only to FTMS service (0x1826)

Fixes #4061