### PR TITLE
yesoulbike: graceful handling when proprietary services missing and FTMS fallback

### DIFF
--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -2346,7 +2346,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 this->signalBluetoothDeviceConnected(sportsPlusRower);
             } else if ((b.name().startsWith(yesoulbike::bluetoothName) || 
                         b.name().toUpper().startsWith("YS_G1M_")) && !yesoulBike && filter &&
-                       b.name().compare(ftms_treadmill, Qt::CaseInsensitive)) {
+                       b.name().compare(ftms_treadmill, Qt::CaseInsensitive) && b.name().compare(ftms_bike, Qt::CaseInsensitive)) {
                 this->setLastBluetoothDevice(b);
                 this->stopDiscovery();
                 yesoulBike =

--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -2345,7 +2345,8 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 sportsPlusRower->deviceDiscovered(b);
                 this->signalBluetoothDeviceConnected(sportsPlusRower);
             } else if ((b.name().startsWith(yesoulbike::bluetoothName) || 
-                        b.name().toUpper().startsWith("YS_G1M_")) && !yesoulBike && filter) {
+                        b.name().toUpper().startsWith("YS_G1M_")) && !yesoulBike && filter &&
+                       b.name().compare(ftms_treadmill, Qt::CaseInsensitive)) {
                 this->setLastBluetoothDevice(b);
                 this->stopDiscovery();
                 yesoulBike =

--- a/src/devices/yesoulbike/yesoulbike.cpp
+++ b/src/devices/yesoulbike/yesoulbike.cpp
@@ -1,4 +1,5 @@
 #include "yesoulbike.h"
+#include "homeform.h"
 
 #ifdef Q_OS_ANDROID
 #include "keepawakehelper.h"
@@ -240,8 +241,11 @@ void yesoulbike::stateChanged(QLowEnergyService::ServiceState state) {
 
         gattWriteCharacteristic = gattCommunicationChannelService->characteristic(_gattWriteCharacteristicId);
         gattNotify1Characteristic = gattCommunicationChannelService->characteristic(_gattNotify1CharacteristicId);
-        Q_ASSERT(gattWriteCharacteristic.isValid());
-        Q_ASSERT(gattNotify1Characteristic.isValid());
+        if (!gattWriteCharacteristic.isValid() || !gattNotify1Characteristic.isValid()) {
+            emit debug(QStringLiteral("yesoulbike missing required characteristics, disconnecting gracefully"));
+            emit disconnected();
+            return;
+        }
 
         // establish hook into notifications
         connect(gattCommunicationChannelService, &QLowEnergyService::characteristicChanged, this,
@@ -310,6 +314,28 @@ void yesoulbike::serviceScanDone(void) {
     QBluetoothUuid _gattCommunicationChannelServiceId((quint16)0xFFF0);
 
     gattCommunicationChannelService = m_control->createServiceObject(_gattCommunicationChannelServiceId);
+    if (!gattCommunicationChannelService) {
+        emit debug(QStringLiteral("yesoulbike missing 0xFFF0 service"));
+
+        if (!bluetoothDevice.name().compare(QStringLiteral("YESOUL"), Qt::CaseInsensitive)) {
+            QBluetoothUuid ftmsServiceId((quint16)0x1826);
+            QLowEnergyService *ftmsService = m_control->createServiceObject(ftmsServiceId);
+            if (ftmsService) {
+                QSettings settings;
+                settings.setValue(QZSettings::ftms_treadmill, bluetoothDevice.name());
+                qDebug() << "forcing FTMS treadmill for YESOUL device exposing FTMS service";
+                if (homeform::singleton()) {
+                    homeform::singleton()->setToastRequested(
+                        "FTMS treadmill found, restart the app to apply the change");
+                }
+                delete ftmsService;
+            }
+        }
+
+        emit disconnected();
+        return;
+    }
+
     connect(gattCommunicationChannelService, &QLowEnergyService::stateChanged, this, &yesoulbike::stateChanged);
     gattCommunicationChannelService->discoverDetails();
 }


### PR DESCRIPTION
### Motivation
- Prevent crashes when a YESOUL bike lacks its proprietary service/characteristics and ensure the app can fall back to FTMS treadmill behavior when appropriate.
- When a device is named exactly `YESOUL` and exposes the FTMS service (`0x1826`), treat it like other FTMS treadmills by setting the configured FTMS device and showing the restart toast.
- Avoid selecting the YESOUL-specific path in discovery when the same device is already configured as the `ftms_treadmill`.

### Description
- Updated `src/devices/yesoulbike/yesoulbike.cpp` to include `homeform.h` for toast notification support.
- Replaced `Q_ASSERT` checks in `yesoulbike::stateChanged()` with runtime validation that logs a debug message and calls `disconnected()` if required characteristics are missing, preventing assert-driven crashes.
- Added logic in `yesoulbike::serviceScanDone()` to detect missing proprietary service `0xFFF0`; if the device name equals `YESOUL` (case-insensitive) and the FTMS service (`0x1826`) exists, set `QZSettings::ftms_treadmill` and request the same restart toast used by other FTMS handlers, then disconnect gracefully.
- Adjusted detection in `src/devices/bluetooth.cpp` so the YESOUL discovery branch is skipped when the device matches the configured `ftms_treadmill` string, preventing conflicting handling.

### Testing
- Ran `git diff --check` to validate diffs and whitespace/patch sanity, which reported no issues.
- Ran `git status --short` to confirm working-tree changes were staged/committed as expected, which succeeded.
- No unit/integration tests were executed in this change; recommend running the project's test suite with `cd tst && qmake && make && ./qdomyos-zwift-tests` in CI or locally to further validate behavior on devices and emulators.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8615d72148325ba8c2491fe606e6e)