### PR TITLE
Add custom Garmin device serial setting

### DIFF
--- a/src/qfit.cpp
+++ b/src/qfit.cpp
@@ -71,6 +71,7 @@ void qfit::save(const QString &filename, QList<SessionLine> session, BLUETOOTH_T
 
     bool fit_file_garmin_device_training_effect = settings.value(QZSettings::fit_file_garmin_device_training_effect, QZSettings::default_fit_file_garmin_device_training_effect).toBool();
     int fit_file_garmin_device_training_effect_device = settings.value(QZSettings::fit_file_garmin_device_training_effect_device, QZSettings::default_fit_file_garmin_device_training_effect_device).toInt();
+    uint32_t garmin_device_serial = settings.value(QZSettings::garmin_device_serial, QZSettings::default_garmin_device_serial).toUInt();
     bool is_zwift_device = (fit_file_garmin_device_training_effect_device == 99999);
     fit::FileIdMesg fileIdMesg; // Every FIT file requires a File ID message
     fileIdMesg.SetType(FIT_FILE_ACTIVITY);
@@ -86,7 +87,7 @@ void qfit::save(const QString &filename, QList<SessionLine> session, BLUETOOTH_T
     }
     if(fit_file_garmin_device_training_effect || is_zwift_device) {
         fileIdMesg.SetProduct(is_zwift_device ? 3288 : fit_file_garmin_device_training_effect_device);
-        fileIdMesg.SetSerialNumber(3313379353);
+        fileIdMesg.SetSerialNumber(garmin_device_serial);
     } else {
         fileIdMesg.SetProduct(1);
         fileIdMesg.SetSerialNumber(12345);
@@ -113,12 +114,12 @@ void qfit::save(const QString &filename, QList<SessionLine> session, BLUETOOTH_T
     deviceInfoMesg.SetDeviceIndex(FIT_DEVICE_INDEX_CREATOR);
     if(is_zwift_device) {
         deviceInfoMesg.SetManufacturer(FIT_MANUFACTURER_ZWIFT);
-        deviceInfoMesg.SetSerialNumber(3313379353);
+        deviceInfoMesg.SetSerialNumber(garmin_device_serial);
         deviceInfoMesg.SetProduct(3288);
         deviceInfoMesg.SetSoftwareVersion(21.19);
     } else if(fit_file_garmin_device_training_effect) {
         deviceInfoMesg.SetManufacturer(FIT_MANUFACTURER_GARMIN);
-        deviceInfoMesg.SetSerialNumber(3313379353);
+        deviceInfoMesg.SetSerialNumber(garmin_device_serial);
         deviceInfoMesg.SetProduct(fit_file_garmin_device_training_effect_device);
         deviceInfoMesg.SetGarminProduct(fit_file_garmin_device_training_effect_device);
         deviceInfoMesg.SetSoftwareVersion(21.19);

--- a/src/qzsettings.cpp
+++ b/src/qzsettings.cpp
@@ -884,6 +884,7 @@ const QString QZSettings::tile_biggears_swap = QStringLiteral("tile_biggears_swa
 const QString QZSettings::treadmill_follow_wattage = QStringLiteral("treadmill_follow_wattage");
 const QString QZSettings::fit_file_garmin_device_training_effect = QStringLiteral("fit_file_garmin_device_training_effect");
 const QString QZSettings::fit_file_garmin_device_training_effect_device = QStringLiteral("fit_file_garmin_device_training_effect_device");
+const QString QZSettings::garmin_device_serial = QStringLiteral("garmin_device_serial");
 const QString QZSettings::proform_treadmill_705_cst_V80_44 = QStringLiteral("proform_treadmill_705_cst_V80_44");
 const QString QZSettings::nordictrack_treadmill_1750_adb = QStringLiteral("nordictrack_treadmill_1750_adb");
 const QString QZSettings::proform_trainer_9_0 = QStringLiteral("proform_trainer_9_0");
@@ -1036,7 +1037,7 @@ const QString QZSettings::proform_csx210 = QStringLiteral("proform_csx210");
 const QString QZSettings::skandika_wiri_x2000_protocol = QStringLiteral("skandika_wiri_x2000_protocol");
 
 
-const uint32_t allSettingsCount = 842;
+const uint32_t allSettingsCount = 843;
 
 QVariant allSettings[allSettingsCount][2] = {
     {QZSettings::cryptoKeySettingsProfiles, QZSettings::default_cryptoKeySettingsProfiles},
@@ -1771,6 +1772,7 @@ QVariant allSettings[allSettingsCount][2] = {
     {QZSettings::treadmill_follow_wattage, QZSettings::default_treadmill_follow_wattage},
     {QZSettings::fit_file_garmin_device_training_effect, QZSettings::default_fit_file_garmin_device_training_effect},
     {QZSettings::fit_file_garmin_device_training_effect_device, QZSettings::default_fit_file_garmin_device_training_effect_device},
+    {QZSettings::garmin_device_serial, QZSettings::default_garmin_device_serial},
     {QZSettings::proform_treadmill_705_cst_V80_44, QZSettings::default_proform_treadmill_705_cst_V80_44},
     {QZSettings::nordictrack_treadmill_1750_adb, QZSettings::default_nordictrack_treadmill_1750_adb},
     {QZSettings::proform_trainer_9_0, QZSettings::default_proform_trainer_9_0},

--- a/src/qzsettings.h
+++ b/src/qzsettings.h
@@ -2413,6 +2413,9 @@ class QZSettings {
     static const QString fit_file_garmin_device_training_effect_device;
     static constexpr int default_fit_file_garmin_device_training_effect_device = FIT_GARMIN_PRODUCT_EDGE_830;
 
+    static const QString garmin_device_serial;
+    static constexpr uint32_t default_garmin_device_serial = 3313379353;
+
     static const QString proform_treadmill_705_cst_V80_44;
     static constexpr bool default_proform_treadmill_705_cst_V80_44 = false;
 

--- a/src/settings.qml
+++ b/src/settings.qml
@@ -1256,9 +1256,10 @@ import Qt.labs.platform 1.1
             property bool power_sensor_cadence_instead_treadmill: false            
             
             property string garmin_oauth1_token: ""
-            property string garmin_oauth1_token_secret: ""            
+            property string garmin_oauth1_token_secret: ""
 
 			property bool domyos_treadmill_sync_start: false
+			property int garmin_device_serial: 3313379353
         }
 
 
@@ -6860,6 +6861,43 @@ import Qt.labs.platform 1.1
                             }
                         }
                         Layout.fillWidth: true
+                    }
+
+                    Label {
+                        text: qsTr("Garmin device serial number")
+                        Layout.alignment: Qt.AlignLeft | Qt.AlignTop
+                        Layout.fillWidth: true
+                    }
+
+                    RowLayout {
+                        spacing: 10
+                        TextField {
+                            id: garminDeviceSerialTextField
+                            text: settings.garmin_device_serial
+                            Layout.fillWidth: true
+                            Layout.preferredWidth: 250
+                            horizontalAlignment: Text.AlignLeft
+                            inputMethodHints: Qt.ImhDigitsOnly
+                            onTextChanged: {
+                                var value = parseInt(text);
+                                if (!isNaN(value)) {
+                                    settings.garmin_device_serial = value;
+                                }
+                            }
+                        }
+                    }
+
+                    Label {
+                        text: qsTr("IMPORTANT: You must set your real Garmin device serial number here to see your actual device in Garmin Connect. You can find your device serial number in the Garmin Connect app or on the back of your Garmin device. The default value (3313379353) is just a placeholder.")
+                        font.bold: true
+                        font.italic: true
+                        font.pixelSize: Qt.application.font.pixelSize - 2
+                        textFormat: Text.PlainText
+                        wrapMode: Text.WordWrap
+                        verticalAlignment: Text.AlignVCenter
+                        Layout.alignment: Qt.AlignLeft | Qt.AlignTop
+                        Layout.fillWidth: true
+                        color: Material.color(Material.Orange)
                     }
                 }
             }


### PR DESCRIPTION
- Added new garmin_device_serial setting to allow users to specify their real Garmin device serial number
- Replaced hardcoded serial (3313379353) in FIT file generation with user-configurable value
- Added UI TextField in settings for serial number input with validation
- Added prominent warning message explaining importance of setting real serial for Garmin Connect
- Updated allSettingsCount to 843
- Serial number is used in FIT file when fit_file_garmin_device_training_effect is enabled

This change is essential for users to see their actual Garmin device in Garmin Connect instead of a generic placeholder.