### PR TITLE
Remove unused changeSpeedAndInclination signal

### DIFF
--- a/src/homeform.cpp
+++ b/src/homeform.cpp
@@ -1654,8 +1654,6 @@ void homeform::trainProgramSignals() {
                     &treadmill::changeFanSpeed);
             connect(trainProgram, &trainprogram::changeInclination, ((treadmill *)bluetoothManager->device()),
                     &treadmill::changeInclination);
-            connect(trainProgram, &trainprogram::changeSpeedAndInclination, ((treadmill *)bluetoothManager->device()),
-                    &treadmill::changeSpeedAndInclination);
             connect(trainProgram, &trainprogram::intervalTransitionApplied, ((treadmill *)bluetoothManager->device()),
                     &treadmill::onTrainingProgramTransition);
             connect(((treadmill *)bluetoothManager->device()), &treadmill::tapeStarted, trainProgram,

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -313,8 +313,6 @@ void MainWindow::trainProgramSignals() {
                 &treadmill::changeSpeed);
         connect(trainProgram, &trainprogram::changeInclination, ((treadmill *)bluetoothManager->device()),
                 &treadmill::changeInclination);
-        connect(trainProgram, &trainprogram::changeSpeedAndInclination, ((treadmill *)bluetoothManager->device()),
-                &treadmill::changeSpeedAndInclination);
         connect(trainProgram, &trainprogram::changeResistance, ((bike *)bluetoothManager->device()),
                 &bike::changeResistance);
         connect(((treadmill *)bluetoothManager->device()), &treadmill::tapeStarted, trainProgram,

--- a/src/trainprogram.h
+++ b/src/trainprogram.h
@@ -147,7 +147,6 @@ private slots:
     void changeRequestedPelotonResistance(int8_t resistance);
     void changeCadence(int16_t cadence);
     void changePower(int32_t power);
-    void changeSpeedAndInclination(double speed, double inclination);
     void changeGeoPosition(QGeoCoordinate p, double azimuth, double avgAzimuthNext300Meters);
     void changeTimestamp(QTime source, QTime actual);
     void toastRequest(QString message);


### PR DESCRIPTION
This is to make sure the other fix I did (disabling HR controller for 10s when changing speed) does not break at some point in the future: At the moment it focusses on changeSpeed but there is also changeSpeedAndInclination, but the latter is never used.

Hence, suggesting here to remove this "dead code", unless you had plans for it?

- Remove unused signal declaration from trainprogram.h
- Remove dead signal connections from homeform.cpp and mainwindow.cpp
