### PR TITLE
Add MQTT elapsed total seconds metric

### DIFF
--- a/src/mqttpublisher.cpp
+++ b/src/mqttpublisher.cpp
@@ -439,7 +439,7 @@ void MQTTPublisher::removeDiscoveryConfig() {
     // Remove all discovery configs by publishing empty messages
     QStringList components = {"sensor", "binary_sensor", "number", "switch", "button"};
     QStringList entities = {
-        "speed_current", "speed_avg", "distance", "calories", "elapsed_time", "heart_current", "heart_avg",
+        "speed_current", "speed_avg", "distance", "calories", "elapsed_time", "elapsed_total_seconds", "heart_current", "heart_avg",
         "watts_current", "watts_avg", "connected", "paused", "resistance", "cadence", "inclination",
         "power", "fan_speed", "start", "stop", "pause"
     };
@@ -473,6 +473,7 @@ void MQTTPublisher::publishWorkoutData() {
     publishToTopic("elapsed/seconds", elapsedTime.second());
     publishToTopic("elapsed/minutes", elapsedTime.minute());
     publishToTopic("elapsed/hours", elapsedTime.hour());
+    publishToTopic("elapsed/total_seconds", QTime(0, 0).secsTo(elapsedTime));
 
     QTime lapTime = m_device->lapElapsedTime();
     publishToTopic("lap/elapsed/seconds", lapTime.second());
@@ -635,6 +636,7 @@ void MQTTPublisher::publishDiscoveryConfig() {
     publishSensorDiscovery("distance", "Distance", baseTopic + "distance", "km", "distance", "mdi:map-marker-distance");
     publishSensorDiscovery("calories", "Calories", baseTopic + "calories", "kcal", "", "mdi:fire");
     publishSensorDiscovery("elapsed_time", "Elapsed Time", baseTopic + "elapsed/minutes", "min", "duration", "mdi:timer");
+    publishSensorDiscovery("elapsed_total_seconds", "Elapsed Total Seconds", baseTopic + "elapsed/total_seconds", "s", "duration", "mdi:timer");
     publishSensorDiscovery("heart_current", "Heart Rate", baseTopic + "heart/current", "bpm", "", "mdi:heart-pulse");
     publishSensorDiscovery("heart_avg", "Average Heart Rate", baseTopic + "heart/avg", "bpm", "", "mdi:heart-pulse");
     publishSensorDiscovery("watts_current", "Power", baseTopic + "watts/current", "W", "power", "mdi:flash");


### PR DESCRIPTION
### Motivation
- Provide a single cumulative elapsed-time metric (total seconds) over MQTT so consumers can read elapsed time as one integer instead of separate hours/minutes/seconds.

### Description
- Publish `elapsed/total_seconds` in `MQTTPublisher::publishWorkoutData()` using `QTime(0, 0).secsTo(elapsedTime)` to compute total seconds.
- Add Home Assistant discovery for `elapsed_total_seconds` in `publishDiscoveryConfig()` mapped to `elapsed/total_seconds` with unit `s`.
- Include `elapsed_total_seconds` in `removeDiscoveryConfig()` so discovery cleanup removes the new entity.

### Testing
- Ran `git diff --check -- src/mqttpublisher.cpp` which reported no whitespace issues and succeeded.
- Verified working tree status with `git status --short` and inspected the diff (`git diff -- src/mqttpublisher.cpp`) to confirm the three-line change, and committed the change as `mqtt: publish elapsed total seconds metric` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a351475c048325a79df227ed0297a2)