### PR TITLE
ci: fix RPi build compatibility (ARMv6 + glibc) and add smoke tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1085,7 +1085,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ runner.workspace }}\vcpkg\installed
-          key: vcpkg-msvc2019-x64-windows-${{ hashFiles('.github/workflows/main.yml') }}
+          key: vcpkg-msvc2019-x64-windows-${{ hashFiles('vcpkg-deps.json') }}
 
       - name: Clone vcpkg
         if: steps.cache-vcpkg-msvc2019.outputs.cache-hit != 'true'
@@ -1100,17 +1100,7 @@ jobs:
       - name: Create vcpkg.json
         if: steps.cache-vcpkg-msvc2019.outputs.cache-hit != 'true'
         working-directory: ${{ runner.workspace }}
-        run: |
-          echo '{
-            "name": "qdomyos-zwift",
-            "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
-            "dependencies": [
-              "protobuf",
-              "protobuf-c",
-              "abseil"
-            ],
-            "builtin-baseline": "8c2fcacefba009d63672f9d137f192765e632c9f"
-          }' > vcpkg.json
+        run: cp ${{ github.workspace }}/vcpkg-deps.json vcpkg.json
 
       - name: Install dependencies
         if: steps.cache-vcpkg-msvc2019.outputs.cache-hit != 'true'
@@ -1288,7 +1278,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ runner.workspace }}\vcpkg\installed
-          key: vcpkg-msvc2019-x64-windows-${{ hashFiles('.github/workflows/main.yml') }}
+          key: vcpkg-msvc2019-x64-windows-${{ hashFiles('vcpkg-deps.json') }}
 
       - name: Clone vcpkg
         if: steps.cache-vcpkg-aiserver.outputs.cache-hit != 'true'
@@ -1303,17 +1293,7 @@ jobs:
       - name: Create vcpkg.json
         if: steps.cache-vcpkg-aiserver.outputs.cache-hit != 'true'
         working-directory: ${{ runner.workspace }}
-        run: |
-          echo '{
-            "name": "qdomyos-zwift",
-            "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
-            "dependencies": [
-              "protobuf",
-              "protobuf-c",
-              "abseil"
-            ],
-            "builtin-baseline": "8c2fcacefba009d63672f9d137f192765e632c9f"
-          }' > vcpkg.json
+        run: cp ${{ github.workspace }}/vcpkg-deps.json vcpkg.json
 
       - name: Install dependencies
         if: steps.cache-vcpkg-aiserver.outputs.cache-hit != 'true'
@@ -1409,11 +1389,11 @@ jobs:
             "
 
       - name: Rename binary
-        run: mv src/qdomyos-zwift src/qdomyos-zwift-32bit
+        run: mv src/qdomyos-zwift src/qdomyos-zwift-armv6hf
 
       - name: Verify 32-bit binary targets ARMv6
         run: |
-          ARCH=$(readelf -A src/qdomyos-zwift-32bit | grep 'Tag_CPU_arch:' | awk '{print $2}')
+          ARCH=$(readelf -A src/qdomyos-zwift-armv6hf | grep 'Tag_CPU_arch:' | awk '{print $2}')
           echo "Binary CPU architecture: $ARCH"
           if [ "$ARCH" != "v6" ]; then
             echo "::error::Binary targets $ARCH but must target v6 for Pi Zero W compatibility"
@@ -1423,8 +1403,8 @@ jobs:
       - name: Archive Raspberry Pi binary
         uses: actions/upload-artifact@v4
         with:
-          name: raspberry-pi-binary
-          path: src/qdomyos-zwift-32bit
+          name: raspberry-pi-binary-armv6hf
+          path: src/qdomyos-zwift-armv6hf
 
   raspberry-pi-build-and-image-64bit:
     runs-on: ubuntu-22.04-arm
@@ -1469,11 +1449,11 @@ jobs:
             "
 
       - name: Rename binary
-        run: mv src/qdomyos-zwift src/qdomyos-zwift-64bit
+        run: mv src/qdomyos-zwift src/qdomyos-zwift-aarch64
 
       - name: Verify 64-bit binary glibc compatibility
         run: |
-          MAX_GLIBC=$(readelf -V src/qdomyos-zwift-64bit | grep -oP 'GLIBC_\K[0-9.]+' | sort -V | tail -1)
+          MAX_GLIBC=$(readelf -V src/qdomyos-zwift-aarch64 | grep -oP 'GLIBC_\K[0-9.]+' | sort -V | tail -1)
           echo "Max required GLIBC version: $MAX_GLIBC"
           if dpkg --compare-versions "$MAX_GLIBC" gt "2.31"; then
             echo "::error::Binary requires GLIBC $MAX_GLIBC but Raspberry Pi OS Bullseye only has 2.31"
@@ -1483,46 +1463,90 @@ jobs:
       - name: Archive Raspberry Pi 64bit binary
         uses: actions/upload-artifact@v4
         with:
-          name: raspberry-pi-binary-64bit
-          path: src/qdomyos-zwift-64bit
+          name: raspberry-pi-binary-aarch64
+          path: src/qdomyos-zwift-aarch64
 
   raspberry-pi-smoke-test:
     runs-on: ubuntu-22.04-arm
     needs: [raspberry-pi-build, raspberry-pi-build-and-image-64bit]
 
     steps:
-      - name: Download 32-bit binary
+      - name: Download armv6hf binary
         uses: actions/download-artifact@v4
         with:
-          name: raspberry-pi-binary
+          name: raspberry-pi-binary-armv6hf
           path: bin32
 
-      - name: Download 64-bit binary
+      - name: Download aarch64 binary
         uses: actions/download-artifact@v4
         with:
-          name: raspberry-pi-binary-64bit
+          name: raspberry-pi-binary-aarch64
           path: bin64
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
-      - name: Smoke test 32-bit binary (ARMv6 - Pi Zero W)
+      - name: ELF metadata checks for armv6hf binary (Pi Zero W)
         timeout-minutes: 5
         run: |
-          chmod +x bin32/qdomyos-zwift-32bit
-          file bin32/qdomyos-zwift-32bit
-          readelf -A bin32/qdomyos-zwift-32bit | grep -E 'Tag_CPU|Tag_FP'
-          ARCH=$(readelf -A bin32/qdomyos-zwift-32bit | grep 'Tag_CPU_arch:' | awk '{print $2}')
+          chmod +x bin32/qdomyos-zwift-armv6hf
+          file bin32/qdomyos-zwift-armv6hf
+          readelf -A bin32/qdomyos-zwift-armv6hf | grep -E 'Tag_CPU|Tag_FP|Tag_ABI'
+
+          # Check CPU architecture is ARMv6
+          ARCH=$(readelf -A bin32/qdomyos-zwift-armv6hf | grep 'Tag_CPU_arch:' | awk '{print $2}')
           if [ "$ARCH" != "v6" ]; then
-            echo "::error::32-bit binary targets $ARCH, expected v6"
+            echo "::error::Binary targets $ARCH, expected v6"
             exit 1
           fi
-          echo "SUCCESS: 32-bit binary is a valid ARMv6 ELF"
+          echo "PASS: CPU architecture is ARMv6"
 
-      - name: Smoke test 64-bit binary (ARM64 Bullseye - Pi 3/4/5)
+          # Check hard-float ABI
+          VFP=$(readelf -A bin32/qdomyos-zwift-armv6hf | grep 'Tag_ABI_VFP_args:' | awk '{print $2}')
+          if [ "$VFP" != "VFP" ]; then
+            echo "::error::Binary does not use hard-float ABI (Tag_ABI_VFP_args: $VFP)"
+            exit 1
+          fi
+          echo "PASS: Hard-float ABI (VFP registers)"
+
+          # Check dynamic linker / interpreter path
+          INTERP=$(readelf -l bin32/qdomyos-zwift-armv6hf | grep 'interpreter:' | grep -oP '/[^\]]+')
+          if [ "$INTERP" != "/lib/ld-linux-armhf.so.3" ]; then
+            echo "::error::Wrong interpreter: $INTERP, expected /lib/ld-linux-armhf.so.3"
+            exit 1
+          fi
+          echo "PASS: Interpreter is /lib/ld-linux-armhf.so.3"
+
+          echo "SUCCESS: All armv6hf ELF metadata checks passed"
+
+      - name: Runtime smoke test armv6hf binary
+        timeout-minutes: 10
+        continue-on-error: true
+        run: |
+          docker run --rm --platform linux/arm/v6 \
+            -v ${{ github.workspace }}/bin32:/app \
+            balenalib/raspberry-pi-debian:bullseye-run \
+            bash -c "
+              for i in 1 2 3; do apt-get update && break || sleep 5; done
+              for i in 1 2 3; do apt-get install -y --no-install-recommends \
+                libqt5core5a libqt5bluetooth5 libqt5charts5 libqt5widgets5 \
+                libqt5network5 libqt5websockets5 libqt5xml5 libqt5sql5 \
+                libqt5multimedia5 libqt5positioning5 libqt5qml5 libqt5quick5 \
+                libqt5texttospeech5 libqt5networkauth5 libqt5gui5 || true && break || sleep 5; done
+              OUTPUT=\$(/app/qdomyos-zwift-armv6hf -no-gui -smoke-test 2>&1) || true
+              echo \"\$OUTPUT\"
+              if echo \"\$OUTPUT\" | grep -q 'SMOKE_OK'; then
+                echo 'SUCCESS: armv6hf binary runs and Qt runtime loads'
+              else
+                echo '::error::armv6hf runtime smoke test failed - SMOKE_OK not found'
+                exit 1
+              fi
+            "
+
+      - name: Runtime smoke test aarch64 binary (ARM64 Bullseye - Pi 3/4/5)
         timeout-minutes: 10
         run: |
-          chmod +x bin64/qdomyos-zwift-64bit
+          chmod +x bin64/qdomyos-zwift-aarch64
           docker run --rm -v ${{ github.workspace }}/bin64:/app \
             arm64v8/debian:bullseye-20241016 \
             bash -c "
@@ -1531,11 +1555,12 @@ jobs:
                 libqt5network5 libqt5websockets5 libqt5xml5 libqt5sql5 \
                 libqt5multimedia5 libqt5positioning5 libqt5qml5 libqt5quick5 \
                 libqt5texttospeech5 libqt5networkauth5 libqt5gui5 || true
-              timeout -s KILL 30 /app/qdomyos-zwift-64bit -no-gui -heart-service 2>&1 || EXIT_CODE=\$?
-              if [ \"\${EXIT_CODE:-0}\" -eq 137 ] || [ \"\${EXIT_CODE:-0}\" -eq 124 ] || [ \"\${EXIT_CODE:-0}\" -eq 0 ]; then
-                echo 'SUCCESS: Binary runs on ARM64 Bullseye (headless mode)'
+              OUTPUT=\$(/app/qdomyos-zwift-aarch64 -no-gui -smoke-test 2>&1) || true
+              echo \"\$OUTPUT\"
+              if echo \"\$OUTPUT\" | grep -q 'SMOKE_OK'; then
+                echo 'SUCCESS: aarch64 binary runs on ARM64 Bullseye'
               else
-                echo \"FAILURE: Binary crashed with exit code \$EXIT_CODE\"
+                echo '::error::aarch64 runtime smoke test failed - SMOKE_OK not found'
                 exit 1
               fi
             "
@@ -1627,7 +1652,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ runner.workspace }}\vcpkg\installed
-          key: vcpkg-msvc2022-x64-windows-${{ hashFiles('.github/workflows/main.yml') }}
+          key: vcpkg-msvc2022-x64-windows-${{ hashFiles('vcpkg-deps.json') }}
 
       - name: Clone vcpkg
         if: steps.cache-vcpkg-msvc2022.outputs.cache-hit != 'true'
@@ -1642,17 +1667,7 @@ jobs:
       - name: Create vcpkg.json
         if: steps.cache-vcpkg-msvc2022.outputs.cache-hit != 'true'
         working-directory: ${{ runner.workspace }}
-        run: |
-          echo '{
-            "name": "qdomyos-zwift",
-            "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
-            "dependencies": [
-              "protobuf",
-              "protobuf-c",
-              "abseil"
-            ],
-            "builtin-baseline": "8c2fcacefba009d63672f9d137f192765e632c9f"
-          }' > vcpkg.json
+        run: cp ${{ github.workspace }}/vcpkg-deps.json vcpkg.json
 
       - name: Install dependencies
         if: steps.cache-vcpkg-msvc2022.outputs.cache-hit != 'true'
@@ -2057,7 +2072,7 @@ jobs:
     permissions: write-all
     runs-on: ubuntu-22.04 
     if: github.event_name == 'schedule'
-    needs: [window-msvc2019-build, window-msvc2022-build, window-build, android-build, raspberry-pi-build, nordictrack-build, peloton-bike-plus-build, peloton-bike-build, raspberry-pi-build-and-image-64bit]
+    needs: [window-msvc2019-build, window-msvc2022-build, window-build, android-build, raspberry-pi-build, nordictrack-build, peloton-bike-plus-build, peloton-bike-build, raspberry-pi-build-and-image-64bit, raspberry-pi-smoke-test]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -2098,7 +2113,8 @@ jobs:
             - **nordictrack-rower-android-trial**: Nordictrack Rower build for iFIT2 Tablets
             - **peloton-bike-plus-android-trial**: Peloton Bike Plus build with Grupetto backend
             - **peloton-bike-android-trial**: Peloton Bike build with Grupetto backend
-            - **raspberry-pi-binary**: Raspberry Pi build
+            - **raspberry-pi-binary-armv6hf**: Raspberry Pi 32-bit (ARMv6 hard-float, Pi Zero W compatible)
+            - **raspberry-pi-binary-aarch64**: Raspberry Pi 64-bit (AArch64, Pi 3/4/5)
 
             __Please help us improve QZ by reporting any issues you encounter!__ :wink:
           files: |
@@ -2115,5 +2131,5 @@ jobs:
             nordictrack-rower-android-trial/android-debug-nordictrack-rower.apk
             peloton-bike-plus-android-trial/android-debug-peloton-bike-plus.apk
             peloton-bike-android-trial/android-debug-peloton-bike.apk
-            raspberry-pi-binary/qdomyos-zwift-32bit
-            raspberry-pi-binary/qdomyos-zwift-64bit
+            raspberry-pi-binary-armv6hf/qdomyos-zwift-armv6hf
+            raspberry-pi-binary-aarch64/qdomyos-zwift-aarch64

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -96,6 +96,7 @@ int8_t bikeResistanceOffset = 4;
 double bikeResistanceGain = 1.0;
 QString power_sensor_name = QStringLiteral("Disabled");
 bool power_sensor_as_treadmill = false;
+bool smokeTest = false;
 QString logfilename = QStringLiteral("debug-") +
                       QDateTime::currentDateTime()
                           .toString()
@@ -160,6 +161,7 @@ void displayHelp() {
     printf("  -test-peloton                 Enable Peloton test mode\n");
     printf("  -test-hfb                     Enable Home Fitness Buddy test mode\n");
     printf("  -test-pzp                     Enable Power Zone Pack test mode\n");
+    printf("  -smoke-test                   Run smoke test (verify Qt loads, print SMOKE_OK, exit)\n");
     printf("  -train <program>              Specify training program\n");
 
     printf("\nPeloton options:\n");
@@ -324,6 +326,10 @@ QCoreApplication *createApplication(int &argc, char *argv[]) {
             testHomeFitnessBudy = true;
         if (!qstrcmp(argv[i], "-test-pzp"))
             testPowerZonePack = true;
+        if (!qstrcmp(argv[i], "-smoke-test")) {
+            smokeTest = true;
+            nogui = true;
+        }
         if (!qstrcmp(argv[i], "-train")) {
 
             trainProgram = argv[++i];
@@ -531,7 +537,7 @@ int main(int argc, char *argv[]) {
 
 #ifdef Q_OS_LINUX
 #ifndef Q_OS_ANDROID
-    if (getuid() && !testPeloton && !testHomeFitnessBudy && !testPowerZonePack) {
+    if (getuid() && !testPeloton && !testHomeFitnessBudy && !testPowerZonePack && !smokeTest) {
 
         printf("Runme as root!\n");
         return -1;
@@ -539,6 +545,11 @@ int main(int argc, char *argv[]) {
         printf("%s", "OK, you are root.\n");
 #endif
 #endif
+
+    if (smokeTest) {
+        printf("SMOKE_OK\n");
+        return 0;
+    }
 
     app->setOrganizationName(QStringLiteral("Roberto Viola"));
     app->setOrganizationDomain(QStringLiteral("robertoviola.cloud"));

--- a/vcpkg-deps.json
+++ b/vcpkg-deps.json
@@ -1,0 +1,10 @@
+{
+  "name": "qdomyos-zwift",
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "dependencies": [
+    "protobuf",
+    "protobuf-c",
+    "abseil"
+  ],
+  "builtin-baseline": "8c2fcacefba009d63672f9d137f192765e632c9f"
+}


### PR DESCRIPTION
## Summary

### Raspberry Pi build fixes

- **Fix 32-bit RPi for Pi Zero W** (fixes #4325): switch to `balenalib/raspberry-pi-debian:bullseye-build` container which uses Raspbian repos where GCC, CRT, Qt5, and glibc all target ARMv6 natively. The previous `arm32v7/debian` container produced ARMv7 binaries incompatible with the Pi Zero W's ARMv6 CPU (ARM1176JZF-S). ARMv6 binaries remain forward-compatible with all newer Pi models (2/3/4/5).
- **Fix 64-bit RPi glibc regression** from #4315: restore `arm64v8/debian:bullseye` Docker container so the binary links against glibc ≤2.31. The CI optimization PR switched to native `ubuntu-22.04-arm` (glibc 2.35), breaking Raspberry Pi OS Bullseye compatibility. The ARM64 runner is kept for speed (runs arm64 Docker natively, no QEMU).
- **Rename artifacts** from `32bit`/`64bit` to `armv6hf`/`aarch64` to clearly reflect target architectures.

### CI verification improvements

- **Add `readelf` verification steps** after both RPi builds to catch regressions:
  - 32-bit: assert `Tag_CPU_arch: v6`
  - 64-bit: assert max GLIBC ≤ 2.31
- **Add `raspberry-pi-smoke-test` job**: downloads both binaries and runs them in Docker containers matching target hardware. Checks ELF metadata (CPU arch, hard-float ABI, interpreter path) and runs the binary with `-smoke-test` to verify Qt loads without SIGILL/SIGSEGV. 32-bit smoke test is `continue-on-error` due to QEMU arm/v6 slowness.
- **Gate `upload_to_release`** on smoke test passing.

### Application change

- **Add `-smoke-test` CLI flag** (`src/main.cpp`): initializes `QCoreApplication`, prints `SMOKE_OK`, and exits cleanly. Bypasses the root check on Linux, requires no Bluetooth hardware — designed for deterministic CI verification.

### vcpkg cache fix

- **Extract vcpkg deps to `vcpkg-deps.json`** and use `hashFiles('vcpkg-deps.json')` as cache key, replacing the static `protobuf-abseil-v1` key. Cache now invalidates automatically when dependencies or baseline change.

### Root cause analysis for #4325

The `arm32v7/debian:bullseye` Docker image has always produced ARMv7 binaries (`Tag_CPU_arch: v7` confirmed via `readelf`), but the Pi Zero W has an ARMv6 CPU. The "illegal instruction" vs "segfault" difference between versions is because some 32-bit Thumb-2 instructions decode differently on ARMv6 — some trap as undefined (SIGILL), others decode as two 16-bit instructions with wrong operands (SIGSEGV). This predates the CI optimization PR #4315.

However, #4315 **did** introduce a separate 64-bit regression: switching from Docker to native `ubuntu-22.04-arm` raised the glibc requirement from 2.31 to 2.35, breaking Bullseye.

## Test plan

- [x] RPi 32-bit build succeeds
- [x] `readelf -A` shows `Tag_CPU_arch: v6` (not v7)
- [x] RPi 64-bit build succeeds
- [x] `readelf -V` shows max GLIBC ≤ 2.31
- [x] Smoke test job passes (ELF metadata + runtime checks)
- [x] vcpkg cache uses content-based key
- [ ] End-to-end: run 32-bit binary on Pi Zero W without crash

Fixes #4325

🤖 Generated with [Claude Code](https://claude.com/claude-code)