### PR TITLE
Fix division by zero in speed ramp calculation

### DIFF
--- a/src/trainprogram.cpp
+++ b/src/trainprogram.cpp
@@ -1729,6 +1729,8 @@ QList<trainrow> trainprogram::loadXML(const QString &filename, BLUETOOTH_TYPE de
                 int durationStep;
                 double speedStep;
                 int spareSeconds;
+                if(speedDelta == 0)
+                    speedDelta = 1;
                 if(speedDelta <= durationS) {
                     durationStep = durationS / speedDelta;
                     speedStep = 0.1;


### PR DESCRIPTION
[I hope it's ok and I'm not spamming you – I'm focusing on small code fixes]

## Problem

When loading workouts with speed ramps where `speedFrom == speedTo` (no speed change), the training program crashes with a division by zero error.

### Root Cause

Line 1728 calculates: `int speedDelta = (fabs(speedTo - speedFrom) / 0.1);`
When `speedTo == speedFrom`, this equals 0. Line 1733 then divides by this zero value:
```cpp
durationStep = durationS / speedDelta;  // speedDelta is 0 → crash
```
### For comparison
The power zone ramp calculation (lines 1778-1793) already has a guard for this exact scenario:
```cpp
if(speedDelta == 0)
    speedDelta = 1;
```
But the speed ramp calculation (lines 1728-1741) was missing this protection, causing an inconsistency where power zone workouts work but speed ramp workouts crash.

### Solution
Add the same guard to the speed ramp section. When there's no speed change, set `speedDelta = 1` to make the division safe. This results in 1 step of 0.1 km/h increments, which is appropriate for zero speed change.

### Changes
- Add 2-line guard after speedDelta calculation in `src/trainprogram.cpp` (line 1732)