### PR TITLE
Add Merach NovaRow R50 to rower settings

### DIFF
--- a/src/devices/trxappgateusbrower/trxappgateusbrower.cpp
+++ b/src/devices/trxappgateusbrower/trxappgateusbrower.cpp
@@ -2,6 +2,7 @@
 #ifdef Q_OS_ANDROID
 #include "keepawakehelper.h"
 #endif
+#include "qzsettings.h"
 #include "virtualdevices/virtualbike.h"
 #include "virtualdevices/virtualrower.h"
 #include "virtualdevices/virtualtreadmill.h"
@@ -18,6 +19,7 @@ using namespace std::chrono_literals;
 
 trxappgateusbrower::trxappgateusbrower(bool noWriteResistance, bool noHeartService, int8_t bikeResistanceOffset,
                                                  double bikeResistanceGain) {
+    QSettings settings;
     m_watt.setType(metric::METRIC_WATT, deviceType());
     Speed.setType(metric::METRIC_SPEED);
     refresh = new QTimer(this);
@@ -25,6 +27,7 @@ trxappgateusbrower::trxappgateusbrower(bool noWriteResistance, bool noHeartServi
     this->noHeartService = noHeartService;
     this->bikeResistanceGain = bikeResistanceGain;
     this->bikeResistanceOffset = bikeResistanceOffset;
+    mearch_novarow_r50 = settings.value(QZSettings::merach_novarow_r50, QZSettings::default_merach_novarow_r50).toBool();
     initDone = false;
     connect(refresh, &QTimer::timeout, this, &trxappgateusbrower::update);
     refresh->start(200ms);
@@ -261,10 +264,8 @@ void trxappgateusbrower::characteristicChanged(const QLowEnergyCharacteristic &c
 
 void trxappgateusbrower::btinit() {
 
-    // Check if device is Mearch NovaRow R50 based on Bluetooth name
-    if (bluetoothDevice.name().toUpper().startsWith(QStringLiteral("MRK-R11S-"))) {
-        mearch_novarow_r50 = true;
-
+    // Check if Mearch NovaRow R50 setting is enabled
+    if (mearch_novarow_r50) {
         // Mearch NovaRow R50 initialization sequence to switch to Bluetooth mode
         uint8_t initData1[] = {0xf0, 0xa5, 0x44, 0x01, 0x04, 0xde};
         uint8_t initData2[] = {0xf0, 0xa0, 0x44, 0x01, 0xd5};

--- a/src/qzsettings.cpp
+++ b/src/qzsettings.cpp
@@ -884,6 +884,7 @@ const QString QZSettings::default_OSC_ip = QStringLiteral("");
 const QString QZSettings::OSC_port = QStringLiteral("osc_port");
 const QString QZSettings::strava_treadmill = QStringLiteral("strava_treadmill");
 const QString QZSettings::iconsole_rower = QStringLiteral("iconsole_rower");
+const QString QZSettings::merach_novarow_r50 = QStringLiteral("merach_novarow_r50");
 const QString QZSettings::proform_treadmill_1500_pro = QStringLiteral("proform_treadmill_1500_pro");
 const QString QZSettings::proform_505_cst_80_44 = QStringLiteral("proform_505_cst_80_44");
 const QString QZSettings::proform_trainer_8_0 = QStringLiteral("proform_trainer_8_0");
@@ -1047,7 +1048,7 @@ const QString QZSettings::skandika_wiri_x2000_protocol = QStringLiteral("skandik
 const QString QZSettings::trainprogram_auto_lap_on_segment = QStringLiteral("trainprogram_auto_lap_on_segment");
 
 
-const uint32_t allSettingsCount = 853;
+const uint32_t allSettingsCount = 854;
 
 QVariant allSettings[allSettingsCount][2] = {
     {QZSettings::cryptoKeySettingsProfiles, QZSettings::default_cryptoKeySettingsProfiles},
@@ -1782,6 +1783,7 @@ QVariant allSettings[allSettingsCount][2] = {
     {QZSettings::OSC_port, QZSettings::default_OSC_port},
     {QZSettings::strava_treadmill, QZSettings::default_strava_treadmill},
     {QZSettings::iconsole_rower, QZSettings::default_iconsole_rower},
+    {QZSettings::merach_novarow_r50, QZSettings::default_merach_novarow_r50},
     {QZSettings::proform_treadmill_1500_pro, QZSettings::default_proform_treadmill_1500_pro},
     {QZSettings::proform_505_cst_80_44, QZSettings::default_proform_505_cst_80_44},
     {QZSettings::proform_trainer_8_0, QZSettings::default_proform_trainer_8_0},

--- a/src/qzsettings.h
+++ b/src/qzsettings.h
@@ -2413,6 +2413,9 @@ class QZSettings {
     static const QString iconsole_rower;
     static constexpr bool default_iconsole_rower = false;
 
+    static const QString merach_novarow_r50;
+    static constexpr bool default_merach_novarow_r50 = false;
+
     static const QString proform_treadmill_1500_pro;
     static constexpr bool default_proform_treadmill_1500_pro = false;
 

--- a/src/settings.qml
+++ b/src/settings.qml
@@ -1270,6 +1270,7 @@ import Qt.labs.platform 1.1
 			property int tile_power_avg_order: 77
 			property bool life_fitness_ic5: false
 			property bool technogym_bike: false
+			property bool merach_novarow_r50: false
         }
 
 
@@ -10162,6 +10163,28 @@ import Qt.labs.platform 1.1
                                     Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
                                     onClicked: { settings.proform_rower_ip = proformRowerIPTextField.text; window.settings_restart_to_apply = true; toast.show("Setting saved!"); }
                                 }
+                            }
+                        }
+                    }
+
+                    AccordionElement {
+                        title: qsTr("Merach Rower Options")
+                        indicatRectColor: Material.color(Material.Grey)
+                        textColor: Material.color(Material.Yellow)
+                        color: Material.backgroundColor
+                        accordionContent: ColumnLayout {
+                            IndicatorOnlySwitch {
+                                text: qsTr("Merach NovaRow R50")
+                                spacing: 0
+                                bottomPadding: 0
+                                topPadding: 0
+                                rightPadding: 0
+                                leftPadding: 0
+                                clip: false
+                                checked: settings.merach_novarow_r50
+                                Layout.alignment: Qt.AlignLeft | Qt.AlignTop
+                                Layout.fillWidth: true
+                                onClicked: { settings.merach_novarow_r50 = checked; window.settings_restart_to_apply = true; }
                             }
                         }
                     }


### PR DESCRIPTION
Instead of auto-detecting the Merach NovaRow R50 based on the Bluetooth name prefix "MRK-R11S-", add a manual settings option that allows users to enable/disable the Merach NovaRow R50 protocol.

Changes:
- Added merach_novarow_r50 setting to qzsettings.h/cpp (default: false)
- Added "Merach Rower Options" section in settings.qml under "Rower Options"
- Added "Merach NovaRow R50" switch in the new section
- Updated trxappgateusbrower to load setting from QSettings in constructor
- Removed auto-detection logic from btinit() method
- Device will still be detected via Bluetooth but protocol selection now depends on the user-configurable setting

Related to issue #3593