### PR TITLE
Fix Garmin Connect login for usernames containing '+' character (#4121)

### DIFF
--- a/src/garminconnect.cpp
+++ b/src/garminconnect.cpp
@@ -407,7 +407,16 @@ bool GarminConnect::performLogin(const QString &email, const QString &password, 
     postData.addQueryItem("embed", "true");
     postData.addQueryItem("_csrf", m_csrfToken);
 
-    QByteArray data = postData.query(QUrl::FullyEncoded).toUtf8();
+    QString queryString = postData.query(QUrl::FullyEncoded);
+
+    // CRITICAL: Fix '+' character encoding for usernames like "user+tag@example.com"
+    // QUrlQuery doesn't percent-encode '+' in form data (treats it as space character)
+    // but Garmin authentication requires literal '+' to be encoded as '%2B'
+    // This is safe because in URL-encoded form data, '+' always means space,
+    // so any literal '+' must be encoded as '%2B'
+    queryString.replace("+", "%2B");
+
+    QByteArray data = queryString.toUtf8();
 
     QNetworkRequest request(url);
     request.setRawHeader("User-Agent", USER_AGENT);


### PR DESCRIPTION
The issue was that QUrlQuery doesn't percent-encode the '+' character in form
data (where '+' represents a space). This caused usernames like
"user+tag@example.com" to be sent as "user tag@example.com" to Garmin's
authentication servers, resulting in login failures.

The fix maintains the existing QUrlQuery approach (preserving all OAuth1
encoding work from PR #3940) but adds a simple post-processing step to replace
any '+' with '%2B' in the generated query string. This is safe because in
URL-encoded form data, '+' always means space, so any literal '+' character
must be encoded as '%2B'.

Fixes #4121