### PR TITLE
Fix scope of `isM7Device` in Nautilus elliptical parser

### DIFF
--- a/src/devices/nautiluselliptical/nautiluselliptical.cpp
+++ b/src/devices/nautiluselliptical/nautiluselliptical.cpp
@@ -233,13 +233,13 @@ void nautiluselliptical::characteristicChanged(const QLowEnergyCharacteristic &c
     lastPacket = newValue;
 
     if (newValue.length() == 20) {
+        const bool isM7Device = bluetoothDevice.name().startsWith(QStringLiteral("Nautilus M7"), Qt::CaseInsensitive);
 
 #ifdef Q_OS_ANDROID
-        if (settings.value(QZSettings::ant_heart, QZSettings::default_ant_heart).toBool())
+        if (settings.value(QZSettings::ant_heart, QZSettings::default_ant_heart).toBool()) {
             Heart = (uint8_t)KeepAwakeHelper::heart();
-        else
+        } else
 #endif
-        const bool isM7Device = bluetoothDevice.name().startsWith(QStringLiteral("Nautilus M7"), Qt::CaseInsensitive);
         {
             uint8_t heart = ((uint8_t)newValue.at(16));
             if (!isM7Device && heartRateBeltName.startsWith(QStringLiteral("Disabled")) && heart != 0) {


### PR DESCRIPTION
### Motivation
- Resolve compiler error caused by `isM7Device` being referenced before it was declared in `nautiluselliptical::characteristicChanged`, and ensure the Android ANT heart-rate branch keeps the original fallback behavior.

### Description
- Declare `isM7Device` earlier (before the `#ifdef Q_OS_ANDROID` heart-rate handling) and add braces around the Android ANT `if` so the existing fallback block that reads heart data from the device remains correct in `src/devices/nautiluselliptical/nautiluselliptical.cpp`.

### Testing
- Attempted to run `make -j2` in this environment as an automated build check, but it failed because no Makefile exists at the repository root in this environment (no further automated tests were run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4eca6914883259919a9b0ced52802)