### PR TITLE
Fix/workout editor case sensitive keys

### DIFF
--- a/src/templateinfosenderbuilder.cpp
+++ b/src/templateinfosenderbuilder.cpp
@@ -52,7 +52,6 @@ using namespace std::chrono_literals;
     item[QStringLiteral("zoneHR")] = row.zoneHR;                                                            \
     item[QStringLiteral("HRmin")] = row.HRmin;                                                              \
     item[QStringLiteral("HRmax")] = row.HRmax;                                                              \
-    item[QStringLiteral("maxSpeed")] = row.maxSpeed;                                                        \
     item[QStringLiteral("latitude")] = row.latitude;                                                        \
     item[QStringLiteral("longitude")] = row.longitude;                                                      \
     item[QStringLiteral("altitude")] = row.altitude;                                                        \

--- a/src/templateinfosenderbuilder.cpp
+++ b/src/templateinfosenderbuilder.cpp
@@ -30,12 +30,12 @@ using namespace std::chrono_literals;
     item[QStringLiteral("duration_s")] = QTime(0,0,0).secsTo(row.duration);                                 \
     item[QStringLiteral("distance")] = row.distance;                                                        \
     item[QStringLiteral("speed")] = row.speed;                                                              \
-    item[QStringLiteral("minspeed")] = row.minSpeed;                                                        \
-    item[QStringLiteral("maxspeed")] = row.maxSpeed;                                                        \
+    item[QStringLiteral("minSpeed")] = row.minSpeed;                                                        \
+    item[QStringLiteral("maxSpeed")] = row.maxSpeed;                                                        \
     item[QStringLiteral("fanspeed")] = row.fanspeed;                                                        \
     item[QStringLiteral("inclination")] = row.inclination;                                                  \
     item[QStringLiteral("resistance")] = row.resistance;                                                    \
-    item[QStringLiteral("maxresistance")] = row.maxResistance;                                              \
+    item[QStringLiteral("maxResistance")] = row.maxResistance;                                              \
     item[QStringLiteral("mets")] = row.mets;                                                                \
     item[QStringLiteral("pace_intensity")] = row.pace_intensity;                                            \
     item[QStringLiteral("lower_resistance")] = row.lower_resistance;                                        \


### PR DESCRIPTION
I noticed loading my xml in the workout editor in iOS was missing the minspeed, hence a fix for this:

Fixes the issue where minSpeed, maxSpeed, and maxResistance values were missing/empty when loading workouts in the iOS workout editor.

## Changes

1. **Fix case mismatch** - The TRAINPROGRAM_FIELD_TO_STRING macro serialized JSON keys as lowercase (minspeed, maxspeed, maxresistance) but the JS workout editor expected camelCase (minSpeed, maxSpeed, maxResistance). This caused these fields to be silently dropped when loading workouts.
2. **Remove duplicate** - Removed the duplicate maxSpeed assignment that was accidentally masking the bug for that field.

## Technical Details
- XML files on disk continue to use lowercase attributes (minspeed, maxspeed) - no breaking changes
- JSON serialization over WebSocket now uses camelCase to match the JS editor's expectations
- The translation between formats happens at the TRAINPROGRAM_FIELD_TO_STRING macro boundary

## Commits
- Fix case mismatch in workout editor serialization keys
- Remove duplicate maxSpeed assignment in TRAINPROGRAM_FIELD_TO_STRING macro