### PR TITLE
Fix Apple Watch battery drain and calorie tracking issue

### DIFF
--- a/build-qdomyos-zwift-Qt_5_15_2_for_iOS-Debug/watchkit Extension/MainController.swift
+++ b/build-qdomyos-zwift-Qt_5_15_2_for_iOS-Debug/watchkit Extension/MainController.swift
@@ -64,6 +64,8 @@ class MainController: WKInterfaceController {
         // This method is called when watch view controller is no longer visible
         super.didDeactivate()
         print("DID DEACTIVE")
+        // Stop pedometer updates when view is not visible to save battery
+        pedometer.stopUpdates()
     }
 }
 
@@ -85,6 +87,8 @@ extension MainController {
             MainController.start = false
             startButton.setTitle("Start")
             WorkoutTracking.shared.stopWorkOut()
+            // Stop pedometer updates when workout ends to save battery
+            pedometer.stopUpdates()
         }
     }
 }


### PR DESCRIPTION
The HKWorkoutSession was not being properly terminated in all cases,
causing the watch to think a workout was still active. This prevented
HealthKit from calculating passive calories throughout the day and
kept the app running in background, draining battery.

Changes:
- Refactored stopWorkOut() to always call endCollection/finishWorkout
  regardless of sample creation failures (removed early returns)
- Added CMPedometer.stopUpdates() in didDeactivate() and when user
  presses Stop to prevent background pedometer updates
- Added nil-safety check for workoutSession/workoutBuilder

https://claude.ai/code/session_01VTr4SETT4Kcs5yWRnJq7Wm