### PR TITLE
Aggiungi riconoscimento TR510-T come FitShow treadmill

### DIFF
--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -2837,6 +2837,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                     emit searchingStop();
                 this->signalBluetoothDeviceConnected(focusTreadmill);
             } else if (((b.name().startsWith(QStringLiteral("FS-")) && !horizonTreadmill && !snode_bike && !fitplus_bike && !ftmsBike && !iconsole_elliptical) ||
+                        (b.name().toUpper().startsWith(QStringLiteral("TR510-T"))) ||
                         (b.name().toUpper().startsWith(QStringLiteral("NOBLEPRO CONNECT")) && !deviceHasService(b, QBluetoothUuid((quint16)0x1826))) || // FTMS
                         (b.name().startsWith(QStringLiteral("SW")) && b.name().length() == 14 &&
                          !b.name().contains('(') && !b.name().contains(')') && !deviceHasService(b, QBluetoothUuid((quint16)0x1826))) ||

--- a/src/devices/fitshowtreadmill/fitshowtreadmill.cpp
+++ b/src/devices/fitshowtreadmill/fitshowtreadmill.cpp
@@ -838,7 +838,8 @@ void fitshowtreadmill::error(QLowEnergyController::Error err) {
 void fitshowtreadmill::deviceDiscovered(const QBluetoothDeviceInfo &device) {
     emit debug(QStringLiteral("Found new device: ") + device.name() + QStringLiteral(" (") +
                device.address().toString() + ')');
-    if (device.name().toUpper().startsWith(QStringLiteral("FS-"))) {
+    if (device.name().toUpper().startsWith(QStringLiteral("FS-")) ||
+        device.name().toUpper().startsWith(QStringLiteral("TR510-T"))) {
         qDebug() << "FS FIX!";
         fs_connected = true;
     } else if (device.name().toUpper().startsWith(QStringLiteral("NOBLEPRO CONNECT"))) {

--- a/tst/Devices/devicetestdataindex.cpp
+++ b/tst/Devices/devicetestdataindex.cpp
@@ -399,6 +399,7 @@ void DeviceTestDataIndex::Initialize() {
     RegisterNewDeviceTestData(DeviceIndex::FitShowFS)
         ->expectDevice<fitshowtreadmill>()        
         ->acceptDeviceName("FS-", DeviceNameComparison::StartsWith)
+        ->acceptDeviceName("TR510-T", DeviceNameComparison::StartsWithIgnoreCase)
         ->configureSettingsWith(
             [](const DeviceDiscoveryInfo& info, bool enable, std::vector<DeviceDiscoveryInfo>& configurations) -> void
             {


### PR DESCRIPTION
### Motivation
- Alcuni treadmill FitShow appaiono con nome Bluetooth `TR510-T` e devono essere riconosciuti dal ramo di discovery che crea `fitshowtreadmill` per essere gestiti correttamente.

### Description
- Aggiunta la condizione `b.name().toUpper().startsWith(QStringLiteral("TR510-T"))` in `src/devices/bluetooth.cpp` per far corrispondere i dispositivi `TR510-T` al parser `fitshowtreadmill`.
- Aggiornato `tst/Devices/devicetestdataindex.cpp` per includere `TR510-T` nelle accettazioni del dataset di test `FitShowFS` (`->acceptDeviceName("TR510-T", DeviceNameComparison::StartsWithIgnoreCase)`).

### Testing
- Eseguiti i controlli automatici base: `git diff --check` è passato e la ricerca `rg -n "TR510-T" src/devices/bluetooth.cpp tst/Devices/devicetestdataindex.cpp` conferma le modifiche; entrambi i controlli hanno avuto esito positivo.
- Non sono stati eseguiti test unitari o lanci dell’intera suite `tst/qdomyos-zwift-tests` in questa modifica.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3cca8afd48325a514f8201332ed47)