### PR TITLE
Fix missing Settings usage in WorkoutsHistory.qml

### DIFF
--- a/src/WorkoutsHistory.qml
+++ b/src/WorkoutsHistory.qml
@@ -3,10 +3,17 @@ import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 import QtCharts 2.15
 import Qt.labs.calendar 1.0
+import Qt.labs.settings 1.0
 
 Page {
     id: workoutHistoryPage
 
+
+
+    Settings {
+        id: settings
+        property bool miles_unit: false
+    }
 
     // Signal for chart preview
     signal fitfile_preview_clicked(var url)


### PR DESCRIPTION
### Motivation
- `WorkoutsHistory.qml` used `settings.miles_unit` when formatting distances but did not define a local `Settings` object, which could lead to undefined references at runtime.

### Description
- Added `import Qt.labs.settings 1.0` and a local `Settings` object (`id: settings`) with `property bool miles_unit: false` to `src/WorkoutsHistory.qml` so distance unit formatting works the same way as in `Wizard.qml`.

### Testing
- No automated tests were executed for this small QML/UI fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5ffa899348325899af0653e16d9a0)