### PR TITLE
Improve cadence detection for walking vs running on treadmill

### DIFF
--- a/src/devices/treadmill.cpp
+++ b/src/devices/treadmill.cpp
@@ -539,8 +539,19 @@ double treadmill::treadmillInclinationOverride(double Inclination) {
 }
 
 void treadmill::evaluateStepCount() {
-    // Auto-detect cadence format: if < 120, assume it's per-leg and needs doubling for step count
-    double effectiveCadence = (Cadence.value() < 120 && Cadence.value() > 0) ? Cadence.value() * 2 : Cadence.value();
+    // Auto-detect cadence format: if per-leg, needs doubling for step count
+    // Running (>6 km/h): double if cadence < 120
+    // Walking (<6 km/h): double if cadence < 60
+    double effectiveCadence = Cadence.value();
+
+    if (Speed.value() > 6.0 && Cadence.value() < 120 && Cadence.value() > 0) {
+        // Running: likely per-leg cadence, double it
+        effectiveCadence = Cadence.value() * 2;
+    } else if (Speed.value() > 0 && Speed.value() <= 6.0 && Cadence.value() < 60 && Cadence.value() > 0) {
+        // Walking: likely per-leg cadence, double it
+        effectiveCadence = Cadence.value() * 2;
+    }
+
     StepCount += (Cadence.lastChanged().msecsTo(QDateTime::currentDateTime())) * (effectiveCadence / 60000);
 }
 


### PR DESCRIPTION
## Summary
Enhanced the treadmill cadence auto-detection logic to differentiate between walking and running speeds, applying appropriate cadence doubling thresholds for each mode.

## Key Changes
- **Speed-aware cadence detection**: Replaced single cadence threshold (120 bpm) with speed-dependent logic
  - Running (>6 km/h): Double cadence if < 120 bpm (per-leg cadence detection)
  - Walking (≤6 km/h): Double cadence if < 60 bpm (per-leg cadence detection)
- **Improved accuracy**: The previous logic applied the same threshold regardless of activity type, which could lead to incorrect step count calculations for walkers
- **Better handling of edge cases**: Added explicit speed range checks to ensure proper categorization between walking and running modes

## Implementation Details
- The 6 km/h threshold is used as the boundary between walking and running speeds
- Cadence values are still validated to be greater than 0 before doubling
- The effective cadence is then used to calculate step count increments based on time elapsed since last cadence change

https://claude.ai/code/session_011Fczogh39fUbumfpsP74fU