### PR TITLE
Fix Peloton remaining time underflow bug

### DIFF
--- a/src/trainprogram.cpp
+++ b/src/trainprogram.cpp
@@ -1921,6 +1921,12 @@ QTime trainprogram::remainingTime() {
     for (calculatedLine = 0; calculatedLine < static_cast<uint32_t>(rows.length()); calculatedLine++) {
         calculatedTotalTime += calculateTimeForRow(calculatedLine);
     }
+
+    // Prevent underflow when workout is complete
+    if (ticks >= calculatedTotalTime) {
+        return QTime(0, 0, 0);
+    }
+
     return QTime(0, 0, 0).addSecs(calculatedTotalTime - ticks);
 }
 


### PR DESCRIPTION
Prevent unsigned integer underflow in remainingTime() calculation when elapsed time (ticks) exceeds total workout duration. Previously, this caused the Peloton remaining time tile to display 23:59:59 instead of 0:00:00 at workout completion.

The fix checks if ticks >= calculatedTotalTime and returns 0:00:00 instead of attempting the subtraction that would underflow.