### PR TITLE
Fix: Initialize lastGearValue to prevent unwanted setResistance on init (#4018)

### DIFF
--- a/src/devices/wahookickrsnapbike/wahookickrsnapbike.cpp
+++ b/src/devices/wahookickrsnapbike/wahookickrsnapbike.cpp
@@ -261,6 +261,7 @@ void wahookickrsnapbike::update() {
         // required to the SS2K only one time
         Resistance = 0;
         emit resistanceRead(Resistance.value());
+        lastGearValue = gears(); // Initialize to prevent false gear change detection on first update
         initRequest = false;
     } else if (m_control &&
                (bluetoothDevice.isValid() && m_control->state() == QLowEnergyController::DiscoveredState)


### PR DESCRIPTION
Problem:
- lastGearValue was initialized to -1 (default)
- During init, it was not set to the current gears() value
- On first update after init, the condition "lastGearValue != gears()"
  was always true (-1 != 0)
- This caused an unwanted setResistance command (0x40 0x5b 0x3f) to be
  sent immediately after setSimMode

Solution:
- Initialize lastGearValue = gears() during init (line 264)
- This prevents false gear change detection on first update
- setResistance is now only sent when there's an actual gear change

Fixes issue #4018 - Resistance Changes when Virtual Shifting