### PR TITLE
Fix division by zero in avgAzimuthNext300Meters

### DIFF
--- a/src/trainprogram.cpp
+++ b/src/trainprogram.cpp
@@ -496,11 +496,8 @@ double trainprogram::avgAzimuthNext300Meters() {
         while (1) {
             if (c < rows.length()) {
                 if (km > 0.3) {
-                    double averageDirection = atan(sinTotal / cosTotal) * (180 / M_PI);
-
-                    if (cosTotal < 0) {
-                        averageDirection += 180;
-                    } else if (sinTotal < 0) {
+                    double averageDirection = atan2(sinTotal, cosTotal) * (180 / M_PI);
+                    if (averageDirection < 0) {
                         averageDirection += 360;
                     }
                     return averageDirection;
@@ -514,11 +511,8 @@ double trainprogram::avgAzimuthNext300Meters() {
                 km += rows.at(c).distance;
 
             } else {
-                double averageDirection = atan(sinTotal / cosTotal) * (180 / M_PI);
-
-                if (cosTotal < 0) {
-                    averageDirection += 180;
-                } else if (sinTotal < 0) {
+                double averageDirection = atan2(sinTotal, cosTotal) * (180 / M_PI);
+                if (averageDirection < 0) {
                     averageDirection += 360;
                 }
                 return averageDirection;


### PR DESCRIPTION
### Problem

When computing average direction for GPS-based routes, if the cumulative cosine component equals zero (e.g., all route segments have azimuths of 90° or 270°), the calculation divides by zero:

```cpp
double averageDirection = atan(sinTotal / cosTotal) * (180 / M_PI);
// When cosTotal = 0 → division by zero → infinity → NaN
```

This results in NaN propagating through GPS heading calculations, causing incorrect route direction during GPS-based workouts.

### Solution

Replace atan(sinTotal / cosTotal) with atan2(sinTotal, cosTotal).
The atan2 function handles both components directly without division, so it is safe when cosTotal is zero.
This also simplifies the quadrant correction logic. The previous code manually adjusted the result based on the signs of cosTotal and sinTotal:
```cpp
// Before: manual quadrant correction
double averageDirection = atan(sinTotal / cosTotal) * (180 / M_PI);
if (cosTotal < 0) {
    averageDirection += 180;
} else if (sinTotal < 0) {
    averageDirection += 360;
}
```
Since atan2 returns values in -180°, 180°, a single normalization check is sufficient:
```cpp
// After: simple normalization
double averageDirection = atan2(sinTotal, cosTotal) * (180 / M_PI);
if (averageDirection < 0) {
    averageDirection += 360;
}
```

### Changes
- Replace atan with atan2 at two call sites in avgAzimuthNext300Meters()
- Simplify quadrant correction to single negative-angle check
- Net result: 4 insertions, 10 deletions