### PR TITLE
Fix QMutexLocker temporary object bug

### DIFF
--- a/src/trainprogram.cpp
+++ b/src/trainprogram.cpp
@@ -530,7 +530,7 @@ double trainprogram::avgAzimuthNext300Meters() {
 }
 
 void trainprogram::clearRows() {
-    QMutexLocker(&this->schedulerMutex);
+    QMutexLocker locker(&this->schedulerMutex);
     rows.clear();
 }
 
@@ -597,7 +597,7 @@ void trainprogram::pelotonOCRcomputeTime(QString t) {
 
 void trainprogram::scheduler() {
 
-    QMutexLocker(&this->schedulerMutex);
+    QMutexLocker locker(&this->schedulerMutex);
     QSettings settings;
     QDateTime now = QDateTime::currentDateTime();
     qint64 msecsElapsed = lastSchedulerCall.msecsTo(now);

--- a/tst/ToolTests/trainprogrammutextestsuite.cpp
+++ b/tst/ToolTests/trainprogrammutextestsuite.cpp
@@ -1,0 +1,74 @@
+#include "trainprogrammutextestsuite.h"
+
+#include "Tools/testsettings.h"
+#include "bluetooth.h"
+#include "qzsettings.h"
+#include "trainprogram.h"
+
+#include <QElapsedTimer>
+#include <QThread>
+#include <atomic>
+#include <thread>
+
+void TrainProgramMutexTestSuite::test_schedulerAndClearRowsDoNotDeadlock() {
+    TestSettings testSettings(QStringLiteral("qdomyos-zwift-tests"),
+                              QStringLiteral("trainprogram-mutex-tests"));
+    testSettings.activate();
+    testSettings.qsettings.clear();
+    testSettings.qsettings.setValue(QZSettings::zwift_username, QString());
+    testSettings.qsettings.setValue(QZSettings::peloton_companion_workout_ocr, false);
+    testSettings.qsettings.setValue(QZSettings::zwift_ocr, false);
+    testSettings.qsettings.setValue(QZSettings::zwift_ocr_climb_portal, false);
+    testSettings.qsettings.setValue(QZSettings::zwift_workout_ocr, false);
+    testSettings.qsettings.setValue(QZSettings::peloton_workout_ocr, false);
+
+    bluetooth *bt = new bluetooth(false, QString(), false, false, 200, false, false, 4, 1.0, false);
+    trainprogram *program = new trainprogram(QList<trainrow>(), bt);
+
+    std::atomic<bool> start(false);
+    std::atomic<bool> schedulerDone(false);
+    std::atomic<bool> clearRowsDone(false);
+
+    std::thread schedulerThread([&]() {
+        while (!start.load()) {
+            std::this_thread::yield();
+        }
+
+        for (int i = 0; i < 1000; ++i) {
+            program->scheduler();
+        }
+        schedulerDone.store(true);
+    });
+
+    std::thread clearRowsThread([&]() {
+        while (!start.load()) {
+            std::this_thread::yield();
+        }
+
+        for (int i = 0; i < 1000; ++i) {
+            program->clearRows();
+        }
+        clearRowsDone.store(true);
+    });
+
+    start.store(true);
+
+    QElapsedTimer timer;
+    timer.start();
+    while ((!schedulerDone.load() || !clearRowsDone.load()) && timer.elapsed() < 5000) {
+        QThread::msleep(10);
+    }
+
+    if (!schedulerDone.load() || !clearRowsDone.load()) {
+        schedulerThread.detach();
+        clearRowsThread.detach();
+        ADD_FAILURE() << "scheduler() and clearRows() did not finish within the timeout; possible deadlock";
+        return;
+    }
+
+    schedulerThread.join();
+    clearRowsThread.join();
+
+    delete program;
+    delete bt;
+}

--- a/tst/ToolTests/trainprogrammutextestsuite.h
+++ b/tst/ToolTests/trainprogrammutextestsuite.h
@@ -1,0 +1,15 @@
+#ifndef TRAINPROGRAMMUTEXTESTSUITE_H
+#define TRAINPROGRAMMUTEXTESTSUITE_H
+
+#include "gtest/gtest.h"
+
+class TrainProgramMutexTestSuite : public testing::Test {
+  public:
+    void test_schedulerAndClearRowsDoNotDeadlock();
+};
+
+TEST_F(TrainProgramMutexTestSuite, SchedulerAndClearRowsDoNotDeadlock) {
+    this->test_schedulerAndClearRowsDoNotDeadlock();
+}
+
+#endif // TRAINPROGRAMMUTEXTESTSUITE_H

--- a/tst/qdomyos-zwift-tests.pro
+++ b/tst/qdomyos-zwift-tests.pro
@@ -23,6 +23,7 @@ SOURCES += \
         GarminConnect/garminconnecttestsuite.cpp \
         ToolTests/qfittestsuite.cpp \
         ToolTests/testsettingstestsuite.cpp \
+        ToolTests/trainprogrammutextestsuite.cpp \
         ToolTests/testtrainingloadtestsuite.cpp \
         Tools/testsettings.cpp \
         Tools/typeidgenerator.cpp \
@@ -62,6 +63,7 @@ HEADERS += \
     GarminConnect/garminconnecttestsuite.h \
     ToolTests/qfittestsuite.h \
     ToolTests/testsettingstestsuite.h \
+    ToolTests/trainprogrammutextestsuite.h \
     ToolTests/testtrainingloadtestsuite.h \
     Tools/devicetypeid.h \
     Tools/testsettings.h \


### PR DESCRIPTION
Claude code seems very confident about it (granted, it always is very confident...), I have been reading up and it seems to make sense, but since I am not an expert, of course if will seems logical to me, that's what LLMs are all about – making it seem plausible.

Do have a detailed and skeptical look to this – most of all because I don't know how to test this.

---

### Problem

QMutexLocker was being instantiated as an unnamed temporary, which locks and immediately unlocks the mutex on the **same line**. This is a well-known C++ pitfall where the compiler silently accepts the code but provides zero synchronization.

### Before (Broken):

```cpp
void trainprogram::clearRows() {
    QMutexLocker(&this->schedulerMutex);  // Temporary created and destroyed
    rows.clear();                           // No lock held here!
}
```
### After (Fixed):
```cpp
void trainprogram::clearRows() {
    QMutexLocker locker(&this->schedulerMutex);  // Variable holds the lock
    rows.clear();                                  // Lock held for entire scope
}
```

### Why This Matters
The `clearRows()` and `scheduler()` methods have been running completely unprotected.
Both methods access and modify the rows list, which can be called concurrently:
- `scheduler()` called every 1 second by a timer (main thread)
- `clearRows()` called from Peloton integration (main thread, different control flow)
- rows list is accessed by both, plus read by interval/ramp calculations
### Consequences of the Bug
Without the mutex held, this creates a data race:
- List corruption during concurrent modifications
- Iterator invalidation crashes when iterating over a list being cleared
- Undefined behavior in speed/incline calculations during workouts
- Silent data loss or duplicate rows in training programs
### Changes
- `src/trainprogram.cpp:533` — Add variable name to `QMutexLocker` in `clearRows()`
- `src/trainprogram.cpp:600` — Add variable name to `QMutexLocker` in `scheduler()`
The fix ensures the mutex is held for the entire duration of each method's execution, providing proper mutual exclusion as intended.