### PR TITLE
Add JFICCYCLE FTMS bike support with power calculation patch

### DIFF
--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -1819,7 +1819,8 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                         (b.name().toUpper().startsWith("DIRETO X")) || (b.name().toUpper().startsWith("MERACH-667-")) ||
                         !b.name().compare(ftms_bike, Qt::CaseInsensitive) || (b.name().toUpper().startsWith("SMB1")) ||
                         (b.name().toUpper().startsWith("UBIKE FTMS")) || (b.name().toUpper().startsWith("INRIDE")) ||
-                        (b.name().toUpper().startsWith("YPBM") && b.name().length() == 10)) &&
+                        (b.name().toUpper().startsWith("YPBM") && b.name().length() == 10) ||
+                        (b.name().toUpper().startsWith("JFICCYCLE"))) &&
                         ftms_rower.contains(QZSettings::default_ftms_rower) &&
                        !ftmsBike && !ftmsRower && !snodeBike && !fitPlusBike && !stagesBike && filter) {
                 this->setLastBluetoothDevice(b);

--- a/src/devices/ftmsbike/ftmsbike.cpp
+++ b/src/devices/ftmsbike/ftmsbike.cpp
@@ -751,6 +751,10 @@ void ftmsbike::characteristicChanged(const QLowEnergyCharacteristic &characteris
             } else if (MRK_S26C) {
                 m_watt = Cadence.value() * (Resistance.value() * 1.16);
                 emit debug(QStringLiteral("Current Watt (MRK-S26C formula): ") + QString::number(m_watt.value()));
+            } else if (JFICCYCLE) {
+                // JFICCYCLE sends power but always at 0, so calculate from cadence or heart rate
+                m_watt = wattFromHR(true);
+                emit debug(QStringLiteral("Current Watt (JFICCYCLE calculated): ") + QString::number(m_watt.value()));
             } else if (LYDSTO && watt_ignore_builtin) {
                 m_watt = wattFromHR(true);
                 emit debug(QStringLiteral("Current Watt: ") + QString::number(m_watt.value()));
@@ -1786,6 +1790,9 @@ void ftmsbike::deviceDiscovered(const QBluetoothDeviceInfo &device) {
             qDebug() << QStringLiteral("S18 found");
             S18 = true;
             max_resistance = 24;
+        } else if(device.name().toUpper().startsWith("JFICCYCLE")) {
+            qDebug() << QStringLiteral("JFICCYCLE found");
+            JFICCYCLE = true;
         }
 
 

--- a/src/devices/ftmsbike/ftmsbike.h
+++ b/src/devices/ftmsbike/ftmsbike.h
@@ -168,6 +168,7 @@ class ftmsbike : public bike {
     bool SPORT01 = false;
     bool FS_YK = false;
     bool S18 = false;
+    bool JFICCYCLE = false;
 
     uint8_t secondsToResetTimer = 5;
 


### PR DESCRIPTION
JFICCYCLE is a Bluetooth FTMS bike that sends power data but always reports 0 watts.
This commit adds support for the JFICCYCLE device with automatic power calculation
from cadence or heart rate, similar to the existing cscbike implementation.

Changes:
- Added JFICCYCLE boolean flag to ftmsbike.h
- Added JFICCYCLE device detection in bluetooth.cpp
- Added JFICCYCLE initialization in ftmsbike.cpp deviceDiscovered()
- Implemented power calculation using wattFromHR() when JFICCYCLE is detected