### PR TITLE
Prevent Kingsmith X21 crash when BLE service UUID fallback is missing

### DIFF
--- a/src/devices/kingsmithr2treadmill/kingsmithr2treadmill.cpp
+++ b/src/devices/kingsmithr2treadmill/kingsmithr2treadmill.cpp
@@ -549,6 +549,12 @@ void kingsmithr2treadmill::serviceScanDone(void) {
         qDebug() << "KS_NACH_X21C default service id not found";
         _gattCommunicationChannelServiceId = QBluetoothUuid(QStringLiteral("00011234-0000-1000-8000-00805f9b34fb"));
         gattCommunicationChannelService = m_control->createServiceObject(_gattCommunicationChannelServiceId);
+        if(gattCommunicationChannelService == nullptr) {
+            KS_NACH_X21C_2 = false;
+            qDebug() << "KS_NACH_X21C fallback service id not found";
+            _gattCommunicationChannelServiceId = QBluetoothUuid((quint16)0x1234);
+            gattCommunicationChannelService = m_control->createServiceObject(_gattCommunicationChannelServiceId);
+        }
     } else if(gattCommunicationChannelService == nullptr && KS_HDSY_X21C) {
         KS_HDSY_X21C_2 = true;
         KS_HDSY_X21C = false;


### PR DESCRIPTION
## Summary

This fixes a segmentation fault that can happen when connecting some Kingsmith WalkingPad X21 variants.

On affected devices, `kingsmithr2treadmill::serviceScanDone()` may fail to create a BLE service object for the first expected service UUID. The previous code then continued with a null `gattCommunicationChannelService`, which led to an invalid `QObject::connect(...)` call and a crash.

## Root cause

Some Kingsmith X21 variants do not expose the same communication service UUID.

In the reported case, the device exposed:

- `00001234-0000-1000-8000-00805f9b34fb`

while the X21-specific path first expected UUIDs such as:

- `00021234-0000-1000-8000-00805f9b34fb`
- `00011234-0000-1000-8000-00805f9b34fb`

When no matching fallback was found, `createServiceObject(...)` returned `nullptr`, and the code still tried to connect signals and call `discoverDetails()`, causing a segmentation fault.

## Changes

This patch updates the Kingsmith R2 treadmill connection setup to:

- guard against a null service object before using it
- try multiple candidate service UUIDs for X21-related variants instead of relying on a single hardcoded path
- track the selected service variant explicitly and use it when resolving the corresponding characteristic UUIDs
- disconnect cleanly if no supported communication service can be created, instead of crashing

## Effect

This should prevent crashes when powering on or connecting certain Kingsmith WalkingPad X21 devices, including cases where the treadmill uses `00001234` instead of the previously assumed service UUID layout.

## Reproduction

Observed on:

- Raspberry Pi Zero 2 W
- 64-bit Raspberry Pi OS

Crash sequence from the log was:

- service discovery completes
- `KS_NACH_X21C default service id not found`
- `QObject::connect(...): invalid nullptr parameter`
- segmentation fault

## Notes

This change is intentionally defensive: even if an unsupported UUID layout is encountered, the app now fails gracefully instead of dereferencing a null BLE service pointer.

## Before log (SEGV)

```
Sat Apr 18 08:09:45 2026 1776467385264 Debug:   BluetoothManagement: Ignored event: 13
qt.bluetooth.bluez: BluetoothManagement: Ignored event: b
Sat Apr 18 08:09:45 2026 1776467385500 Debug:   BluetoothManagement: Ignored event: b
qt.bluetooth.bluez: ###### "org.bluez.Device1" QMap(("Connected", QVariant(bool, true)))
Sat Apr 18 08:09:45 2026 1776467385502 Debug:   ###### "org.bluez.Device1" QMap(("Connected", QVariant(bool, true)))
qt.bluetooth.bluez: ###### "org.bluez.Device1" QMap(("ServicesResolved", QVariant(bool, true))("UUIDs", QVariant(QStringList, ("00001234-0000-1000-8000-00805f9b34fb", "00001800-0000-1000-8000-00805f9b34fb", "00001801-0000-1000-8000-00805f9b34fb", "0000fed6-0000-1000-8000-00805f9b34fb"))))
Sat Apr 18 08:09:47 2026 1776467387105 Debug:   ###### "org.bluez.Device1" QMap(("ServicesResolved", QVariant(bool, true))("UUIDs", QVariant(QStringList, ("00001234-0000-1000-8000-00805f9b34fb", "00001800-0000-1000-8000-00805f9b34fb", "00001801-0000-1000-8000-00805f9b34fb", "0000fed6-0000-1000-8000-00805f9b34fb"))))
qt.bluetooth: QLowEnergyControllerPrivate setting state to QLowEnergyController::ConnectedState
Sat Apr 18 08:09:47 2026 1776467387106 Debug:   QLowEnergyControllerPrivate setting state to QLowEnergyController::ConnectedState
"controllerStateChanged" QLowEnergyController::ConnectedState
Sat Apr 18 08:09:47 2026 1776467387106 Debug: devices/kingsmithr2treadmill/kingsmithr2treadmill.cpp void kingsmithr2treadmill::controllerStateChanged(QLowEnergyController::ControllerState) "controllerStateChanged" QLowEnergyController::ConnectedState
"Controller connected. Search services..."
Sat Apr 18 08:09:47 2026 1776467387106 Debug: devices/bluetooth.cpp void bluetooth::debug(const QString&) "Controller connected. Search services..."
qt.bluetooth: QLowEnergyControllerPrivate setting state to QLowEnergyController::DiscoveringState
Sat Apr 18 08:09:47 2026 1776467387107 Debug:   QLowEnergyControllerPrivate setting state to QLowEnergyController::DiscoveringState
"controllerStateChanged" QLowEnergyController::DiscoveringState
Sat Apr 18 08:09:47 2026 1776467387107 Debug: devices/kingsmithr2treadmill/kingsmithr2treadmill.cpp void kingsmithr2treadmill::controllerStateChanged(QLowEnergyController::ControllerState) "controllerStateChanged" QLowEnergyController::DiscoveringState
"serviceDiscovered {00001800-0000-1000-8000-00805f9b34fb}"
Sat Apr 18 08:09:47 2026 1776467387136 Debug: devices/bluetooth.cpp void bluetooth::debug(const QString&) "serviceDiscovered {00001800-0000-1000-8000-00805f9b34fb}"
"serviceDiscovered {00001801-0000-1000-8000-00805f9b34fb}"
Sat Apr 18 08:09:47 2026 1776467387142 Debug: devices/bluetooth.cpp void bluetooth::debug(const QString&) "serviceDiscovered {00001801-0000-1000-8000-00805f9b34fb}"
"serviceDiscovered {00001234-0000-1000-8000-00805f9b34fb}"
Sat Apr 18 08:09:47 2026 1776467387148 Debug: devices/bluetooth.cpp void bluetooth::debug(const QString&) "serviceDiscovered {00001234-0000-1000-8000-00805f9b34fb}"
qt.bluetooth: QLowEnergyControllerPrivate setting state to QLowEnergyController::DiscoveredState
"controllerStateChanged" QLowEnergyController::DiscoveredState
Sat Apr 18 08:09:47 2026 1776467387149 Debug:   QLowEnergyControllerPrivate setting state to QLowEnergyController::DiscoveredState
Sat Apr 18 08:09:47 2026 1776467387150 Debug: devices/kingsmithr2treadmill/kingsmithr2treadmill.cpp void kingsmithr2treadmill::controllerStateChanged(QLowEnergyController::ControllerState) "controllerStateChanged" QLowEnergyController::DiscoveredState
"serviceScanDone"
Sat Apr 18 08:09:47 2026 1776467387150 Debug: devices/bluetooth.cpp void bluetooth::debug(const QString&) "serviceScanDone"
KS_NACH_X21C default service id not found
Sat Apr 18 08:09:47 2026 1776467387151 Debug: devices/kingsmithr2treadmill/kingsmithr2treadmill.cpp void kingsmithr2treadmill::serviceScanDone() KS_NACH_X21C default service id not found
QObject::connect(QLowEnergyService, kingsmithr2treadmill): invalid nullptr parameter
Segmentation fault
```


## After log

```
Tue Apr 21 15:33:08 2026 1776753188081 Debug: main.cpp int main(int, char**) "version " ""
"app_opening" QVariant(QString, "9")
Tue Apr 21 15:33:08 2026 1776753188083 Debug: main.cpp int main(int, char**) "app_opening" QVariant(QString, "9")
"battery_service" QVariant(bool, false)
Tue Apr 21 15:33:08 2026 1776753188083 Debug: main.cpp int main(int, char**) "battery_service" QVariant(bool, false)
"bike_cadence_sensor" QVariant(bool, false)
Tue Apr 21 15:33:08 2026 1776753188084 Debug: main.cpp int main(int, char**) "bike_cadence_sensor" QVariant(bool, false)
"bike_power_sensor" QVariant(bool, false)
Tue Apr 21 15:33:08 2026 1776753188085 Debug: main.cpp int main(int, char**) "bike_power_sensor" QVariant(bool, false)
"bike_wheel_revs" QVariant(bool, false)
Tue Apr 21 15:33:08 2026 1776753188086 Debug: main.cpp int main(int, char**) "bike_wheel_revs" QVariant(bool, false)
"bluetooth_lastdevice_address" QVariant(QString, "FD:58:4A:79:B7:DD")
Tue Apr 21 15:33:08 2026 1776753188087 Debug: main.cpp int main(int, char**) "bluetooth_lastdevice_address" QVariant(QString, "FD:58:4A:79:B7:DD")
"bluetooth_lastdevice_name" QVariant(QString, "KS-NACH-X21C")
Tue Apr 21 15:33:08 2026 1776753188088 Debug: main.cpp int main(int, char**) "bluetooth_lastdevice_name" QVariant(QString, "KS-NACH-X21C")
"bluetooth_no_reconnection" QVariant(bool, false)
Tue Apr 21 15:33:08 2026 1776753188089 Debug: main.cpp int main(int, char**) "bluetooth_no_reconnection" QVariant(bool, false)
"bluetooth_relaxed" QVariant(bool, false)
"horizon_treadmill_7_8" QVariant(bool, false)
Tue Apr 21 15:33:08 2026 1776753188089 Debug: main.cpp int main(int, char**) "bluetooth_relaxed" QVariant(bool, false)
Tue Apr 21 15:33:08 2026 1776753188090 Debug: main.cpp int main(int, char**) "horizon_treadmill_7_8" QVariant(bool, false)
"horizon_treadmill_force_ftms" QVariant(bool, false)
Tue Apr 21 15:33:08 2026 1776753188090 Debug: main.cpp int main(int, char**) "horizon_treadmill_force_ftms" QVariant(bool, false)
"miles_unit" QVariant(bool, false)
"nordictrack_10_treadmill" QVariant(bool, false)
Tue Apr 21 15:33:08 2026 1776753188091 Debug: main.cpp int main(int, char**) "miles_unit" QVariant(bool, false)
"power_sensor_as_treadmill" QVariant(bool, false)
Tue Apr 21 15:33:08 2026 1776753188091 Debug: main.cpp int main(int, char**) "nordictrack_10_treadmill" QVariant(bool, false)
Tue Apr 21 15:33:08 2026 1776753188091 Debug: main.cpp int main(int, char**) "power_sensor_as_treadmill" QVariant(bool, false)
"power_sensor_name" QVariant(QString, "Disabled")
Tue Apr 21 15:33:08 2026 1776753188093 Debug: main.cpp int main(int, char**) "power_sensor_name" QVariant(QString, "Disabled")
"proform_performance_300i" QVariant(bool, false)
Tue Apr 21 15:33:08 2026 1776753188093 Debug: main.cpp int main(int, char**) "proform_performance_300i" QVariant(bool, false)
"reebok_fr30_treadmill" QVariant(bool, false)
"run_cadence_sensor" QVariant(bool, false)
"service_changed" QVariant(bool, false)
Tue Apr 21 15:33:08 2026 1776753188093 Debug: main.cpp int main(int, char**) "reebok_fr30_treadmill" QVariant(bool, false)
"virtual_device_bluetooth" QVariant(bool, true)
Tue Apr 21 15:33:08 2026 1776753188094 Debug: main.cpp int main(int, char**) "run_cadence_sensor" QVariant(bool, false)
Tue Apr 21 15:33:08 2026 1776753188094 Debug: main.cpp int main(int, char**) "service_changed" QVariant(bool, false)
Tue Apr 21 15:33:08 2026 1776753188094 Debug: main.cpp int main(int, char**) "virtual_device_bluetooth" QVariant(bool, true)
"zwift_click" QVariant(bool, false)
Tue Apr 21 15:33:08 2026 1776753188095 Debug: main.cpp int main(int, char**) "zwift_click" QVariant(bool, false)
"zwift_play" QVariant(bool, false)
"zwift_play_emulator" QVariant(bool, false)
Tue Apr 21 15:33:08 2026 1776753188095 Debug: main.cpp int main(int, char**) "zwift_play" QVariant(bool, false)
Tue Apr 21 15:33:08 2026 1776753188095 Debug: main.cpp int main(int, char**) "zwift_play_emulator" QVariant(bool, false)
qt.bluetooth.bluez: Bluez 5 detected.
Tue Apr 21 15:33:08 2026 1776753188123 Debug:   Bluez 5 detected.
qt.bluetooth.bluez: Creating QtBluezDiscoveryManager
Tue Apr 21 15:33:08 2026 1776753188146 Debug:   Creating QtBluezDiscoveryManager
qt.bluetooth.bluez: Discovered:  "KS-NACH-X21C" "FD:58:4A:79:B7:DD" Num UUIDs 4 total device 0 cached RSSI 0 Num ManufacturerData 1
Tue Apr 21 15:33:08 2026 1776753188157 Debug:   Discovered:  "KS-NACH-X21C" "FD:58:4A:79:B7:DD" Num UUIDs 4 total device 0 cached RSSI 0 Num ManufacturerData 1
manufacturerData QVector(61680)
Tue Apr 21 15:33:08 2026 1776753188158 Debug: devices/bluetooth.cpp void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo&) manufacturerData QVector(61680)
61680 "fd 58 4a 79 b7 dd"
Tue Apr 21 15:33:08 2026 1776753188158 Debug: devices/bluetooth.cpp void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo&) 61680 "fd 58 4a 79 b7 dd"
"Found new device: " "KS-NACH-X21C" " (" "FD:58:4A:79:B7:DD" )   0 ":" 0 ("{00001234-0000-1000-8000-00805f9b34fb}", "{00001800-0000-1000-8000-00805f9b34fb}", "{00001801-0000-1000-8000-00805f9b34fb}", "{0000fed6-0000-1000-8000-00805f9b34fb}")
Tue Apr 21 15:33:08 2026 1776753188159 Debug: devices/bluetooth.cpp void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo&) "Found new device: " "KS-NACH-X21C" " (" "FD:58:4A:79:B7:DD" )   0 ":" 0 ("{00001234-0000-1000-8000-00805f9b34fb}", "{00001800-0000-1000-8000-00805f9b34fb}", "{00001801-0000-1000-8000-00805f9b34fb}", "{0000fed6-0000-1000-8000-00805f9b34fb}")
homeform not yet loaded
Tue Apr 21 15:33:08 2026 1776753188160 Debug: devices/bluetooth.cpp void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo&) homeform not yet loaded
qt.bluetooth.bluez: BluetoothManagement: Ignored event: 13
Tue Apr 21 15:33:08 2026 1776753188161 Debug:   BluetoothManagement: Ignored event: 13
qt.bluetooth.bluez: Discovered:  "62-40-BB-F2-74-AA" "62:40:BB:F2:74:AA" Num UUIDs 0 total device 1 cached RSSI -53 Num ManufacturerData 1
Tue Apr 21 15:33:08 2026 1776753188162 Debug:   Discovered:  "62-40-BB-F2-74-AA" "62:40:BB:F2:74:AA" Num UUIDs 0 total device 1 cached RSSI -53 Num ManufacturerData 1
manufacturerData QVector(76)
Tue Apr 21 15:33:08 2026 1776753188163 Debug: devices/bluetooth.cpp void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo&) manufacturerData QVector(76)
76 "10 06 0d 1d c1 11 67 48"
Tue Apr 21 15:33:08 2026 1776753188164 Debug: devices/bluetooth.cpp void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo&) 76 "10 06 0d 1d c1 11 67 48"
"Found new device: " "62-40-BB-F2-74-AA" " (" "62:40:BB:F2:74:AA" )   0 ":" 0 ()
Tue Apr 21 15:33:08 2026 1776753188164 Debug: devices/bluetooth.cpp void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo&) "Found new device: " "62-40-BB-F2-74-AA" " (" "62:40:BB:F2:74:AA" )   0 ":" 0 ()
qt.bluetooth.bluez: void QBluetoothDeviceDiscoveryAgentPrivate::stop()
Tue Apr 21 15:33:08 2026 1776753188183 Debug:   void QBluetoothDeviceDiscoveryAgentPrivate::stop()
"BTLE scanning stops"
Tue Apr 21 15:33:08 2026 1776753188185 Debug: devices/bluetooth.cpp void bluetooth::debug(const QString&) "BTLE scanning stops"
"Open status.xml for writing failed"
Tue Apr 21 15:33:08 2026 1776753188190 Debug: devices/bluetooth.cpp void bluetooth::stateFileRead() "Open status.xml for writing failed"
KS-NACH-X21C workaround!
Tue Apr 21 15:33:08 2026 1776753188191 Debug: devices/kingsmithr2treadmill/kingsmithr2treadmill.cpp void kingsmithr2treadmill::deviceDiscovered(const QBluetoothDeviceInfo&) KS-NACH-X21C workaround!
qt.bluetooth.bluez: Detecting bluetoothd version
Tue Apr 21 15:33:08 2026 1776753188192 Debug:   Detecting bluetoothd version
qt.bluetooth.bluez: Using /proc/<pid>/exe
Tue Apr 21 15:33:08 2026 1776753188195 Debug:   Using /proc/<pid>/exe
qt.bluetooth.bluez: Detected bluetoothd version 5.82
Tue Apr 21 15:33:08 2026 1776753188213 Debug:   Detected bluetoothd version 5.82
qt.bluetooth.bluez: Bluetoothd: "5.82"
Tue Apr 21 15:33:08 2026 1776753188214 Debug:   Bluetoothd: "5.82"
qt.bluetooth: Using BlueZ LE DBus API
Tue Apr 21 15:33:08 2026 1776753188214 Warning:   Using BlueZ LE DBus API
qt.bluetooth.bluez: QLowEnergyControllerPrivateBluezDBus::connectToDevice()
Tue Apr 21 15:33:08 2026 1776753188238 Debug:   QLowEnergyControllerPrivateBluezDBus::connectToDevice()
qt.bluetooth: QLowEnergyControllerPrivate setting state to QLowEnergyController::ConnectingState
Tue Apr 21 15:33:08 2026 1776753188253 Debug:   QLowEnergyControllerPrivate setting state to QLowEnergyController::ConnectingState
"controllerStateChanged" QLowEnergyController::ConnectingState
Tue Apr 21 15:33:08 2026 1776753188253 Debug: devices/kingsmithr2treadmill/kingsmithr2treadmill.cpp void kingsmithr2treadmill::controllerStateChanged(QLowEnergyController::ControllerState) "controllerStateChanged" QLowEnergyController::ConnectingState
qt.bluetooth: QLowEnergyControllerPrivate setting state to QLowEnergyController::ConnectedState
Tue Apr 21 15:33:08 2026 1776753188258 Debug:   QLowEnergyControllerPrivate setting state to QLowEnergyController::ConnectedState
"controllerStateChanged" QLowEnergyController::ConnectedState
Tue Apr 21 15:33:08 2026 1776753188258 Debug: devices/kingsmithr2treadmill/kingsmithr2treadmill.cpp void kingsmithr2treadmill::controllerStateChanged(QLowEnergyController::ControllerState) "controllerStateChanged" QLowEnergyController::ConnectedState
"Controller connected. Search services..."
Tue Apr 21 15:33:08 2026 1776753188259 Debug: devices/bluetooth.cpp void bluetooth::debug(const QString&) "Controller connected. Search services..."
qt.bluetooth: QLowEnergyControllerPrivate setting state to QLowEnergyController::DiscoveringState
Tue Apr 21 15:33:08 2026 1776753188259 Debug:   QLowEnergyControllerPrivate setting state to QLowEnergyController::DiscoveringState
"controllerStateChanged" QLowEnergyController::DiscoveringState
Tue Apr 21 15:33:08 2026 1776753188259 Debug: devices/kingsmithr2treadmill/kingsmithr2treadmill.cpp void kingsmithr2treadmill::controllerStateChanged(QLowEnergyController::ControllerState) "controllerStateChanged" QLowEnergyController::DiscoveringState
"serviceDiscovered {00001800-0000-1000-8000-00805f9b34fb}"
Tue Apr 21 15:33:08 2026 1776753188271 Debug: devices/bluetooth.cpp void bluetooth::debug(const QString&) "serviceDiscovered {00001800-0000-1000-8000-00805f9b34fb}"
"serviceDiscovered {00001801-0000-1000-8000-00805f9b34fb}"
Tue Apr 21 15:33:08 2026 1776753188277 Debug: devices/bluetooth.cpp void bluetooth::debug(const QString&) "serviceDiscovered {00001801-0000-1000-8000-00805f9b34fb}"
"serviceDiscovered {00001234-0000-1000-8000-00805f9b34fb}"
Tue Apr 21 15:33:08 2026 1776753188283 Debug: devices/bluetooth.cpp void bluetooth::debug(const QString&) "serviceDiscovered {00001234-0000-1000-8000-00805f9b34fb}"
qt.bluetooth: QLowEnergyControllerPrivate setting state to QLowEnergyController::DiscoveredState
Tue Apr 21 15:33:08 2026 1776753188284 Debug:   QLowEnergyControllerPrivate setting state to QLowEnergyController::DiscoveredState
"controllerStateChanged" QLowEnergyController::DiscoveredState
Tue Apr 21 15:33:08 2026 1776753188284 Debug: devices/kingsmithr2treadmill/kingsmithr2treadmill.cpp void kingsmithr2treadmill::controllerStateChanged(QLowEnergyController::ControllerState) "controllerStateChanged" QLowEnergyController::DiscoveredState
"serviceScanDone"
Tue Apr 21 15:33:08 2026 1776753188285 Debug: devices/bluetooth.cpp void bluetooth::debug(const QString&) "serviceScanDone"
"service id not found 00021234"
Tue Apr 21 15:33:08 2026 1776753188285 Debug: devices/bluetooth.cpp void bluetooth::debug(const QString&) "service id not found 00021234"
"service id not found 00011234"
Tue Apr 21 15:33:08 2026 1776753188286 Debug: devices/bluetooth.cpp void bluetooth::debug(const QString&) "service id not found 00011234"
"using service id 00001234"
Tue Apr 21 15:33:08 2026 1776753188286 Debug: devices/bluetooth.cpp void bluetooth::debug(const QString&) "using service id 00001234"
"BTLE stateChanged DiscoveringServices"
Tue Apr 21 15:33:08 2026 1776753188287 Debug: devices/bluetooth.cpp void bluetooth::debug(const QString&) "BTLE stateChanged DiscoveringServices"
qt.bluetooth.bluez: BluetoothManagement: found random device "62:40:BB:F2:74:AA"
Tue Apr 21 15:33:08 2026 1776753188312 Debug:   BluetoothManagement: found random device "62:40:BB:F2:74:AA"
qt.bluetooth.bluez: BluetoothManagement: Ignored event: 13
```

