### PR TITLE
Fix workout values changing on load

### DIFF
--- a/src/inner_templates/workouteditor/workout-editor-app.js
+++ b/src/inner_templates/workouteditor/workout-editor-app.js
@@ -501,6 +501,11 @@
                         value = value / 1.60934;
                     }
 
+                    // Truncate speed values to 1 decimal place to avoid floating-point precision issues
+                    if (def.unitKey === 'speed' && !isDefaultValue) {
+                        value = Math.round(value * 10) / 10;
+                    }
+
                     if (!isDefaultValue) {
                         out[def.key] = value;
                         // Mark field as enabled if it has a non-default value


### PR DESCRIPTION
When loading workouts, speed values were displaying with excessive decimal places (e.g., 7.500031068686833 instead of 7.5) due to floating-point arithmetic errors during km/miles conversions.

This fix truncates all speed-related values (speed, minSpeed, maxSpeed) to 1 decimal place when loading workouts, eliminating the precision display issue while maintaining accuracy.

Fixes issue where speed values change when loading recently created workouts.

#4072