### PR TITLE
Reduce bike inclination step from 0.5 to 0.2

### DIFF
--- a/src/homeform.cpp
+++ b/src/homeform.cpp
@@ -7187,7 +7187,7 @@ void homeform::update() {
                             }
                         } else if(inclinationAvailable) {
                             // Use inclination control for bikes without erg mode but with inclination support (e.g., ftmsbike)
-                            double step = 0.5;
+                            double step = 0.2;
                             double currentInclination = ((bike *)bluetoothManager->device())->currentInclination().value();
                             if (zone < ((uint8_t)currentHRZone)) {
                                 ((bike *)bluetoothManager->device())->changeInclination(currentInclination - step, currentInclination - step);
@@ -7375,7 +7375,7 @@ void homeform::update() {
                             }
                         } else if (inclinationAvailable) {
                             // Use inclination control for bikes without erg mode but with inclination support (e.g., ftmsbike)
-                            const double step = 0.5;
+                            const double step = 0.2;
                             double currentInclination = ((bike *)bluetoothManager->device())->currentInclination().value();
                             qDebug() << QStringLiteral("BIKE PID HR - Using inclination control, currentInclination:") << currentInclination;
 


### PR DESCRIPTION
Lower the inclination adjustment increment in homeform::update from 0.5 to 0.2 for bikes without erg mode (e.g., FTMS bikes). This makes PID/HR-based inclination control apply finer, smoother changes (updated in two code paths).