### PR TITLE
Exclude Garmin username from debug logging

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -657,7 +657,7 @@ int main(int argc, char *argv[]) {
     qInstallMessageHandler(myMessageOutput);
     qDebug() << QStringLiteral("version ") << app->applicationVersion();
     foreach (QString s, settings.allKeys()) {
-        if (!s.contains(QStringLiteral("password")) && !s.contains("user_email") && !s.contains("username") && !s.contains("token")) {
+        if (!s.contains(QStringLiteral("password")) && !s.contains("user_email") && !s.contains("username") && !s.contains("token") && !s.contains("garmin_device_serial") && !s.contains("garmin_email")) {
 
             qDebug() << s << settings.value(s);
         }


### PR DESCRIPTION
## Summary
Updated the debug logging filter in main.cpp to exclude Garmin-related credentials from being logged, protecting sensitive user information.

## Changes
- Extended the settings key filter to exclude `garmin_device_serial` and `garmin_email` from debug output
- These sensitive fields are now treated the same as existing excluded credentials (password, user_email, username, and token)

## Details
The debug logging statement iterates through all application settings and logs them, but filters out known sensitive keys to prevent credentials from appearing in logs. This change adds two additional Garmin-specific credential fields to that exclusion list, ensuring they are not inadvertently exposed in debug output.

https://claude.ai/code/session_01Bb3K9KzcJGewehcn2x5RXe