### PR TITLE
Fix Garmin ConnectIQ crash with malformed messages

### DIFF
--- a/src/android/src/IQMessageReceiverWrapper.java
+++ b/src/android/src/IQMessageReceiverWrapper.java
@@ -31,8 +31,8 @@ public class IQMessageReceiverWrapper extends BroadcastReceiver {
 
         try {
             receiver.onReceive(context, intent);
-        } catch (IllegalArgumentException | BufferUnderflowException e) {
-            QLog.d(TAG, e.toString());
+        } catch (Exception e) {
+            QLog.d(TAG, "Exception in Garmin message receiver: " + e.toString());
         }
     }
 


### PR DESCRIPTION
Fixes app crash when receiving corrupted or malformed messages from Garmin ConnectIQ devices that cause IllegalArgumentException or BufferUnderflowException during deserialization.

Changes:
- IQMessageReceiverWrapper: Changed catch block from specific exception types to generic Exception to handle all deserialization errors including wrapped exceptions
- Garmin: Refactored initialization to create wrapped context BEFORE getInstance() call, ensuring ALL BroadcastReceivers registered by the SDK (including during getInstance) pass through the wrapper

Root cause: The SDK was receiving the original context in getInstance() before the wrapper was created, so some receivers bypassed the wrapper's exception handling. Now the wrapped context is created first and passed to both getInstance() and initialize().