### PR TITLE
Prevent repopulating deleted XML and ZWO files

### DIFF
--- a/src/homeform.cpp
+++ b/src/homeform.cpp
@@ -669,8 +669,11 @@ homeform::homeform(QQmlApplicationEngine *engine, bluetooth *bl) {
     QDir().mkdir(getWritableAppDir() + "training/");
     while (itZwo.hasNext()) {
         qDebug() << itZwo.next() << itZwo.fileName();
-        if (!QFile(getWritableAppDir() + "training/" + itZwo.fileName()).exists()) {
-            QFile::copy(":/zwo/" + itZwo.fileName(), getWritableAppDir() + "training/" + itZwo.fileName());
+        QString targetPath = getWritableAppDir() + "training/" + itZwo.fileName();
+        QString markerPath = getWritableAppDir() + "training/.deleted_" + itZwo.fileName();
+        // Only copy if file doesn't exist AND no deletion marker exists
+        if (!QFile(targetPath).exists() && !QFile(markerPath).exists()) {
+            QFile::copy(":/zwo/" + itZwo.fileName(), targetPath);
         }
     }
 
@@ -678,8 +681,11 @@ homeform::homeform(QQmlApplicationEngine *engine, bluetooth *bl) {
     QDir().mkdir(getWritableAppDir() + "gpx/");
     while (itGpx.hasNext()) {
         qDebug() << itGpx.next() << itGpx.fileName();
-        if (!QFile(getWritableAppDir() + "gpx/" + itGpx.fileName()).exists()) {
-            QFile::copy(":/gpx/" + itGpx.fileName(), getWritableAppDir() + "gpx/" + itGpx.fileName());
+        QString targetPath = getWritableAppDir() + "gpx/" + itGpx.fileName();
+        QString markerPath = getWritableAppDir() + "gpx/.deleted_" + itGpx.fileName();
+        // Only copy if file doesn't exist AND no deletion marker exists
+        if (!QFile(targetPath).exists() && !QFile(markerPath).exists()) {
+            QFile::copy(":/gpx/" + itGpx.fileName(), targetPath);
         }
     }
 


### PR DESCRIPTION
When users delete default ZWO/GPX files from the workout editor, create a hidden marker file (.deleted_<filename>) to prevent the app from automatically recreating them on next startup.

Changes:
- Modified onDeleteTrainingProgram to create deletion markers
- Updated homeform.cpp to check for markers before copying default files
- Added QFile and QFileInfo includes to templateinfosenderbuilder.cpp

This allows users to permanently remove unwanted default workout files without them reappearing after each app restart.