### PR TITLE
Fix Garmin Connect consecutive upload SSL error

### DIFF
--- a/src/garminconnect.cpp
+++ b/src/garminconnect.cpp
@@ -111,6 +111,11 @@ bool GarminConnect::uploadFitFile(const QString &fitFilePath)
     QNetworkRequest request(url);
     request.setRawHeader("User-Agent", USER_AGENT);
 
+    // CRITICAL: Force connection close to prevent SSL connection reuse issues
+    // Without this, consecutive uploads fail with "SSL routines:ssl3_read_bytes:sslv3 alert bad record mac"
+    // because QNetworkAccessManager tries to reuse a stale SSL connection
+    request.setRawHeader("Connection", "close");
+
     // Use OAuth2 Bearer token for authorization
     QString authHeader = "Bearer " + m_oauth2Token.access_token;
     request.setRawHeader("Authorization", authHeader.toUtf8());
@@ -1334,6 +1339,12 @@ bool GarminConnect::uploadActivity(const QByteArray &fitData, const QString &fil
     QUrl url(connectApiUrl() + "/upload-service/upload");
     QNetworkRequest request(url);
     request.setRawHeader("User-Agent", "GCM-iOS-5.7.2.1");
+
+    // CRITICAL: Force connection close to prevent SSL connection reuse issues
+    // Without this, consecutive uploads fail with "SSL routines:ssl3_read_bytes:sslv3 alert bad record mac"
+    // because QNetworkAccessManager tries to reuse a stale SSL connection
+    request.setRawHeader("Connection", "close");
+
     request.setRawHeader("Authorization", QString("Bearer %1").arg(m_oauth2Token.access_token).toUtf8());
 
     // Perform upload


### PR DESCRIPTION
Fixes #4135 - Users reported that only the first FIT file upload
to Garmin Connect succeeded, while consecutive uploads failed with:
"SSL routines:ssl3_read_bytes:sslv3 alert bad record mac"

Root cause: QNetworkAccessManager was reusing stale SSL connections
between consecutive uploads, causing the server to reject the second
request due to connection state inconsistency.

Solution: Added "Connection: close" header to both uploadFitFile()
and uploadActivity() methods to force connection closure after each
upload, preventing SSL connection reuse issues.

This ensures clean SSL handshakes for every upload request.