### PR TITLE
Add background audio keep-alive for iOS to prevent app termination

### DIFF
--- a/src/ios/Info.plist
+++ b/src/ios/Info.plist
@@ -82,6 +82,7 @@
 	<string>access to step cadence in order to show it on the iphone</string>
 	<key>UIBackgroundModes</key>
 	<array>
+		<string>audio</string>
 		<string>bluetooth-central</string>
 		<string>bluetooth-peripheral</string>
 	</array>

--- a/src/ios/ios_app_delegate.mm
+++ b/src/ios/ios_app_delegate.mm
@@ -80,5 +80,17 @@
 performFetchWithCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler
 {
 }
+
+- (void)applicationDidEnterBackground:(UIApplication *)application
+{
+    lockscreen ls;
+    ls.startBackgroundAudio();
+}
+
+- (void)applicationWillEnterForeground:(UIApplication *)application
+{
+    lockscreen ls;
+    ls.stopBackgroundAudio();
+}
 @end
 #endif

--- a/src/ios/lockscreen.h
+++ b/src/ios/lockscreen.h
@@ -64,6 +64,10 @@ class lockscreen {
     // volume
     double getVolume();
 
+    // background audio (keep-alive when iOS would kill the app)
+    void startBackgroundAudio();
+    void stopBackgroundAudio();
+
     // garmin
     bool urlParser(const char *url);
     void garminconnect_init();

--- a/src/ios/lockscreen.mm
+++ b/src/ios/lockscreen.mm
@@ -11,6 +11,8 @@
 #include "ios/lockscreen.h"
 #include "devices/bluetoothdevice.h"
 #include <QDebug>
+#include <QSettings>
+#include "qzsettings.h"
 #include "ios/AdbClient.h"
 #include "ios/ios_eliteariafan.h"
 #include "ios/ios_echelonconnectsport.h"
@@ -427,6 +429,11 @@ double lockscreen::getVolume()
 
 void lockscreen::startBackgroundAudio()
 {
+    QSettings settings;
+    if (!settings.value(QZSettings::android_notification, QZSettings::default_android_notification).toBool()) {
+        return; // "Allow Background Mode" is disabled
+    }
+
     if (_bgAudioEngine && [_bgAudioEngine isRunning]) {
         return; // already running
     }

--- a/src/ios/lockscreen.mm
+++ b/src/ios/lockscreen.mm
@@ -56,6 +56,10 @@ static zwift_protobuf_layer* zwiftProtobufLayer = nil;
 
 static NSString* profile_selected;
 
+// Background audio keep-alive
+static AVAudioEngine* _bgAudioEngine = nil;
+static AVAudioPlayerNode* _bgPlayerNode = nil;
+
 bool lockscreen::appleWatchAppInstalled() {
     static int lastState = -1; // -1 = not initialized, 0 = not supported/not paired, 1 = paired but no app, 2 = paired with app
     
@@ -419,6 +423,72 @@ double lockscreen::getVolume()
 {
     [[AVAudioSession sharedInstance] setActive:true error:0];
     return [[AVAudioSession sharedInstance] outputVolume];
+}
+
+void lockscreen::startBackgroundAudio()
+{
+    if (_bgAudioEngine && [_bgAudioEngine isRunning]) {
+        return; // already running
+    }
+
+    NSError *sessionError = nil;
+    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback
+                                     withOptions:AVAudioSessionCategoryOptionMixWithOthers
+                                           error:&sessionError];
+    if (sessionError) {
+        NSLog(@"[QZ] startBackgroundAudio: setCategory error: %@", sessionError.localizedDescription);
+    }
+
+    [[AVAudioSession sharedInstance] setActive:YES error:&sessionError];
+    if (sessionError) {
+        NSLog(@"[QZ] startBackgroundAudio: setActive error: %@", sessionError.localizedDescription);
+    }
+
+    _bgAudioEngine = [[AVAudioEngine alloc] init];
+    _bgPlayerNode = [[AVAudioPlayerNode alloc] init];
+
+    [_bgAudioEngine attachNode:_bgPlayerNode];
+
+    AVAudioFormat *format = [[AVAudioFormat alloc] initStandardFormatWithSampleRate:44100 channels:2];
+    [_bgAudioEngine connect:_bgPlayerNode to:_bgAudioEngine.mainMixerNode format:format];
+
+    // Create a short silent PCM buffer and schedule it in an infinite loop
+    AVAudioFrameCount frameCount = 4410; // 0.1s at 44100 Hz
+    AVAudioPCMBuffer *silentBuffer = [[AVAudioPCMBuffer alloc] initWithPCMFormat:format frameCapacity:frameCount];
+    silentBuffer.frameLength = frameCount;
+    // Buffer memory is already zeroed (silent)
+
+    NSError *engineError = nil;
+    [_bgAudioEngine startAndReturnError:&engineError];
+    if (engineError) {
+        NSLog(@"[QZ] startBackgroundAudio: engine start error: %@", engineError.localizedDescription);
+        _bgAudioEngine = nil;
+        _bgPlayerNode = nil;
+        return;
+    }
+
+    [_bgPlayerNode scheduleBuffer:silentBuffer atTime:nil options:AVAudioPlayerNodeBufferLoops completionHandler:nil];
+    [_bgPlayerNode play];
+
+    NSLog(@"[QZ] Background audio keep-alive started");
+}
+
+void lockscreen::stopBackgroundAudio()
+{
+    if (_bgPlayerNode) {
+        [_bgPlayerNode stop];
+        _bgPlayerNode = nil;
+    }
+    if (_bgAudioEngine) {
+        [_bgAudioEngine stop];
+        _bgAudioEngine = nil;
+    }
+
+    [[AVAudioSession sharedInstance] setActive:NO
+                                   withOptions:AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation
+                                         error:nil];
+
+    NSLog(@"[QZ] Background audio keep-alive stopped");
 }
 
 void lockscreen::debug(const char* debugstring) {

--- a/src/settings.qml
+++ b/src/settings.qml
@@ -14175,7 +14175,7 @@ import Qt.labs.platform 1.1
 
                     IndicatorOnlySwitch {
                         id: androidNotificationDelegate
-                        text: qsTr("Android Notification")
+                        text: qsTr("Allow Background Mode")
                         spacing: 0
                         bottomPadding: 0
                         topPadding: 0
@@ -14189,7 +14189,7 @@ import Qt.labs.platform 1.1
                     }
 
                     Label {
-                        text: qsTr("Android Only: enable this to force Android to don't kill QZ when it's running on background")
+                        text: qsTr("On Android, adds a persistent notification to prevent QZ from being killed in the background. On iOS, plays silent audio to keep the app alive in the background.")
                         font.bold: true
                         font.italic: true
                         font.pixelSize: Qt.application.font.pixelSize - 2


### PR DESCRIPTION
## Summary
Implements a background audio keep-alive mechanism for iOS to prevent the app from being terminated when running in the background. This complements the existing Android notification-based approach with a platform-specific solution for iOS.

## Key Changes
- **Background audio implementation**: Added `startBackgroundAudio()` and `stopBackgroundAudio()` methods to the `lockscreen` class that manage an `AVAudioEngine` playing silent audio in a loop
- **App lifecycle integration**: Connected the background audio to app lifecycle events via `applicationDidEnterBackground:` and `applicationWillEnterForeground:` delegates in `ios_app_delegate.mm`
- **Settings integration**: The background audio feature respects the existing "Allow Background Mode" setting (previously labeled "Android Notification")
- **iOS capabilities**: Added `audio` to the `UIBackgroundModes` in `Info.plist` to enable background audio execution
- **UI/UX updates**: Updated the settings label and description to clarify that the feature now applies to both Android (persistent notification) and iOS (silent background audio)

## Implementation Details
- Uses `AVAudioEngine` with an `AVAudioPlayerNode` to play a short (0.1s) silent PCM buffer in an infinite loop
- Properly configures the `AVAudioSession` with `AVAudioSessionCategoryPlayback` and `MixWithOthers` option to allow background audio without interrupting other audio
- Includes error handling and logging for audio engine initialization
- Gracefully handles cases where the feature is disabled or already running
- Cleans up audio resources when the app returns to foreground

https://claude.ai/code/session_017EdDE8odeuvJVrHaE5hA6P