### PR TITLE
Add lap tracking for Peloton workouts and TrainProgram rows

### DIFF
--- a/src/qzsettings.cpp
+++ b/src/qzsettings.cpp
@@ -1036,9 +1036,10 @@ const QString QZSettings::height = QStringLiteral("height");
 const QString QZSettings::taurua_ic90 = QStringLiteral("taurua_ic90");
 const QString QZSettings::proform_csx210 = QStringLiteral("proform_csx210");
 const QString QZSettings::skandika_wiri_x2000_protocol = QStringLiteral("skandika_wiri_x2000_protocol");
+const QString QZSettings::trainprogram_auto_lap_on_segment = QStringLiteral("trainprogram_auto_lap_on_segment");
 
 
-const uint32_t allSettingsCount = 844;
+const uint32_t allSettingsCount = 845;
 
 QVariant allSettings[allSettingsCount][2] = {
     {QZSettings::cryptoKeySettingsProfiles, QZSettings::default_cryptoKeySettingsProfiles},
@@ -1898,6 +1899,7 @@ QVariant allSettings[allSettingsCount][2] = {
     {QZSettings::taurua_ic90, QZSettings::default_taurua_ic90},
     {QZSettings::proform_csx210, QZSettings::default_proform_csx210},
     {QZSettings::skandika_wiri_x2000_protocol, QZSettings::default_skandika_wiri_x2000_protocol},
+    {QZSettings::trainprogram_auto_lap_on_segment, QZSettings::default_trainprogram_auto_lap_on_segment},
     {QZSettings::toorxtreadmill_discovery_completed, QZSettings::default_toorxtreadmill_discovery_completed},
     {QZSettings::proform_treadmill_sport_3_0, QZSettings::default_proform_treadmill_sport_3_0},
     {QZSettings::garmin_oauth1_token, QZSettings::default_garmin_oauth1_token},

--- a/src/qzsettings.h
+++ b/src/qzsettings.h
@@ -2826,6 +2826,12 @@ class QZSettings {
     static constexpr bool default_skandika_wiri_x2000_protocol = true;
 
     /**
+     * @brief Automatically trigger a lap when completing each workout segment/row in TrainProgram
+     */
+    static const QString trainprogram_auto_lap_on_segment;
+    static constexpr bool default_trainprogram_auto_lap_on_segment = false;
+
+    /**
      * @brief Write the QSettings values using the constants from this namespace.
      * @param showDefaults Optionally indicates if the default should be shown with the key.
      */

--- a/src/settings.qml
+++ b/src/settings.qml
@@ -1261,6 +1261,7 @@ import Qt.labs.platform 1.1
 			property bool domyos_treadmill_sync_start: false
 			property string garmin_device_serial: "3313379353"
 			property real treadmill_speed_min: 0
+			property bool trainprogram_auto_lap_on_segment: false
         }
 
 
@@ -7155,7 +7156,35 @@ import Qt.labs.platform 1.1
                         Layout.alignment: Qt.AlignLeft | Qt.AlignTop
                         Layout.fillWidth: true
                         color: Material.color(Material.Lime)
-                    }                    
+                    }
+
+                    IndicatorOnlySwitch {
+                        id: trainprogramAutoLapOnSegmentDelegate
+                        text: qsTr("Auto Lap on Segment")
+                        spacing: 0
+                        bottomPadding: 0
+                        topPadding: 0
+                        rightPadding: 0
+                        leftPadding: 0
+                        clip: false
+                        checked: settings.trainprogram_auto_lap_on_segment
+                        Layout.alignment: Qt.AlignLeft | Qt.AlignTop
+                        Layout.fillWidth: true
+                        onClicked: settings.trainprogram_auto_lap_on_segment = checked
+                    }
+
+                    Label {
+                        text: qsTr("Automatically trigger a lap when completing each workout segment/row. For ramp segments, lap is triggered only at the end of the ramp to avoid creating a lap every second.")
+                        font.bold: true
+                        font.italic: true
+                        font.pixelSize: Qt.application.font.pixelSize - 2
+                        textFormat: Text.PlainText
+                        wrapMode: Text.WordWrap
+                        verticalAlignment: Text.AlignVCenter
+                        Layout.alignment: Qt.AlignLeft | Qt.AlignTop
+                        Layout.fillWidth: true
+                        color: Material.color(Material.Lime)
+                    }
 
                     IndicatorOnlySwitch {
                         text: qsTr("Treadmill Auto-adjust speed by power")

--- a/src/trainprogram.cpp
+++ b/src/trainprogram.cpp
@@ -1040,7 +1040,9 @@ void trainprogram::scheduler() {
 
                 // Emit lap for each completed row, but skip intermediate ramp steps
                 // Only emit lap when rampDuration is 0 (standalone row or end of ramp)
-                if (QTime(0, 0, 0).secsTo(rows.at(currentStep).rampDuration) == 0) {
+                if (settings.value(QZSettings::trainprogram_auto_lap_on_segment,
+                                   QZSettings::default_trainprogram_auto_lap_on_segment).toBool() &&
+                    QTime(0, 0, 0).secsTo(rows.at(currentStep).rampDuration) == 0) {
                     qDebug() << "Emitting lap for completed row" << currentStep;
                     emit lap();
                 }


### PR DESCRIPTION
Implement automatic lap triggering for each completed workout row.
The lap is emitted when a row finishes, but intelligently skips
intermediate steps in ramps to avoid creating a lap every second.

Key features:
- Emit lap() signal when completing a workout row
- Detect ramp segments using rampDuration field
- Only trigger lap at the END of a ramp (when rampDuration == 0)
- Avoid lap spam during 1-second ramp intermediate steps
- Maintains compatibility with existing lap tracking system

This enables better workout interval tracking for Peloton workouts
and other structured training programs.