### PR TITLE
Add support for WT series treadmills

### DIFF
--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -1569,7 +1569,8 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                         (b.name().toUpper().startsWith(QStringLiteral("TC-"))) ||                            // FTMS (Focus Fitness Jet 7 iPlus)
                         b.name().toUpper().startsWith(QStringLiteral("TM XP_")) ||                           // FTMS
                         b.name().toUpper().startsWith(QStringLiteral("THERUN  T15")) ||                      // FTMS
-                        b.name().toUpper().startsWith(QStringLiteral("BODYCRAFT_"))                          // Bodycraft T850 Treadmill
+                        b.name().toUpper().startsWith(QStringLiteral("BODYCRAFT_")) ||                         // Bodycraft T850 Treadmill
+                        (b.name().toUpper().startsWith(QStringLiteral("WT")) && b.name().length() == 5 && b.name().midRef(2).toInt() > 0) // WT treadmill (e.g. WT703)
                         ) &&
                        !horizonTreadmill && filter) {
                 this->setLastBluetoothDevice(b);

--- a/src/devices/horizontreadmill/horizontreadmill.cpp
+++ b/src/devices/horizontreadmill/horizontreadmill.cpp
@@ -1261,7 +1261,7 @@ void horizontreadmill::forceSpeed(double requestSpeed) {
         if(BOWFLEX_T9) {
             requestSpeed *= miles_conversion;   // this treadmill wants the speed in miles, at least seems so!!
         }        
-        if(TM4800 || TM6500 || T3G_ELITE) {
+        if(TM4800 || TM6500 || T3G_ELITE || WT_TREADMILL) {
             bool miles = settings.value(QZSettings::miles_unit, QZSettings::default_miles_unit).toBool();
             if(miles) {
                 requestSpeed *= miles_conversion;   // these treadmills want the speed in miles when miles_unit is enabled
@@ -2698,6 +2698,9 @@ void horizontreadmill::deviceDiscovered(const QBluetoothDeviceInfo &device) {
             qDebug() << QStringLiteral("TM6500 treadmill found");
             TM6500 = true;
             minInclination = -3.0;
+        } else if (device.name().toUpper().startsWith(QStringLiteral("WT")) && device.name().length() == 5) {
+            qDebug() << QStringLiteral("WT treadmill found");
+            WT_TREADMILL = true;
         }
 
         if (device.name().toUpper().startsWith(QStringLiteral("TRX3500"))) {

--- a/src/devices/horizontreadmill/horizontreadmill.h
+++ b/src/devices/horizontreadmill/horizontreadmill.h
@@ -119,6 +119,7 @@ class horizontreadmill : public treadmill {
     bool T01 = false;
     bool TM4800 = false;
     bool TM6500 = false;
+    bool WT_TREADMILL = false;
 
     void testProfileCRC();
     void updateProfileCRC();


### PR DESCRIPTION
## Summary
This PR adds Bluetooth device discovery and speed unit handling support for WT series treadmills (e.g., WT703).

## Key Changes
- **Device Discovery**: Added WT treadmill detection in the Bluetooth device discovery filter with validation for device name format (5 characters starting with "WT" followed by numeric characters)
- **Speed Unit Handling**: Updated the `forceSpeed()` method to apply miles conversion for WT treadmills when the miles unit setting is enabled, consistent with other treadmill models (TM4800, TM6500, T3G_ELITE)
- **Device Tracking**: Added `WT_TREADMILL` boolean flag to track when a WT treadmill is connected

## Implementation Details
- WT treadmill detection validates that the device name is exactly 5 characters long and the last 3 characters form a valid positive integer
- Speed conversion logic mirrors existing behavior for similar treadmill models that require miles-based speed values
- Changes are minimal and focused, following existing code patterns for treadmill-specific handling

https://claude.ai/code/session_01GJXMLrS4sA9LFxSkASSwuU