### PR TITLE
Add virtual rower support to cscbike

### DIFF
--- a/src/devices/cscbike/cscbike.cpp
+++ b/src/devices/cscbike/cscbike.cpp
@@ -1,5 +1,6 @@
 #include "cscbike.h"
 #include "virtualdevices/virtualbike.h"
+#include "virtualdevices/virtualrower.h"
 #include <QBluetoothLocalDevice>
 #include <QDateTime>
 #include <QFile>
@@ -459,6 +460,8 @@ void cscbike::stateChanged(QLowEnergyService::ServiceState state) {
         QSettings settings;
         bool virtual_device_enabled =
             settings.value(QZSettings::virtual_device_enabled, QZSettings::default_virtual_device_enabled).toBool();
+        bool virtual_device_rower =
+            settings.value(QZSettings::virtual_device_rower, QZSettings::default_virtual_device_rower).toBool();
 #ifdef Q_OS_IOS
 #ifndef IO_UNDER_QT
         bool cadence =
@@ -473,11 +476,17 @@ void cscbike::stateChanged(QLowEnergyService::ServiceState state) {
 #endif
 #endif
             if (virtual_device_enabled) {
-            emit debug(QStringLiteral("creating virtual bike interface..."));
-            auto virtualBike = new virtualbike(this, noWriteResistance, noHeartService);
-            connect(virtualBike, &virtualbike::changeInclination, this, &cscbike::changeInclination);
-            // connect(virtualBike,&virtualbike::debug ,this,&cscbike::debug);
-            this->setVirtualDevice(virtualBike, VIRTUAL_DEVICE_MODE::PRIMARY);
+            if (virtual_device_rower) {
+                emit debug(QStringLiteral("creating virtual rower interface..."));
+                auto virtualRower = new virtualrower(this, noWriteResistance, noHeartService);
+                this->setVirtualDevice(virtualRower, VIRTUAL_DEVICE_MODE::ALTERNATIVE);
+            } else {
+                emit debug(QStringLiteral("creating virtual bike interface..."));
+                auto virtualBike = new virtualbike(this, noWriteResistance, noHeartService);
+                connect(virtualBike, &virtualbike::changeInclination, this, &cscbike::changeInclination);
+                // connect(virtualBike,&virtualbike::debug ,this,&cscbike::debug);
+                this->setVirtualDevice(virtualBike, VIRTUAL_DEVICE_MODE::PRIMARY);
+            }
         }
     }
     firstStateChanged = 1;


### PR DESCRIPTION
Enable the virtual_device_rower setting for cscbike, following the same
pattern used in other bike modules like echelonconnectsport.

https://claude.ai/code/session_01NCB7NrRQxR5fmmMmEeX4b3