### PR TITLE
Fix null dereference in scheduler tick processing

### DIFF
--- a/src/trainprogram.cpp
+++ b/src/trainprogram.cpp
@@ -866,6 +866,10 @@ void trainprogram::scheduler() {
         qDebug() << QStringLiteral("fixing jitter!") << seconds << ticks << currentTimerJitter;
     }
 
+    if (!bluetoothManager || !bluetoothManager->device()) {
+        return;
+    }
+
     double odometerFromTheDevice = bluetoothManager->device()->odometer();
 
     if(ticks < 0) {


### PR DESCRIPTION
### Fix null dereference in scheduler path

#### Problem

In `trainprogram.cpp:869`, `odometer()` is called unconditionally:

```cpp
double odometerFromTheDevice = bluetoothManager->device()->odometer();
```

This occurs before the null-guard at line 626, creating a TOCTOU race condition:
1. First, bluetoothManager->device() is accessed (line 869)  
2. Then later, it's checked for null (line 626)
If the device disconnects between these operations, the code crashes.
#### Root Cause
Method `timeRateFromGPX()` calls `bluetoothManager->device()->odometer()` without checking if device is null (TOCTOU race).

#### Solution

Add a null guard before the odometer() call to prevent crash under race conditions.
Changes
- Add preliminary null check in `trainprogram.cpp:869` before device access