### PR TITLE
Handle VICTORY transition from simulation to target power

### DIFF
--- a/src/devices/ftmsbike/ftmsbike.cpp
+++ b/src/devices/ftmsbike/ftmsbike.cpp
@@ -1543,6 +1543,14 @@ void ftmsbike::ftmsCharacteristicChanged(const QLowEnergyCharacteristic &charact
         } else if(b.at(0) == FTMS_SET_TARGET_POWER && !ergModeSupported) {
             qDebug() << "discarding";
             return;
+        } else if (b.at(0) == FTMS_SET_TARGET_POWER && VICTORY && lastRoutedCommandWasIndoorSimulation) {
+            uint8_t requestControl[] = {FTMS_REQUEST_CONTROL};
+            writeCharacteristic(requestControl, sizeof(requestControl), "victory requestControl", false, true);
+
+            uint8_t startSimulation[] = {FTMS_START_RESUME};
+            writeCharacteristic(startSimulation, sizeof(startSimulation), "victory start simulation", false, true);
+
+            lastRoutedCommandWasIndoorSimulation = false;
         } else if(b.at(0) == FTMS_SET_TARGET_POWER && b.length() > 2) {
             // handling watt gain and offset for erg mode
             double watt_gain = settings.value(QZSettings::watt_gain, QZSettings::default_watt_gain).toDouble();
@@ -1574,6 +1582,12 @@ void ftmsbike::ftmsCharacteristicChanged(const QLowEnergyCharacteristic &charact
         }*/
 
         writeCharacteristic((uint8_t*)b.data(), b.length(), "injectWrite ", false, true);
+
+        if (b.at(0) == FTMS_SET_INDOOR_BIKE_SIMULATION_PARAMS) {
+            lastRoutedCommandWasIndoorSimulation = true;
+        } else if (b.at(0) == FTMS_SET_TARGET_POWER) {
+            lastRoutedCommandWasIndoorSimulation = false;
+        }
     }
 }
 
@@ -1801,6 +1815,9 @@ void ftmsbike::deviceDiscovered(const QBluetoothDeviceInfo &device) {
         } else if(device.name().toUpper().startsWith("JFICCYCLE")) {
             qDebug() << QStringLiteral("JFICCYCLE found");
             JFICCYCLE = true;
+        } else if(device.name().toUpper().startsWith("VICTORY")) {
+            qDebug() << QStringLiteral("VICTORY found");
+            VICTORY = true;
         }
 
 

--- a/src/devices/ftmsbike/ftmsbike.h
+++ b/src/devices/ftmsbike/ftmsbike.h
@@ -170,6 +170,8 @@ class ftmsbike : public bike {
     bool S18 = false;
     bool JFICCYCLE = false;
     bool ZIPRO_RAVE = false;
+    bool VICTORY = false;
+    bool lastRoutedCommandWasIndoorSimulation = false;
 
     uint8_t secondsToResetTimer = 5;
 


### PR DESCRIPTION
### Motivation
- Alcuni device VICTORY richiedono di reinizializzare il controllo/simulazione quando si passa da pacchetti di tipo `SET_INDOOR_BIKE_SIMULATION_PARAMS` (inclination/simulation) a `SET_TARGET_POWER` altrimenti il comando power potrebbe non essere applicato correttamente.

### Description
- Aggiunti due flag interni `VICTORY` e `lastRoutedCommandWasIndoorSimulation` alla classe `ftmsbike` per tracciare il device e l'ultimo comando inoltrato.
- Rilevamento del device VICTORY implementato in `deviceDiscovered` impostando `VICTORY = true` quando il nome BLE inizia con `"VICTORY"`.
- In `ftmsCharacteristicChanged` quando arriva `FTMS_SET_TARGET_POWER` per un device VICTORY e `lastRoutedCommandWasIndoorSimulation` è `true`, ora vengono inviati prima `FTMS_REQUEST_CONTROL` e poi `FTMS_START_RESUME` prima di inoltrare il `SET_TARGET_POWER` al bike, e il flag viene azzerato.
- Aggiunto tracciamento dello stato `lastRoutedCommandWasIndoorSimulation` subito dopo l'invio con `writeCharacteristic` per mantenere coerente la logica di transizione tra comandi simulation e power.

### Testing
- Verificata la posizione dei punti di intervento con ricerche sul codice (`rg`) e ispezione dei file modificati per confermare l'inserimento della logica nei punti corretti; operazione completata con successo.
- Ispezionato il diff delle sorgenti per convalidare le modifiche apportate; diff coerente con il comportamento richiesto.
- Nessuna build o test runtime automatizzato è stato eseguito in questo ambiente di modifica.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b046ceb8e083258cccbd10fd7c2db8)