### PR TITLE
Fix Domyos-TC horizon treadmill service discovery

### DIFF
--- a/src/devices/horizontreadmill/horizontreadmill.cpp
+++ b/src/devices/horizontreadmill/horizontreadmill.cpp
@@ -2304,14 +2304,13 @@ void horizontreadmill::stateChanged(QLowEnergyService::ServiceState state) {
     QBluetoothUuid _gattTreadmillDataId((quint16)0x2ACD);
     QBluetoothUuid _gattCrossTrainerDataId((quint16)0x2ACE);
     QBluetoothUuid _gattInclinationSupported((quint16)0x2AD5);
-    QBluetoothUuid _DomyosServiceId(QStringLiteral("49535343-fe7d-4ae5-8fa9-9fafd205e455"));
     QBluetoothUuid _YpooMiniProCharId(QStringLiteral("d18d2c10-c44c-11e8-a355-529269fb1459"));
     emit debug(QStringLiteral("BTLE stateChanged ") + QString::fromLocal8Bit(metaEnum.valueToKey(state)));
 
     for (QLowEnergyService *s : qAsConst(gattCommunicationChannelService)) {
         qDebug() << QStringLiteral("stateChanged") << s->serviceUuid() << s->state();
 
-        if(s->serviceUuid() == _DomyosServiceId && DOMYOS) {
+        if(s->serviceUuid() == DomyosServiceId && DOMYOS) {
             settings.setValue(QZSettings::domyostreadmill_notfmts, true);
             settings.sync();
             if(homeform::singleton())
@@ -2519,13 +2518,12 @@ void horizontreadmill::serviceScanDone(void) {
     auto services_list = m_control->services();
 
     // Check if DOMYOS device has native service
-    QBluetoothUuid _DomyosServiceId(QStringLiteral("49535343-fe7d-4ae5-8fa9-9fafd205e455"));
     QBluetoothUuid _FTMSServiceId((quint16)0x1826);
     bool hasNativeDomyosService = false;
 
     if (DOMYOS) {
         for (const QBluetoothUuid &s : qAsConst(services_list)) {
-            if (s == _DomyosServiceId) {
+            if (s == DomyosServiceId) {
                 hasNativeDomyosService = true;
                 qDebug() << "Native Domyos service found";
                 break;

--- a/src/devices/horizontreadmill/horizontreadmill.h
+++ b/src/devices/horizontreadmill/horizontreadmill.h
@@ -64,6 +64,8 @@ class horizontreadmill : public treadmill {
     QLowEnergyService *gattCustomService = nullptr;
     volatile int notificationSubscribed = 0;
 
+    static inline const QBluetoothUuid DomyosServiceId{QStringLiteral("49535343-fe7d-4ae5-8fa9-9fafd205e455")};
+
     uint8_t sec1Update = 0;
     QByteArray lastPacket;
     QByteArray lastPacketComplete;


### PR DESCRIPTION
Domyos-TC devices are FTMS-compatible treadmills that were incorrectly
being blocked from proper service initialization. The code was treating
all DOMYOS devices the same way, causing an early return when the Domyos
service ID was found, which prevented the FTMS service (0x1826) from
being fully initialized.

Changes:
- Add DOMYOS_TC flag to differentiate DOMYOS-TC devices from regular DOMYOS
- Detect DOMYOS-TC devices separately in deviceDiscovered()
- Exclude DOMYOS-TC from the early return in stateChanged()

This allows DOMYOS-TC devices to properly initialize all services,
including the FTMS service.