### PR TITLE
Add step count gain multiplier setting for cadence calibration

### DIFF
--- a/src/devices/treadmill.cpp
+++ b/src/devices/treadmill.cpp
@@ -552,7 +552,10 @@ void treadmill::evaluateStepCount() {
         effectiveCadence = Cadence.value() * 2;
     }
 
-    StepCount += (Cadence.lastChanged().msecsTo(QDateTime::currentDateTime())) * (effectiveCadence / 60000);
+    QSettings settings;
+    double step_gain = settings.value(QZSettings::step_gain, QZSettings::default_step_gain).toDouble();
+
+    StepCount += (Cadence.lastChanged().msecsTo(QDateTime::currentDateTime())) * (effectiveCadence / 60000) * step_gain;
 }
 
 bool treadmill::cadenceFromAppleWatch() {

--- a/src/qzsettings.cpp
+++ b/src/qzsettings.cpp
@@ -1055,9 +1055,10 @@ const QString QZSettings::proform_csx210 = QStringLiteral("proform_csx210");
 const QString QZSettings::skandika_wiri_x2000_protocol = QStringLiteral("skandika_wiri_x2000_protocol");
 const QString QZSettings::trainprogram_auto_lap_on_segment = QStringLiteral("trainprogram_auto_lap_on_segment");
 const QString QZSettings::kingsmith_r2_enable_hw_buttons = QStringLiteral("kingsmith_r2_enable_hw_buttons");
+const QString QZSettings::step_gain = QStringLiteral("step_gain");
 
 
-const uint32_t allSettingsCount = 861;
+const uint32_t allSettingsCount = 862;
 
 QVariant allSettings[allSettingsCount][2] = {
     {QZSettings::cryptoKeySettingsProfiles, QZSettings::default_cryptoKeySettingsProfiles},
@@ -1940,6 +1941,7 @@ QVariant allSettings[allSettingsCount][2] = {
     {QZSettings::proform_treadmill_sport_3_0, QZSettings::default_proform_treadmill_sport_3_0},
     {QZSettings::garmin_oauth1_token, QZSettings::default_garmin_oauth1_token},
     {QZSettings::garmin_oauth1_token_secret, QZSettings::default_garmin_oauth1_token_secret},
+    {QZSettings::step_gain, QZSettings::default_step_gain},
 };
 
 void QZSettings::qDebugAllSettings(bool showDefaults) {

--- a/src/qzsettings.h
+++ b/src/qzsettings.h
@@ -2906,6 +2906,12 @@ class QZSettings {
     static constexpr bool default_kingsmith_r2_enable_hw_buttons = false;
 
     /**
+     * @brief Gain multiplier applied to step count calculated from cadence for calibration purposes
+     */
+    static const QString step_gain;
+    static constexpr double default_step_gain = 1.0;
+
+    /**
      * @brief Write the QSettings values using the constants from this namespace.
      * @param showDefaults Optionally indicates if the default should be shown with the key.
      */

--- a/src/settings.qml
+++ b/src/settings.qml
@@ -1283,6 +1283,7 @@ import Qt.labs.platform 1.1
 			property bool tile_hrv_enabled: false
 			property int tile_hrv_order: 78                 
             property bool nordictrack_gx_4_5_pro: false
+            property double step_gain: 1.0
         }
 
 
@@ -8410,6 +8411,44 @@ import Qt.labs.platform 1.1
 
                     Label {
                         text: qsTr("This overrides the minimum speed value of your treadmill (in order to limit the min speed). Default is 0 km/h (0 mph)")
+                        font.bold: true
+                        font.italic: true
+                        font.pixelSize: Qt.application.font.pixelSize - 2
+                        textFormat: Text.PlainText
+                        wrapMode: Text.WordWrap
+                        verticalAlignment: Text.AlignVCenter
+                        Layout.alignment: Qt.AlignLeft | Qt.AlignTop
+                        Layout.fillWidth: true
+                        color: Material.color(Material.Lime)
+                    }
+
+                    RowLayout {
+                        spacing: 10
+                        Label {
+                            id: labelStepGain
+                            text: qsTr("Step Count Gain:")
+                            Layout.fillWidth: true
+                        }
+                        TextField {
+                            id: stepGainTextField
+                            text: settings.step_gain
+                            horizontalAlignment: Text.AlignRight
+                            Layout.fillHeight: false
+                            Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                            inputMethodHints: Qt.ImhFormattedNumbersOnly
+                            onAccepted: settings.step_gain = text
+                            onActiveFocusChanged: if(this.focus) this.cursorPosition = this.text.length
+                        }
+                        Button {
+                            id: okStepGainButton
+                            text: "OK"
+                            Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                            onClicked: { settings.step_gain = stepGainTextField.text; toast.show("Setting saved!"); }
+                        }
+                    }
+
+                    Label {
+                        text: qsTr("Multiplier applied to the step count calculated from cadence for calibration. Increase above 1.0 to count more steps, decrease below 1.0 to count fewer steps. Default is 1.0.")
                         font.bold: true
                         font.italic: true
                         font.pixelSize: Qt.application.font.pixelSize - 2


### PR DESCRIPTION
## Summary
This PR adds a configurable step count gain multiplier that allows users to adjust the number of steps calculated from cadence during treadmill calibration. This provides fine-tuning capability for devices where the default step calculation may not match user expectations.

## Key Changes
- **Settings Definition**: Added `step_gain` property (double, default 1.0) to the settings system in `qzsettings.h` and `qzsettings.cpp`
- **UI Control**: Added a new settings panel in `settings.qml` with:
  - Text input field for entering the gain multiplier value
  - OK button to save the setting
  - Descriptive label explaining the multiplier's purpose and behavior
- **Step Calculation**: Modified `treadmill::evaluateStepCount()` in `treadmill.cpp` to apply the gain multiplier to the calculated step count
- **Settings Registry**: Updated the total settings count from 861 to 862 and registered the new setting in the allSettings array

## Implementation Details
- The gain multiplier is applied directly to the step count calculation: `StepCount += ... * step_gain`
- Values above 1.0 increase step count, values below 1.0 decrease it
- The setting defaults to 1.0 (no modification) for backward compatibility
- The UI input field is restricted to formatted numbers only via `Qt.ImhFormattedNumbersOnly`
- User receives a toast notification confirming the setting was saved

https://claude.ai/code/session_01VSfEwazZNLJn5VaHyPJPRg