### PR TITLE
Add FTMS treadmill detection for Dynamax devices

### DIFF
--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -1348,11 +1348,11 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 this->signalBluetoothDeviceConnected(kingsmithR2Treadmill);
             } else if ((b.name().toUpper().startsWith(QStringLiteral("R1 PRO")) ||
                         b.name().toUpper().startsWith(QStringLiteral("KINGSMITH")) ||
-                        b.name().toUpper().startsWith(QStringLiteral("DYNAMAX")) ||
+                        (b.name().toUpper().startsWith(QStringLiteral("DYNAMAX")) && ftms_treadmill.contains(QZSettings::default_ftms_treadmill)) ||
                         b.name().toUpper().startsWith(QStringLiteral("WALKINGPAD")) ||
                         b.name().toUpper().startsWith(QStringLiteral("KS-ST-A1P")) ||  // KingSmith Walkingpad A1 Pro #2041
                         // Poland-distributed WalkingPad R2 TRR2FB
-                        b.name().toUpper().startsWith(QStringLiteral("KS-SC-BLR2C")) ||                        
+                        b.name().toUpper().startsWith(QStringLiteral("KS-SC-BLR2C")) ||
                         !b.name().toUpper().compare(QStringLiteral("RE")) || // just "RE"
                         b.name().toUpper().startsWith(QStringLiteral("KS-H")) ||
                         b.name().toUpper().startsWith(QStringLiteral("KS-F0")) ||

--- a/src/devices/kingsmithr1protreadmill/kingsmithr1protreadmill.cpp
+++ b/src/devices/kingsmithr1protreadmill/kingsmithr1protreadmill.cpp
@@ -1,4 +1,5 @@
 #include "kingsmithr1protreadmill.h"
+#include "homeform.h"
 
 #ifdef Q_OS_ANDROID
 #include "keepawakehelper.h"
@@ -483,6 +484,20 @@ void kingsmithr1protreadmill::serviceScanDone(void) {
     ignoreFirstPackage = true;
 
     gattCommunicationChannelService = m_control->createServiceObject(_gattCommunicationChannelServiceId);
+    if(!gattCommunicationChannelService) {
+        // Check if this device has FTMS service (0x1826)
+        QBluetoothUuid ftmsServiceId((quint16)0x1826);
+        QLowEnergyService *ftmsService = m_control->createServiceObject(ftmsServiceId);
+        if(ftmsService) {
+            QSettings settings;
+            settings.setValue(QZSettings::ftms_treadmill, bluetoothDevice.name());
+            qDebug() << "forcing FTMS treadmill since it has FTMS service but not the main kingsmith service";
+            if(homeform::singleton())
+                homeform::singleton()->setToastRequested("FTMS treadmill found, restart the app to apply the change");
+            delete ftmsService;
+        }
+        return;
+    }
     connect(gattCommunicationChannelService, &QLowEnergyService::stateChanged, this,
             &kingsmithr1protreadmill::stateChanged);
     gattCommunicationChannelService->discoverDetails();


### PR DESCRIPTION
## Summary
This PR adds automatic detection and handling of FTMS (Fitness Machine Service) treadmills, particularly for Dynamax devices that may expose the standard FTMS service instead of the proprietary KingSmith service.

## Key Changes
- **bluetooth.cpp**: Added logic to exclude Dynamax devices from KingSmith treadmill detection when FTMS treadmill mode is enabled, preventing device conflicts
- **kingsmithr1protreadmill.cpp**: 
  - Added `homeform.h` include for UI notifications
  - Implemented fallback detection: when a device lacks the main KingSmith GATT service but has the standard FTMS service (UUID 0x1826), the app now automatically:
    - Saves the device name to the FTMS treadmill settings
    - Logs a debug message indicating the device was identified as FTMS
    - Notifies the user via toast message to restart the app for changes to take effect
    - Gracefully returns without attempting to use the missing KingSmith service

## Implementation Details
The detection logic checks for the presence of the FTMS service (0x1826) when the expected KingSmith service is unavailable. This allows devices that support both protocols to be properly routed to the FTMS handler, improving device compatibility and user experience.

https://claude.ai/code/session_01Qpksc3Vsqz1MRgmEikZsNE