### PR TITLE
Add virtual rower support to sportsplusrower

### DIFF
--- a/src/devices/sportsplusrower/sportsplusrower.cpp
+++ b/src/devices/sportsplusrower/sportsplusrower.cpp
@@ -3,6 +3,7 @@
 #include "keepawakehelper.h"
 #endif
 #include "virtualdevices/virtualbike.h"
+#include "virtualdevices/virtualrower.h"
 #include <QBluetoothLocalDevice>
 #include <QDateTime>
 #include <QEventLoop>
@@ -275,17 +276,26 @@ void sportsplusrower::stateChanged(QLowEnergyService::ServiceState state) {
         connect(gattCommunicationChannelService, &QLowEnergyService::descriptorWritten, this,
                 &sportsplusrower::descriptorWritten);
 
-        // ******************************************* virtual bike init *************************************
+        // ******************************************* virtual bike/rower init *************************************
         if (!firstVirtualBike && !this->hasVirtualDevice()) {
             QSettings settings;
             bool virtual_device_enabled =
                 settings.value(QZSettings::virtual_device_enabled, QZSettings::default_virtual_device_enabled).toBool();
+            bool virtual_device_rower =
+                settings.value(QZSettings::virtual_device_rower, QZSettings::default_virtual_device_rower).toBool();
             if (virtual_device_enabled) {
-                emit debug(QStringLiteral("creating virtual bike interface..."));
-                auto virtualBike = new virtualbike(this, noWriteResistance, noHeartService);
-                // connect(virtualBike,&virtualbike::debug ,this,&sportsplusrower::debug);
-                connect(virtualBike, &virtualbike::changeInclination, this, &sportsplusrower::changeInclination);
-                this->setVirtualDevice(virtualBike, VIRTUAL_DEVICE_MODE::PRIMARY);
+                if (!virtual_device_rower) {
+                    emit debug(QStringLiteral("creating virtual bike interface..."));
+                    auto virtualBike = new virtualbike(this, noWriteResistance, noHeartService);
+                    // connect(virtualBike,&virtualbike::debug ,this,&sportsplusrower::debug);
+                    connect(virtualBike, &virtualbike::changeInclination, this, &sportsplusrower::changeInclination);
+                    this->setVirtualDevice(virtualBike, VIRTUAL_DEVICE_MODE::PRIMARY);
+                } else {
+                    emit debug(QStringLiteral("creating virtual rower interface..."));
+                    auto virtualRower = new virtualrower(this, noWriteResistance, noHeartService);
+                    // connect(virtualRower,&virtualrower::debug ,this,&sportsplusrower::debug);
+                    this->setVirtualDevice(virtualRower, VIRTUAL_DEVICE_MODE::PRIMARY);
+                }
             }
         }
         firstVirtualBike = 1;

--- a/src/devices/sportsplusrower/sportsplusrower.h
+++ b/src/devices/sportsplusrower/sportsplusrower.h
@@ -27,6 +27,7 @@
 
 #include "devices/rower.h"
 #include "virtualdevices/virtualbike.h"
+#include "virtualdevices/virtualrower.h"
 
 class sportsplusrower : public rower {
     Q_OBJECT


### PR DESCRIPTION
- Added virtualrower.h include in both header and implementation files
- Added virtual_device_rower setting check in stateChanged method
- Sportsplusrower can now create either a virtual bike or virtual rower
  based on the virtual_device_rower setting
- Follows the same pattern as other rower implementations
  (echelonrower, domyosrower, csaferower, etc.)

This ensures all rower devices in the codebase have consistent
virtual rower support, allowing users to choose whether their rower
should appear as a virtual bike or virtual rower to fitness apps.