### PR TITLE
Fix watts not resetting to zero when cadence stops in cscbike

### DIFF
--- a/src/devices/cscbike/cscbike.cpp
+++ b/src/devices/cscbike/cscbike.cpp
@@ -78,7 +78,12 @@ void cscbike::update() {
         double rpm = currentCadence().value();
         m_watt = 0.000602337 * pow(rpm, 3.11762) + 32.6404;
     } else {
-        m_watt = wattFromHR(false);
+        // When cadence is zero, watts should be zero regardless of HR
+        if (currentCadence().value() == 0) {
+            m_watt = 0;
+        } else {
+            m_watt = wattFromHR(false);
+        }
     }
     emit debug(QStringLiteral("Current Watt: ") + QString::number(m_watt.value()));
 


### PR DESCRIPTION
When using wattsFromHR on cscbike, watts were not going to zero when
cadence reached zero. Added explicit cadence check before calculating
watts from HR to ensure watts reset to zero when user stops pedaling,
while avoiding circular dependency with speed_power_based setting.