### PR TITLE
Add Bodycraft T850 treadmill support to horizontreadmill

### DIFF
--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -1567,7 +1567,8 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                         (b.name().toUpper().startsWith(QStringLiteral("X-T"))) ||                            // FTMS (X-T421)
                         (b.name().toUpper().startsWith(QStringLiteral("TC-"))) ||                            // FTMS (Focus Fitness Jet 7 iPlus)
                         b.name().toUpper().startsWith(QStringLiteral("TM XP_")) ||                           // FTMS
-                        b.name().toUpper().startsWith(QStringLiteral("THERUN  T15"))                         // FTMS
+                        b.name().toUpper().startsWith(QStringLiteral("THERUN  T15")) ||                      // FTMS
+                        b.name().toUpper().startsWith(QStringLiteral("BODYCRAFT_"))                          // Bodycraft T850 Treadmill
                         ) &&
                        !horizonTreadmill && filter) {
                 this->setLastBluetoothDevice(b);


### PR DESCRIPTION
Added BODYCRAFT_ Bluetooth device name detection to the horizontreadmill
device class, enabling support for the Bodycraft T850 treadmill.

https://claude.ai/code/session_01RNoh5o3x2aWdcjbcNrYXtq