### PR TITLE
Add iOS App Store build and publish workflow

### DIFF
--- a/.github/workflows/IOS_APP_STORE_SETUP.md
+++ b/.github/workflows/IOS_APP_STORE_SETUP.md
@@ -1,0 +1,138 @@
+# iOS App Store Workflow Setup
+
+This document explains how to configure the GitHub Actions workflow for building and publishing the iOS app to App Store Connect.
+
+## Prerequisites
+
+1. **Apple Developer Account** with App Store Connect access
+2. **Distribution Certificate** (.p12 file with private key)
+3. **Provisioning Profiles** for App Store distribution
+4. **App Store Connect API Key** for automated uploads
+
+## Required GitHub Secrets
+
+Go to your repository's **Settings → Secrets and variables → Actions** and add the following secrets:
+
+### Certificate & Signing
+
+| Secret Name | Description | How to Get It |
+|-------------|-------------|---------------|
+| `APPLE_CERTIFICATE_P12` | Base64 encoded distribution certificate | See "Exporting Certificate" below |
+| `APPLE_CERTIFICATE_PASSWORD` | Password for the .p12 file | Password you set when exporting |
+| `KEYCHAIN_PASSWORD` | Any secure password for temp keychain | Generate a random password |
+
+### Provisioning Profiles
+
+| Secret Name | Description | How to Get It |
+|-------------|-------------|---------------|
+| `APPLE_PROVISIONING_PROFILE` | Base64 encoded main app profile | Download from Apple Developer Portal |
+| `APPLE_PROVISIONING_PROFILE_WATCHKIT` | Base64 encoded WatchKit app profile | Download from Apple Developer Portal |
+| `APPLE_PROVISIONING_PROFILE_WATCHKIT_EXTENSION` | Base64 encoded WatchKit Extension profile | Download from Apple Developer Portal |
+
+### App Store Connect API
+
+| Secret Name | Description | How to Get It |
+|-------------|-------------|---------------|
+| `APP_STORE_CONNECT_API_KEY_ID` | API Key ID (e.g., "ABC123DEFG") | App Store Connect → Users and Access → Keys |
+| `APP_STORE_CONNECT_API_ISSUER_ID` | Issuer ID (UUID format) | App Store Connect → Users and Access → Keys |
+| `APP_STORE_CONNECT_API_KEY_P8` | Base64 encoded API Key (.p8 file) | See "Creating API Key" below |
+
+## Step-by-Step Setup
+
+### 1. Exporting Distribution Certificate
+
+1. Open **Keychain Access** on your Mac
+2. Find your "Apple Distribution" or "iPhone Distribution" certificate
+3. Right-click → **Export** → Save as .p12 with a password
+4. Convert to Base64:
+   ```bash
+   base64 -i certificate.p12 | pbcopy
+   ```
+5. Paste the result into `APPLE_CERTIFICATE_P12` secret
+
+### 2. Getting Provisioning Profiles
+
+1. Go to [Apple Developer Portal](https://developer.apple.com/account/resources/profiles/list)
+2. Download the **App Store** distribution profiles for:
+   - Main app: `org.cagnulein.qdomyoszwift`
+   - WatchKit app: `org.cagnulein.qdomyoszwift.watchkitapp`
+   - WatchKit Extension: `org.cagnulein.qdomyoszwift.watchkitapp.watchkitextension`
+3. Convert each to Base64:
+   ```bash
+   base64 -i profile.mobileprovision | pbcopy
+   ```
+4. Paste into the corresponding secrets
+
+### 3. Creating App Store Connect API Key
+
+1. Go to [App Store Connect → Users and Access → Integrations → App Store Connect API](https://appstoreconnect.apple.com/access/integrations/api)
+2. Click **+** to create a new key
+3. Give it a name (e.g., "GitHub Actions")
+4. Select **Admin** or **App Manager** access
+5. Download the .p8 file (you can only download it once!)
+6. Note the **Key ID** and **Issuer ID**
+7. Convert the .p8 to Base64:
+   ```bash
+   base64 -i AuthKey_XXXXXXXX.p8 | pbcopy
+   ```
+8. Add all three values to secrets
+
+### 4. Existing Secrets (Already Configured)
+
+These secrets should already exist for the CI build:
+- `strava_secret_key`
+- `peloton_secret_key`
+- `smtp_username`
+- `smtp_password`
+- `smtp_server`
+- `intervalsicu_client_id`
+- `intervalsicu_client_secret`
+- `cesiumkey`
+
+## Running the Workflow
+
+1. Go to **Actions** tab in your repository
+2. Select **iOS App Store** workflow
+3. Click **Run workflow**
+4. Options:
+   - **Upload to TestFlight**: Check to automatically upload after build
+   - **Build number increment**: Enter a new build number (optional)
+
+## Workflow Outputs
+
+- **IPA file**: Downloaded as artifact, stored for 30 days
+- **dSYM files**: For crash reporting, stored for 30 days
+- **TestFlight upload**: Automatic if selected
+
+## Troubleshooting
+
+### "No signing certificate found"
+- Verify the certificate is not expired
+- Ensure it's a Distribution certificate (not Development)
+- Check the Base64 encoding is correct
+
+### "Provisioning profile doesn't match"
+- Download fresh profiles from Apple Developer Portal
+- Ensure profiles are for App Store distribution
+- Verify bundle IDs match
+
+### "Invalid API Key"
+- Regenerate the key in App Store Connect
+- Check Key ID and Issuer ID are correct
+- Ensure the key has sufficient permissions
+
+## Manual Alternative
+
+If you prefer the manual process:
+
+1. Run the workflow with "Upload to TestFlight" unchecked
+2. Download the IPA artifact
+3. Use **Transporter** app on Mac to upload manually
+
+## Build Number Management
+
+The workflow can automatically update the build number. Enter a new build number in the workflow input, or leave empty to keep the current version from `project.pbxproj`.
+
+Current version info in project:
+- Marketing Version: 2.20
+- Current Build Number: 1274

--- a/.github/workflows/ios-app-store.yml
+++ b/.github/workflows/ios-app-store.yml
@@ -1,0 +1,222 @@
+# iOS App Store Build and Publish Workflow
+# This workflow builds the iOS app and uploads it to App Store Connect
+#
+# Required secrets:
+# - APPLE_CERTIFICATE_P12: Base64 encoded distribution certificate (.p12)
+# - APPLE_CERTIFICATE_PASSWORD: Password for the .p12 certificate
+# - APPLE_PROVISIONING_PROFILE: Base64 encoded provisioning profile (.mobileprovision)
+# - APPLE_PROVISIONING_PROFILE_WATCHKIT: Base64 encoded WatchKit provisioning profile
+# - APPLE_PROVISIONING_PROFILE_WATCHKIT_EXTENSION: Base64 encoded WatchKit Extension provisioning profile
+# - APP_STORE_CONNECT_API_KEY_ID: App Store Connect API Key ID
+# - APP_STORE_CONNECT_API_ISSUER_ID: App Store Connect API Issuer ID
+# - APP_STORE_CONNECT_API_KEY_P8: Base64 encoded App Store Connect API Key (.p8)
+# - KEYCHAIN_PASSWORD: A password for the temporary keychain
+
+name: iOS App Store
+
+on:
+  workflow_dispatch:
+    inputs:
+      upload_to_testflight:
+        description: 'Upload to TestFlight after build'
+        required: true
+        default: 'true'
+        type: boolean
+      build_number_increment:
+        description: 'Increment build number (leave empty to keep current)'
+        required: false
+        type: string
+
+env:
+  XCODE_PROJECT_PATH: 'build-qdomyos-zwift-Qt_5_15_2_for_iOS-Debug/qdomyoszwift.xcodeproj'
+  SCHEME_NAME: 'qdomyoszwift'
+  BUNDLE_ID: 'org.cagnulein.qdomyoszwift'
+  TEAM_ID: '6335M7T29D'
+
+jobs:
+  build-and-upload:
+    runs-on: macos-14
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout SmtpClient submodule
+        uses: actions/checkout@v4
+        with:
+          repository: bluetiger9/SmtpClient-for-Qt
+          path: "src/smtpclient/"
+          ref: 3fa4a0fe5797070339422cf18b5e9ed8dcb91f9c
+
+      - name: Checkout googletest submodule
+        uses: actions/checkout@v4
+        with:
+          repository: google/googletest
+          path: "tst/googletest/"
+          ref: "release-1.12.1"
+
+      - name: Select Xcode version
+        run: sudo xcode-select -s /Applications/Xcode_15.2.app
+
+      - name: Show Xcode version
+        run: xcodebuild -version
+
+      # Install Apple certificates and provisioning profiles
+      - name: Install Apple Certificate
+        env:
+          APPLE_CERTIFICATE_P12: ${{ secrets.APPLE_CERTIFICATE_P12 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          # Create variables
+          CERTIFICATE_PATH=$RUNNER_TEMP/certificate.p12
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+
+          # Decode certificate from base64
+          echo -n "$APPLE_CERTIFICATE_P12" | base64 --decode -o $CERTIFICATE_PATH
+
+          # Create temporary keychain
+          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+
+          # Import certificate to keychain
+          security import $CERTIFICATE_PATH -P "$APPLE_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security list-keychain -d user -s $KEYCHAIN_PATH
+
+      - name: Install Provisioning Profiles
+        env:
+          APPLE_PROVISIONING_PROFILE: ${{ secrets.APPLE_PROVISIONING_PROFILE }}
+          APPLE_PROVISIONING_PROFILE_WATCHKIT: ${{ secrets.APPLE_PROVISIONING_PROFILE_WATCHKIT }}
+          APPLE_PROVISIONING_PROFILE_WATCHKIT_EXTENSION: ${{ secrets.APPLE_PROVISIONING_PROFILE_WATCHKIT_EXTENSION }}
+        run: |
+          # Create Provisioning Profiles directory
+          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+
+          # Decode and install main app provisioning profile
+          echo -n "$APPLE_PROVISIONING_PROFILE" | base64 --decode -o ~/Library/MobileDevice/Provisioning\ Profiles/main.mobileprovision
+
+          # Decode and install WatchKit provisioning profile (if provided)
+          if [ -n "$APPLE_PROVISIONING_PROFILE_WATCHKIT" ]; then
+            echo -n "$APPLE_PROVISIONING_PROFILE_WATCHKIT" | base64 --decode -o ~/Library/MobileDevice/Provisioning\ Profiles/watchkit.mobileprovision
+          fi
+
+          # Decode and install WatchKit Extension provisioning profile (if provided)
+          if [ -n "$APPLE_PROVISIONING_PROFILE_WATCHKIT_EXTENSION" ]; then
+            echo -n "$APPLE_PROVISIONING_PROFILE_WATCHKIT_EXTENSION" | base64 --decode -o ~/Library/MobileDevice/Provisioning\ Profiles/watchkit_extension.mobileprovision
+          fi
+
+      # Increment build number if requested
+      - name: Increment Build Number
+        if: ${{ inputs.build_number_increment != '' }}
+        run: |
+          # Update CURRENT_PROJECT_VERSION in project.pbxproj
+          NEW_BUILD_NUMBER="${{ inputs.build_number_increment }}"
+          sed -i '' "s/CURRENT_PROJECT_VERSION = [0-9]*;/CURRENT_PROJECT_VERSION = $NEW_BUILD_NUMBER;/g" "$XCODE_PROJECT_PATH/project.pbxproj"
+          echo "Updated build number to: $NEW_BUILD_NUMBER"
+
+      # Create secrets file
+      - name: Create secrets file
+        run: |
+          cd src
+          echo "#define STRAVA_SECRET_KEY ${{ secrets.strava_secret_key }}" > secret.h
+          echo "#define PELOTON_SECRET_KEY ${{ secrets.peloton_secret_key }}" >> secret.h
+          echo "#define SMTP_USERNAME ${{ secrets.smtp_username }}" >> secret.h
+          echo "#define SMTP_PASSWORD ${{ secrets.smtp_password }}" >> secret.h
+          echo "#define SMTP_SERVER ${{ secrets.smtp_server }}" >> secret.h
+          echo "#define INTERVALSICU_CLIENT_ID ${{ secrets.intervalsicu_client_id }}" >> secret.h
+          echo "#define INTERVALSICU_CLIENT_SECRET ${{ secrets.intervalsicu_client_secret }}" >> secret.h
+          echo "${{ secrets.cesiumkey }}" >> inner_templates/googlemaps/cesium-key.js
+
+      # Build for Release (App Store)
+      - name: Build Archive
+        run: |
+          xcodebuild archive \
+            -project "$XCODE_PROJECT_PATH" \
+            -scheme "$SCHEME_NAME" \
+            -configuration Release \
+            -destination "generic/platform=iOS" \
+            -archivePath $RUNNER_TEMP/qdomyoszwift.xcarchive \
+            CODE_SIGN_STYLE=Manual \
+            DEVELOPMENT_TEAM=$TEAM_ID \
+            CODE_SIGN_IDENTITY="iPhone Distribution" \
+            -allowProvisioningUpdates
+
+      # Create ExportOptions.plist for App Store distribution
+      - name: Create ExportOptions
+        run: |
+          cat > $RUNNER_TEMP/ExportOptions.plist << EOF
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+              <key>method</key>
+              <string>app-store-connect</string>
+              <key>teamID</key>
+              <string>${TEAM_ID}</string>
+              <key>uploadSymbols</key>
+              <true/>
+              <key>destination</key>
+              <string>upload</string>
+          </dict>
+          </plist>
+          EOF
+
+      # Export IPA
+      - name: Export IPA
+        run: |
+          xcodebuild -exportArchive \
+            -archivePath $RUNNER_TEMP/qdomyoszwift.xcarchive \
+            -exportOptionsPlist $RUNNER_TEMP/ExportOptions.plist \
+            -exportPath $RUNNER_TEMP/export \
+            -allowProvisioningUpdates
+
+      # Setup App Store Connect API Key
+      - name: Setup App Store Connect API Key
+        if: ${{ inputs.upload_to_testflight == true }}
+        env:
+          APP_STORE_CONNECT_API_KEY_P8: ${{ secrets.APP_STORE_CONNECT_API_KEY_P8 }}
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+        run: |
+          mkdir -p ~/.appstoreconnect/private_keys
+          echo -n "$APP_STORE_CONNECT_API_KEY_P8" | base64 --decode -o ~/.appstoreconnect/private_keys/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8
+
+      # Upload to App Store Connect / TestFlight
+      - name: Upload to TestFlight
+        if: ${{ inputs.upload_to_testflight == true }}
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+        run: |
+          xcrun altool --upload-app \
+            --type ios \
+            --file "$RUNNER_TEMP/export/qdomyoszwift.ipa" \
+            --apiKey "$APP_STORE_CONNECT_API_KEY_ID" \
+            --apiIssuer "$APP_STORE_CONNECT_API_ISSUER_ID"
+
+      # Upload IPA as artifact (always, for backup)
+      - name: Upload IPA Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: qdomyoszwift-ipa
+          path: ${{ runner.temp }}/export/*.ipa
+          retention-days: 30
+
+      # Upload dSYM for crash reporting
+      - name: Upload dSYM Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: qdomyoszwift-dsym
+          path: ${{ runner.temp }}/qdomyoszwift.xcarchive/dSYMs
+          retention-days: 30
+
+      # Cleanup keychain
+      - name: Cleanup
+        if: always()
+        run: |
+          security delete-keychain $RUNNER_TEMP/app-signing.keychain-db || true
+          rm -f $RUNNER_TEMP/certificate.p12 || true
+          rm -rf ~/Library/MobileDevice/Provisioning\ Profiles/*.mobileprovision || true
+          rm -rf ~/.appstoreconnect || true


### PR DESCRIPTION
## Summary
This PR adds a complete GitHub Actions workflow for building and publishing the iOS app to App Store Connect/TestFlight, along with comprehensive setup documentation.

## Changes
- **New Workflow**: `ios-app-store.yml` - Automated CI/CD pipeline that:
  - Builds the iOS app for App Store distribution
  - Manages code signing with certificates and provisioning profiles
  - Exports IPA files
  - Optionally uploads to TestFlight via App Store Connect API
  - Supports manual build number increments
  - Preserves build artifacts (IPA and dSYM files) for 30 days

- **Setup Documentation**: `IOS_APP_STORE_SETUP.md` - Complete guide covering:
  - Prerequisites and required GitHub secrets
  - Step-by-step instructions for certificate export, provisioning profile setup, and API key creation
  - Workflow usage and options
  - Troubleshooting common issues
  - Manual alternative process using Transporter app

## Key Features
- **Manual Workflow Dispatch**: Triggered via GitHub Actions UI with optional inputs
- **Flexible Build Numbers**: Can increment build number on-demand or keep current version
- **Secure Credential Handling**: Uses GitHub secrets for all sensitive data (certificates, API keys, passwords)
- **Artifact Management**: Automatically uploads IPA and dSYM files for crash reporting
- **Optional TestFlight Upload**: Can build without uploading, or automatically push to TestFlight
- **Comprehensive Cleanup**: Removes temporary keychains and sensitive files after workflow completion

## Implementation Details
- Uses macOS 14 runner with Xcode 15.2
- Supports multi-target signing (main app, WatchKit app, WatchKit extension)
- Implements secure keychain management for code signing
- Includes proper error handling and conditional steps
- Leverages `xcrun altool` for App Store Connect uploads

https://claude.ai/code/session_01VD2HqWevobbytbN6GyK5gh