### PR TITLE
Add inCondi S150i FTMS bike support

### DIFF
--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -1826,9 +1826,9 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                         (b.name().toUpper().startsWith("DIRETO X")) || (b.name().toUpper().startsWith("MERACH-667-")) ||
                         !b.name().compare(ftms_bike, Qt::CaseInsensitive) || (b.name().toUpper().startsWith("SMB1")) ||
                         (b.name().toUpper().startsWith("UBIKE FTMS")) || (b.name().toUpper().startsWith("INRIDE")) ||
+                        (b.name().toUpper().startsWith("INCONDI")) || // inCondi S150i
                         (b.name().toUpper().startsWith("YPBM") && b.name().length() == 10) ||
-                        (b.name().toUpper().startsWith("JFICCYCLE")) ||
-                        (b.name().toUpper().startsWith("INCONDI"))) && // inCondi S150i
+                        (b.name().toUpper().startsWith("JFICCYCLE"))) &&
                         ftms_rower.contains(QZSettings::default_ftms_rower) &&
                        !ftmsBike && !ftmsRower && !snodeBike && !fitPlusBike && !stagesBike && filter) {
                 this->setLastBluetoothDevice(b);


### PR DESCRIPTION
Add "INCONDI" device name to FTMS bike detection in bluetooth.cpp
to support the inCondi S150i bike model.