### PR TITLE
feat: Set Domyos treadmill minStepSpeed to 0.1

### DIFF
--- a/src/devices/domyostreadmill/domyostreadmill.cpp
+++ b/src/devices/domyostreadmill/domyostreadmill.cpp
@@ -983,3 +983,5 @@ bool domyostreadmill::connected() {
 }
 
 void domyostreadmill::searchingStop() { searchStopped = true; }
+
+double domyostreadmill::minStepSpeed() { return 0.1; }

--- a/src/devices/domyostreadmill/domyostreadmill.h
+++ b/src/devices/domyostreadmill/domyostreadmill.h
@@ -42,6 +42,7 @@ class domyostreadmill : public treadmill {
                     double forceInitSpeed = 0.0, double forceInitInclination = 0.0);
     bool connected() override;
     bool changeFanSpeed(uint8_t speed) override;
+    double minStepSpeed() override;
 
   private:
     // Structure for async write queue


### PR DESCRIPTION
Configure the Domyos treadmill virtual device with minStepSpeed of 0.1 km/h
to enable finer speed adjustments in the UI. This aligns the Domyos treadmill
behavior with other treadmill models like ZiPro, ProForm, and LifeFitness.

Fixes #4297
https://claude.ai/code/session_0189s4M7DBFmKdAyR7x8zDzP