### PR TITLE
Fix step count using intelligent cadence auto-detection

### DIFF
--- a/src/devices/treadmill.cpp
+++ b/src/devices/treadmill.cpp
@@ -533,7 +533,9 @@ double treadmill::treadmillInclinationOverride(double Inclination) {
 }
 
 void treadmill::evaluateStepCount() {
-    StepCount += (Cadence.lastChanged().msecsTo(QDateTime::currentDateTime())) * (Cadence.value() / 60000) * 2.0;
+    // Auto-detect cadence format: if < 120, assume it's per-leg and needs doubling for step count
+    double effectiveCadence = (Cadence.value() < 120 && Cadence.value() > 0) ? Cadence.value() * 2 : Cadence.value();
+    StepCount += (Cadence.lastChanged().msecsTo(QDateTime::currentDateTime())) * (effectiveCadence / 60000);
 }
 
 bool treadmill::cadenceFromAppleWatch() {


### PR DESCRIPTION
Different sources send cadence in different formats:
- Some send "per-leg" cadence (SPM/2, ~80-90 when running)
- Others send total SPM (~160-180 when running)

The original code had a * 2.0 multiplier in evaluateStepCount() which
worked for per-leg cadence but caused double counting with total SPM.

Solution: Smart auto-detection based on cadence value
- If rawCadence < 120 and > 0: assume per-leg format, multiply by 2
- If rawCadence >= 120: assume total SPM, use as-is

Benefits:
- Source-agnostic: works with any device/companion app
- Self-adapting: no need to hardcode device-specific logic
- Future-proof: handles new cadence sources automatically
- Robust: handles both Apple Watch (~90) and Garmin (~180)

Now both formats work correctly:
- Total SPM (180) → 10000 steps per 10km ✓
- Per-leg (90 × 2 = 180) → 10000 steps per 10km ✓

Fixes issue where 10km run showed 20000 steps with certain devices.