### PR TITLE
Recognize TM4500 treadmill and set minInclination to -3.0

### DIFF
--- a/src/devices/horizontreadmill/horizontreadmill.cpp
+++ b/src/devices/horizontreadmill/horizontreadmill.cpp
@@ -2717,6 +2717,10 @@ void horizontreadmill::deviceDiscovered(const QBluetoothDeviceInfo &device) {
         } else if (device.name().toUpper().startsWith(QStringLiteral("TM4800-"))) {
             qDebug() << QStringLiteral("TM4800 treadmill found");
             TM4800 = true;
+        } else if (device.name().toUpper().startsWith(QStringLiteral("TM4500"))) {
+            qDebug() << QStringLiteral("TM4500 treadmill found");
+            TM4500 = true;
+            minInclination = -3.0;
         } else if (device.name().toUpper().startsWith(QStringLiteral("TM6500-"))) {
             qDebug() << QStringLiteral("TM6500 treadmill found");
             TM6500 = true;

--- a/src/devices/horizontreadmill/horizontreadmill.h
+++ b/src/devices/horizontreadmill/horizontreadmill.h
@@ -119,6 +119,7 @@ class horizontreadmill : public treadmill {
     bool TP1 = false;
     bool T01 = false;
     bool TM4800 = false;
+    bool TM4500 = false;
     bool TM6500 = false;
     bool WT_TREADMILL = false;
     bool THERUN_T15 = false;


### PR DESCRIPTION
### Motivation
- Support detection of the `TM4500` treadmill which requires a negative minimum inclination range similar to existing `TM6500` support.

### Description
- Added a `TM4500` flag in `horizontreadmill.h` and a detection branch in `deviceDiscovered` that logs the device, sets `TM4500 = true`, and applies `minInclination = -3.0`.

### Testing
- Built the project and ran the existing automated test suite, and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c34bab69488325a3c3a312a6d8d361)