### PR TITLE
Set FIT_SUB_SPORT_INDOOR_CYCLING for bike sessions when strava_virtual_activity is disabled.

### DIFF
--- a/src/qfit.cpp
+++ b/src/qfit.cpp
@@ -479,6 +479,8 @@ void qfit::save(const QString &filename, QList<SessionLine> session, BLUETOOTH_T
         sessionMesg.SetSport(FIT_SPORT_CYCLING);
         if (strava_virtual_activity) {
             sessionMesg.SetSubSport(FIT_SUB_SPORT_VIRTUAL_ACTIVITY);
+        } else {
+            sessionMesg.SetSubSport(FIT_SUB_SPORT_INDOOR_CYCLING);
         }
     }
 


### PR DESCRIPTION
When virtual activity setting is disabled for bikes, the FIT file now uses
the INDOOR_CYCLING subsport instead of leaving the subsport unset. This provides
better categorization for indoor bike sessions on platforms like Strava.

https://claude.ai/code/session_01JuNn3ZdhGBouwzkGKnfnFB