### PR TITLE
Add average speed to Garmin FIT session fields

### DIFF
--- a/src/qfit.cpp
+++ b/src/qfit.cpp
@@ -389,6 +389,9 @@ void qfit::save(const QString &filename, QList<SessionLine> session, BLUETOOTH_T
     sessionMesg.SetTotalMovingTime(session.last().elapsedTime);
     sessionMesg.SetTotalAscent(session.last().elevationGain);  // Total elevation gain (meters)
     sessionMesg.SetTotalDescent(session.last().negativeElevationGain);  // Total elevation loss/descent (meters)
+    if (speed_avg > 0) {
+        sessionMesg.SetAvgSpeed(speed_avg / 3.6);  // Convert from km/h to m/s
+    }
     sessionMesg.SetMinAltitude(min_alt);
     sessionMesg.SetMaxAltitude(max_alt);
     sessionMesg.SetEvent(FIT_EVENT_SESSION);


### PR DESCRIPTION
Added SetAvgSpeed to session message in qfit.cpp to include average speed
as a standard Garmin field. The speed is properly converted from km/h to m/s
to match FIT protocol requirements.

Note: Total ascent and total descent fields were already present in the
session section.

https://claude.ai/code/session_013LLnko3FBSGhMpccokusdC