### PR TITLE
Fix division by zero in currentRowRemainingTime

### DIFF
--- a/src/trainprogram.cpp
+++ b/src/trainprogram.cpp
@@ -1923,6 +1923,8 @@ QTime trainprogram::currentRowRemainingTime() {
     if (currentStep < rows.length() && rows.at(currentStep).distance > 0 && bluetoothManager &&
         bluetoothManager->device()) {
         double speed = bluetoothManager->device()->currentSpeed().value();
+        if (speed <= 0)
+            return QTime(0, 0, 0);
         double distance = rows.at(currentStep).distance;
         distance -= currentStepDistance;
         int seconds = (distance / speed) * 3600.0;


### PR DESCRIPTION
## Problem

When the treadmill is stationary (speed = 0), `currentRowRemainingTime()` crashes or displays garbage values in the UI time display.

### Root Cause

The method calculates remaining time based on remaining distance divided by current speed:

```cpp
double speed = bluetoothManager->device()->currentSpeed().value();
double distance = rows.at(currentStep).distance - currentStepDistance;
int seconds = (distance / speed) * 3600.0;  // ← Division by zero if speed = 0
```
When speed = 0, this produces infinity. Casting infinity to int is undefined behavior in C++, resulting in garbage values or crashes.

### Solution

Guard against speed <= 0 and return a sensible default:
```cpp
double speed = bluetoothManager->device()->currentSpeed().value();
if (speed <= 0)
    return QTime(0, 0, 0);
```
When the device is stationary, there is no meaningful way to calculate time remaining based on current speed, so returning 0 time is appropriate.

### Changes

- Add 2-line guard after speed retrieval in `src/trainprogram.cpp:1926`