### PR TITLE
Fix MyWhoosh compatibility condition in dircon processor

### DIFF
--- a/src/devices/dircon/dirconprocessor.cpp
+++ b/src/devices/dircon/dirconprocessor.cpp
@@ -265,7 +265,8 @@ bool DirconProcessor::sendCharacteristicNotification(quint16 uuid, const QByteAr
     pkt.uuid = uuid;
     for (QHash<QTcpSocket *, DirconProcessorClient *>::iterator i = clientsMap.begin(); i != clientsMap.end(); ++i) {
         client = i.value();
-        if (client->char_notify.indexOf(uuid) >= 0 || settings.value(QZSettings::zwift_play_emulator, QZSettings::default_zwift_play_emulator).toBool()) {
+        if (!settings.value(QZSettings::wahoo_rgt_dircon, QZSettings::default_wahoo_rgt_dircon).toBool() ||
+            client->char_notify.indexOf(uuid) >= 0) {
             socket = i.key();
             rvs = socket->write(pkt.encode(0)) < 0;
             if (rvs)

--- a/src/settings.qml
+++ b/src/settings.qml
@@ -13287,6 +13287,34 @@ import Qt.labs.platform 1.1
                                 accordionContent: ColumnLayout {
                                     spacing: 0
 
+                                    IndicatorOnlySwitch {
+                                        id: wahooRGTDirconDelegate
+                                        text: qsTr("MyWhoosh Compatibility")
+                                        spacing: 0
+                                        bottomPadding: 0
+                                        topPadding: 0
+                                        rightPadding: 0
+                                        leftPadding: 0
+                                        clip: false
+                                        checked: settings.wahoo_rgt_dircon
+                                        Layout.alignment: Qt.AlignLeft | Qt.AlignTop
+                                        Layout.fillWidth: true
+                                        onClicked: { settings.wahoo_rgt_dircon = checked; window.settings_restart_to_apply = true; }
+                                    }
+
+                                    Label {
+                                        text: qsTr("Enables the compatibility of the Wahoo KICKR protocol to MyWhoosh app. Leave the MyWhoosh compatibility disabled in order to use Zwift.")
+                                        font.bold: true
+                                        font.italic: true
+                                        font.pixelSize: Qt.application.font.pixelSize - 2
+                                        textFormat: Text.PlainText
+                                        wrapMode: Text.WordWrap
+                                        verticalAlignment: Text.AlignVCenter
+                                        Layout.alignment: Qt.AlignLeft | Qt.AlignTop
+                                        Layout.fillWidth: true
+                                        color: Material.color(Material.Lime)
+                                    }
+
                                     RowLayout {
                                         spacing: 10
                                         Label {


### PR DESCRIPTION
This commit restores the MyWhoosh Compatibility toggle in settings and
fixes the notification logic in dirconprocessor.cpp to properly handle
MyWhoosh connections.

Changes:
- Restored MyWhoosh Compatibility toggle in settings.qml (wahoo_rgt_dircon)
- Modified notification condition in dirconprocessor.cpp:
  - When MyWhoosh compatibility is disabled: always send notifications (default behavior for Zwift)
  - When MyWhoosh compatibility is enabled: only send notifications if client has explicitly registered for them
- Removed dependency on zwift_play_emulator for this logic

Fixes #4119 and #4177