### PR TITLE
Fix iOS widget heart rate from external sources like Garmin Companion

### DIFF
--- a/src/devices/bluetoothdevice.cpp
+++ b/src/devices/bluetoothdevice.cpp
@@ -359,7 +359,7 @@ void bluetoothdevice::update_ios_live_activity() {
         if(kcal < 0)
             kcal = 0;
         bool useMiles = settings.value(QZSettings::miles_unit, QZSettings::default_miles_unit).toBool();
-        h.workoutTrackingUpdate(Speed.value(), Cadence.value(), (uint16_t)m_watt.value(), kcal, StepCount.value(), deviceType(), odometer() * 1000.0, totalCalories().value(), useMiles);
+        h.workoutTrackingUpdate(Speed.value(), Cadence.value(), (uint16_t)m_watt.value(), kcal, StepCount.value(), deviceType(), odometer() * 1000.0, totalCalories().value(), useMiles, (uint8_t)Heart.value());
 
         lastUpdate = current;
     }

--- a/src/ios/lockscreen.h
+++ b/src/ios/lockscreen.h
@@ -20,7 +20,7 @@ class lockscreen {
     void setHeartRate(unsigned char heartRate);
     void startWorkout(unsigned short deviceType);
     void stopWorkout();
-    void workoutTrackingUpdate(double speed, unsigned short cadence, unsigned short watt, unsigned short currentCalories, unsigned long long currentSteps, unsigned char deviceType, double currentDistance, double totalKcal, bool useMiles);
+    void workoutTrackingUpdate(double speed, unsigned short cadence, unsigned short watt, unsigned short currentCalories, unsigned long long currentSteps, unsigned char deviceType, double currentDistance, double totalKcal, bool useMiles, unsigned char heartRate);
     bool appleWatchAppInstalled();
 
     // virtualbike

--- a/src/ios/lockscreen.mm
+++ b/src/ios/lockscreen.mm
@@ -206,7 +206,7 @@ void lockscreen::virtualbike_setCadence(unsigned short crankRevolutions, unsigne
         [_virtualbike updateCadenceWithCrankRevolutions:crankRevolutions LastCrankEventTime:lastCrankEventTime];
 }
 
-void lockscreen::workoutTrackingUpdate(double speed, unsigned short cadence, unsigned short watt, unsigned short currentCalories, unsigned long long currentSteps, unsigned char deviceType, double currentDistance, double totalKcal, bool useMiles) {
+void lockscreen::workoutTrackingUpdate(double speed, unsigned short cadence, unsigned short watt, unsigned short currentCalories, unsigned long long currentSteps, unsigned char deviceType, double currentDistance, double totalKcal, bool useMiles, unsigned char heartRate) {
     if(workoutTracking != nil && !appleWatchAppInstalled())
         [workoutTracking addMetricsWithPower:watt cadence:cadence*2 speed:speed * 100 kcal:currentCalories steps:currentSteps deviceType:deviceType distance:currentDistance totalKcal:totalKcal elevationGain:0];
 
@@ -214,7 +214,7 @@ void lockscreen::workoutTrackingUpdate(double speed, unsigned short cadence, uns
     if (!ios_liveactivity::isLiveActivityRunning()) {
         ios_liveactivity::startLiveActivity("QZ", useMiles);
     }
-    ios_liveactivity::updateLiveActivity(speed, cadence, watt, [h heartRate], currentDistance, currentCalories, useMiles);
+    ios_liveactivity::updateLiveActivity(speed, cadence, watt, heartRate, currentDistance, currentCalories, useMiles);
 }
 
 void lockscreen::virtualbike_zwift_ios(bool disable_hr, bool garmin_bluetooth_compatibility, bool zwift_play_emulator, bool watt_bike_emulator)


### PR DESCRIPTION
The iOS Live Activity widget was always reading heart rate from HealthKit
instead of using the actual heart rate value from connected devices and
external apps like Garmin Companion.

Changes:
- Add heartRate parameter to workoutTrackingUpdate() method
- Pass Heart.value() from bluetoothdevice to the widget
- Use the passed heart rate value instead of HealthKit's value

This ensures the widget correctly displays heart rate from all sources
including Garmin Companion, Bluetooth heart rate monitors, and other
connected devices.