### PR TITLE
Fix doubled iOS Health cadence for bike workouts

### DIFF
--- a/src/ios/lockscreen.mm
+++ b/src/ios/lockscreen.mm
@@ -212,8 +212,9 @@ void lockscreen::workoutTrackingUpdate(double speed, unsigned short cadence, uns
                                        bool useMiles, unsigned char heartRate, const char *compactLeadingMetric,
                                        int compactLeadingValue, const char *compactTrailingMetric,
                                        int compactTrailingValue) {
+    const double healthCadence = (deviceType == BIKE) ? cadence : cadence * 2.0;
     if(workoutTracking != nil && !appleWatchAppInstalled())
-        [workoutTracking addMetricsWithPower:watt cadence:cadence*2 speed:speed * 100 kcal:currentCalories steps:currentSteps deviceType:deviceType distance:currentDistance totalKcal:totalKcal elevationGain:0];
+        [workoutTracking addMetricsWithPower:watt cadence:healthCadence speed:speed * 100 kcal:currentCalories steps:currentSteps deviceType:deviceType distance:currentDistance totalKcal:totalKcal elevationGain:0];
 
     // Start Live Activity on first update, then keep updating
     if (!ios_liveactivity::isLiveActivityRunning()) {


### PR DESCRIPTION
### Motivation
- Prevent Apple Health from recording doubled cadence for bike workouts when QZ runs on iOS without an Apple Watch companion.
- The bridge layer was always multiplying cadence by 2 before forwarding to HealthKit, causing values like `60` RPM in QZ to appear as `120` in Apple Health.

### Description
- Compute a `healthCadence` in `lockscreen::workoutTrackingUpdate(...)` and set it to `cadence` when `deviceType == BIKE`, otherwise preserve the previous `cadence * 2.0` behavior.
- Replace the previous hard-coded `cadence*2` argument with `healthCadence` when calling `workoutTracking->addMetrics(...)` in `src/ios/lockscreen.mm`.
- No changes were made to `WorkoutTracking.swift` or the HealthKit cadence conversion (`cadence / 60.0`), so cycling cadence is still converted to `count/second` as expected.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3e92ea24c8325898606e9f2b60a80)