### PR TITLE
Show distances in user-selected unit (km/mi) in WorkoutsHistory

### DIFF
--- a/src/WorkoutsHistory.qml
+++ b/src/WorkoutsHistory.qml
@@ -373,7 +373,11 @@ Page {
                                 }
 
                                 Text {
-                                    text: "📏 " + distance.toFixed(2) + " km"
+                                    text: {
+                                        var useMiles = settings && settings.miles_unit
+                                        var displayDistance = useMiles ? (distance / 1.60934) : distance
+                                        return "📏 " + displayDistance.toFixed(2) + (useMiles ? " mi" : " km")
+                                    }
                                 }
                             }
 


### PR DESCRIPTION
### Motivation
- Respect the user's unit preference when rendering workout distances instead of always showing kilometers.

### Description
- Replace the static distance text in `WorkoutsHistory.qml` with a JavaScript binding that checks `settings.miles_unit`, converts the value using `distance / 1.60934` when miles are requested, formats with `toFixed(2)`, and appends either `mi` or `km` accordingly.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4bedc88b08325a87097922062c91b)