### PR TITLE
Conditionalize Dircon Rouvy compatibility features to rouvy_compatibility flag

### DIFF
--- a/src/devices/dircon/dirconpacket.h
+++ b/src/devices/dircon/dirconpacket.h
@@ -55,8 +55,8 @@ class DirconPacket {
     bool isRequest = false;
     DirconPacket(const DirconPacket &cp);
     DirconPacket &operator=(const DirconPacket &cp);
-    QByteArray encode(int last_seq_number);
-    int parse(const QByteArray &buf, int last_seq_number);
+    QByteArray encode(int last_seq_number, bool rouvy_compatibility = false);
+    int parse(const QByteArray &buf, int last_seq_number, bool rouvy_compatibility = false);
     operator QString() const;
 
   private:


### PR DESCRIPTION
#4138 

This commit ensures that all Rouvy-specific protocol changes are properly conditioned to the rouvy_compatibility flag, restoring original behavior when the flag is disabled.

Changes:
- dirconmanager.cpp: Remove hardcoded INDICATE flag from 0x2AD9 characteristics, add conditional logic to apply INDICATE only when rouvy_compatibility is true
- dirconpacket.h: Add rouvy_compatibility parameter to parse() and encode() methods
- dirconpacket.cpp: Conditionalize relaxed validation (>= vs ==) and 0x07 message handling to rouvy_compatibility flag
- dirconprocessor.cpp: Conditionalize INDICATE flag check and pass rouvy_compatibility to all parse()/encode() calls

Result: Complete backward compatibility when rouvy_compatibility=false