### PR TITLE
Add Tacx device support for Garmin device settings

### DIFF
--- a/src/qfit.cpp
+++ b/src/qfit.cpp
@@ -75,20 +75,28 @@ void qfit::save(const QString &filename, QList<SessionLine> session, BLUETOOTH_T
     int fit_file_garmin_device_training_effect_device = settings.value(QZSettings::fit_file_garmin_device_training_effect_device, QZSettings::default_fit_file_garmin_device_training_effect_device).toInt();
     uint32_t garmin_device_serial = settings.value(QZSettings::garmin_device_serial, QZSettings::default_garmin_device_serial).toUInt();
     bool is_zwift_device = (fit_file_garmin_device_training_effect_device == 99999);
+    bool is_tacx_device = (fit_file_garmin_device_training_effect_device == 88888);
     fit::FileIdMesg fileIdMesg; // Every FIT file requires a File ID message
     fileIdMesg.SetType(FIT_FILE_ACTIVITY);
-    if(bluetooth_device_name.toUpper().startsWith("DOMYOS") && !is_zwift_device && !fit_file_garmin_device_training_effect)
+    if(bluetooth_device_name.toUpper().startsWith("DOMYOS") && !is_zwift_device && !is_tacx_device && !fit_file_garmin_device_training_effect)
         fileIdMesg.SetManufacturer(FIT_MANUFACTURER_DECATHLON);
     else {
         if(is_zwift_device)
             fileIdMesg.SetManufacturer(FIT_MANUFACTURER_ZWIFT);
+        else if(is_tacx_device)
+            fileIdMesg.SetManufacturer(FIT_MANUFACTURER_TACX);
         else if(fit_file_garmin_device_training_effect)
             fileIdMesg.SetManufacturer(FIT_MANUFACTURER_GARMIN);
         else
             fileIdMesg.SetManufacturer(FIT_MANUFACTURER_DEVELOPMENT);
     }
-    if(fit_file_garmin_device_training_effect || is_zwift_device) {
-        fileIdMesg.SetProduct(is_zwift_device ? 3288 : fit_file_garmin_device_training_effect_device);
+    if(fit_file_garmin_device_training_effect || is_zwift_device || is_tacx_device) {
+        if(is_zwift_device)
+            fileIdMesg.SetProduct(3288);
+        else if(is_tacx_device)
+            fileIdMesg.SetProduct(20533);
+        else
+            fileIdMesg.SetProduct(fit_file_garmin_device_training_effect_device);
         fileIdMesg.SetSerialNumber(garmin_device_serial);
     } else {
         fileIdMesg.SetProduct(1);
@@ -119,6 +127,11 @@ void qfit::save(const QString &filename, QList<SessionLine> session, BLUETOOTH_T
         deviceInfoMesg.SetSerialNumber(garmin_device_serial);
         deviceInfoMesg.SetProduct(3288);
         deviceInfoMesg.SetSoftwareVersion(21.19);
+    } else if(is_tacx_device) {
+        deviceInfoMesg.SetManufacturer(FIT_MANUFACTURER_TACX);
+        deviceInfoMesg.SetSerialNumber(garmin_device_serial);
+        deviceInfoMesg.SetProduct(20533);
+        deviceInfoMesg.SetSoftwareVersion(1.30);
     } else if(fit_file_garmin_device_training_effect) {
         deviceInfoMesg.SetManufacturer(FIT_MANUFACTURER_GARMIN);
         deviceInfoMesg.SetSerialNumber(garmin_device_serial);

--- a/src/settings.qml
+++ b/src/settings.qml
@@ -6981,6 +6981,7 @@ import Qt.labs.platform 1.1
                             "Vivoactive 4 Small",
                             "Vivoactive 5",
                             "Vivoactive 6",
+                            "Tacx",
                             "Zwift"
                         ]
                         currentIndex: {
@@ -7098,7 +7099,8 @@ import Qt.labs.platform 1.1
                             if (settings.fit_file_garmin_device_training_effect_device === 3224) return 111;  // VIVOACTIVE4_SMALL
                             if (settings.fit_file_garmin_device_training_effect_device === 4426) return 112;  // VIVOACTIVE5
                             if (settings.fit_file_garmin_device_training_effect_device === 4625) return 113;  // VIVOACTIVE6
-                            if (settings.fit_file_garmin_device_training_effect_device === 99999) return 114;  // Zwift
+                            if (settings.fit_file_garmin_device_training_effect_device === 88888) return 114;  // Tacx
+                            if (settings.fit_file_garmin_device_training_effect_device === 99999) return 115;  // Zwift
                             return 20;  // Default to Edge 830
                         }
                         onCurrentIndexChanged: {
@@ -7217,7 +7219,8 @@ import Qt.labs.platform 1.1
                                 case 111: settings.fit_file_garmin_device_training_effect_device = 3224; break;  // VIVOACTIVE4_SMALL
                                 case 112: settings.fit_file_garmin_device_training_effect_device = 4426; break;  // VIVOACTIVE5
                                 case 113: settings.fit_file_garmin_device_training_effect_device = 4625; break;  // VIVOACTIVE6
-                                case 114: settings.fit_file_garmin_device_training_effect_device = 99999; break;  // Zwift
+                                case 114: settings.fit_file_garmin_device_training_effect_device = 88888; break;  // Tacx
+                                case 115: settings.fit_file_garmin_device_training_effect_device = 99999; break;  // Zwift
                             }
                         }
                         Layout.fillWidth: true


### PR DESCRIPTION
- Add Tacx option to Garmin device dropdown in settings.qml
- Use device ID 88888 for Tacx identification (similar to 99999 for Zwift)
- Configure qfit.cpp to use FIT_MANUFACTURER_TACX (89) and product ID 20533
- Set software version to 1.30 for Tacx device
- This allows FIT files to be recognized correctly by Garmin Connect for training metrics

Based on https://github.com/philosowaffle/peloton-to-garmin/issues/578