### PR TITLE
Add VICTORY FTMS reset when switching simulation to power

### DIFF
--- a/src/devices/ftmsbike/ftmsbike.cpp
+++ b/src/devices/ftmsbike/ftmsbike.cpp
@@ -1473,8 +1473,24 @@ void ftmsbike::ftmsCharacteristicChanged(const QLowEnergyCharacteristic &charact
     if (gattWriteCharControlPointId.isValid()) {
         qDebug() << "routing FTMS packet to the bike from virtualbike" << characteristic.uuid() << newValue.toHex(' ');
 
+        bool isSimulationCommand = (b.at(0) == FTMS_SET_INDOOR_BIKE_SIMULATION_PARAMS);
+        bool isPowerTargetCommand = (b.at(0) == FTMS_SET_TARGET_POWER);
+
+        if (VICTORY) {
+            if (isSimulationCommand) {
+                victoryLastCommandWasSimulation = true;
+            } else if (isPowerTargetCommand && victoryLastCommandWasSimulation) {
+                qDebug() << "VICTORY workaround: switching from simulation to target power, sending control reset";
+                uint8_t requestControl[] = {FTMS_REQUEST_CONTROL};
+                writeCharacteristic(requestControl, sizeof(requestControl), "victory requestControl", false, true);
+                uint8_t startSimulation[] = {FTMS_START_RESUME};
+                writeCharacteristic(startSimulation, sizeof(startSimulation), "victory start simulation", false, true);
+                victoryLastCommandWasSimulation = false;
+            }
+        }
+
         // handling gears
-        if (b.at(0) == FTMS_SET_INDOOR_BIKE_SIMULATION_PARAMS && (zwiftPlayService == nullptr || !gears_zwift_ratio)) {
+        if (isSimulationCommand && (zwiftPlayService == nullptr || !gears_zwift_ratio)) {
             double min_inclination = settings.value(QZSettings::min_inclination, QZSettings::default_min_inclination).toDouble();
             double offset =
                 settings.value(QZSettings::zwift_inclination_offset, QZSettings::default_zwift_inclination_offset).toDouble();
@@ -1504,7 +1520,7 @@ void ftmsbike::ftmsCharacteristicChanged(const QLowEnergyCharacteristic &charact
 
             qDebug() << "applying gears mod" << gears() << slope;
 
-        } else if(b.at(0) == FTMS_SET_INDOOR_BIKE_SIMULATION_PARAMS && zwiftPlayService != nullptr && gears_zwift_ratio) {
+        } else if(isSimulationCommand && zwiftPlayService != nullptr && gears_zwift_ratio) {
             int16_t slope = (((uint8_t)b.at(3)) + (b.at(4) << 8));
             
 #ifdef Q_OS_IOS
@@ -1540,10 +1556,10 @@ void ftmsbike::ftmsCharacteristicChanged(const QLowEnergyCharacteristic &charact
 #endif
             writeCharacteristicZwiftPlay((uint8_t*)message.data(), message.length(), "gearInclination", false, false);
             return;
-        } else if(b.at(0) == FTMS_SET_TARGET_POWER && !ergModeSupported) {
+        } else if(isPowerTargetCommand && !ergModeSupported) {
             qDebug() << "discarding";
             return;
-        } else if(b.at(0) == FTMS_SET_TARGET_POWER && b.length() > 2) {
+        } else if(isPowerTargetCommand && b.length() > 2) {
             // handling watt gain and offset for erg mode
             double watt_gain = settings.value(QZSettings::watt_gain, QZSettings::default_watt_gain).toDouble();
             double watt_offset = settings.value(QZSettings::watt_offset, QZSettings::default_watt_offset).toDouble();
@@ -1738,6 +1754,9 @@ void ftmsbike::deviceDiscovered(const QBluetoothDeviceInfo &device) {
             resistance_lvl_mode = true;
             ergModeSupported = false;
             ZIPRO_RAVE = true;
+        } else if ((bluetoothDevice.name().toUpper().startsWith("VICTORY"))) {
+            qDebug() << QStringLiteral("VICTORY found");
+            VICTORY = true;
         } else if ((bluetoothDevice.name().toUpper().startsWith("TITAN 7000"))) {
             qDebug() << QStringLiteral("Titan 7000 found");
             TITAN_7000 = true;

--- a/src/devices/ftmsbike/ftmsbike.h
+++ b/src/devices/ftmsbike/ftmsbike.h
@@ -170,6 +170,8 @@ class ftmsbike : public bike {
     bool S18 = false;
     bool JFICCYCLE = false;
     bool ZIPRO_RAVE = false;
+    bool VICTORY = false;
+    bool victoryLastCommandWasSimulation = false;
 
     uint8_t secondsToResetTimer = 5;
 


### PR DESCRIPTION
### Motivation
- Alcuni dispositivi "VICTORY" richiedono un reset del controllo FTMS quando si passa da comandi di simulazione indoor a un `SET_TARGET_POWER` per evitare che il trainer rimanga nello stato inclinazione; lo scopo è inviare prima un `REQUEST_CONTROL` e poi un `START_RESUME` per resettare questo passaggio.

### Description
- Aggiunte due variabili di stato in `ftmsbike` (`VICTORY` e `victoryLastCommandWasSimulation`) per tracciare il device e l'ultimo comando ricevuto modificando `src/devices/ftmsbike/ftmsbike.h`.
- Rilevamento del device `VICTORY` in `deviceDiscovered` impostando il flag `VICTORY` quando il nome BLE inizia con `VICTORY` in `src/devices/ftmsbike/ftmsbike.cpp`.
- In `ftmsCharacteristicChanged` introdotte le variabili `isSimulationCommand` e `isPowerTargetCommand` e aggiunta la logica specifica per `VICTORY` che, se arriva un `SET_TARGET_POWER` dopo un `SET_INDOOR_BIKE_SIMULATION_PARAMS`, invia prima `FTMS_REQUEST_CONTROL` e poi `FTMS_START_RESUME` prima di inoltrare il comando power; la logica esistente per gears/erg è stata mantenuta ma i controlli sono stati normalizzati per chiarezza.

### Testing
- Eseguito controllo di formato e incoerenze con `git diff --check`, esito: successo.
- Verificato lo stato dei file modificati con `git status --short`, esito: risultato coerente con le modifiche previste.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b050d7eb608325b1fa3a23e0dcfc3b)