### PR TITLE
Fix memory leak and use-after-free risk for trainProgram

### DIFF
--- a/src/homeform.cpp
+++ b/src/homeform.cpp
@@ -8127,6 +8127,7 @@ void homeform::trainprogram_open_clicked(const QUrl &fileName) {
             }
             if (trainProgram) {
                 delete trainProgram;
+                trainProgram = nullptr;
             }
 
             trainProgram = trainprogram::load(file.fileName(), bluetoothManager, file.fileName().right(3).toUpper());
@@ -8222,6 +8223,7 @@ void homeform::trainprogram_preview(const QUrl &fileName) {
 
 void homeform::trainprogram_zwo_loaded(const QString &s) {
     qDebug() << QStringLiteral("trainprogram_zwo_loaded") << s;
+    delete trainProgram;
     trainProgram = new trainprogram(zwiftworkout::loadJSON(s), bluetoothManager);
     if (trainProgram) {
         QJsonDocument doc = QJsonDocument::fromJson(s.toUtf8());
@@ -8425,6 +8427,7 @@ void homeform::gpx_open_clicked(const QUrl &fileName) {
             if (trainProgram) {
 
                 delete trainProgram;
+                trainProgram = nullptr;
             }
 
             // KML to GPX https://www.gpsvisualizer.com/elevation


### PR DESCRIPTION
### Problem
Three locations in `homeform.cpp` where `trainProgram` is not properly managed, causing a memory leak and use-after-free risk.

1. `trainprogram_open_clicked` (line 8129) — dangling pointer
`trainProgram` is deleted but not set to `nullptr`. If `trainprogram::load()` fails, the pointer remains dangling and future `if (trainProgram)` checks pass on freed memory.
2. `trainprogram_zwo_loaded` (line 8226) — memory leak
`trainProgram` is overwritten with a new allocation without deleting the old object first. Every time a ZWO workout is loaded, the previous trainProgram object leaks.
3. `gpx_open_clicked` (line 8427) — dangling pointer
Same issue as location 1: deleted without null assignment.
### Root Cause
Inconsistent application of the delete-then-null pattern. The codebase already follows the correct pattern elsewhere (e.g., line 1254):
```cpp
delete trainProgram;
trainProgram = nullptr;
```
### Solution
- Locations 1 and 3: Add `trainProgram = nullptr;` after delete
- Location 2: Add `delete trainProgram;` before the new allocation
Note: `delete nullptr` is safe in C++ (it's a no-op), so the added delete at location 2 is safe even if `trainProgram` is already null.
### Changes
- src/homeform.cpp:8130 — Add null assignment in `trainprogram_open_clicked()`
- src/homeform.cpp:8226 — Add missing delete in `trainprogram_zwo_loaded()`
- src/homeform.cpp:8429 — Add null assignment in `gpx_open_clicked()`