### PR TITLE
Add FTMS elliptical filter check for Sole device discovery

### DIFF
--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -1269,7 +1269,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                         b.name().toUpper().startsWith(QStringLiteral("E98")) ||
                         b.name().toUpper().startsWith(QStringLiteral("XG400")) ||
                         b.name().toUpper().startsWith(QStringLiteral("E98S"))) &&
-                       !soleElliptical && filter) {
+                       !soleElliptical && ftms_elliptical.contains(QZSettings::default_ftms_elliptical) && filter) {
                 this->setLastBluetoothDevice(b);
                 this->stopDiscovery();
                 soleElliptical = new soleelliptical(noWriteResistance, noHeartService, testResistance,


### PR DESCRIPTION
## Summary
Added an additional filter condition when discovering Sole elliptical devices via Bluetooth to check if the device matches the default FTMS elliptical setting.

## Key Changes
- Modified the device discovery logic in `bluetooth::deviceDiscovered()` to include a check for `ftms_elliptical.contains(QZSettings::default_ftms_elliptical)` alongside existing filter conditions
- This ensures that Sole elliptical devices (E98, XG400, E98S variants) are only auto-connected when they match the configured FTMS elliptical settings

## Implementation Details
- The new condition is added to the existing device name matching logic for Sole elliptical devices
- The check is performed before device initialization and discovery stop, ensuring proper filtering at the discovery stage
- This prevents unintended connections to Sole devices that don't match the user's FTMS elliptical configuration

https://claude.ai/code/session_01NGQPJnypFiD8jWWy3FasJL