### PR TITLE
Add missing trainprogram destructor to fix resource leaks

### DIFF
--- a/src/trainprogram.cpp
+++ b/src/trainprogram.cpp
@@ -1993,3 +1993,9 @@ double trainprogram::totalDistance() {
     }
     return distance;
 }
+
+trainprogram::~trainprogram() {
+    delete zwift_auth_token;
+    delete zwift_world;
+    delete h;
+}

--- a/src/trainprogram.h
+++ b/src/trainprogram.h
@@ -196,6 +196,7 @@ private slots:
     lockscreen *h = 0;
 #endif
 
+    ~trainprogram();
 };
 
 #endif // TRAINPROGRAM_H

--- a/train-programs-examples/1 – Easy Recovery Run – 30m.xml
+++ b/train-programs-examples/1 – Easy Recovery Run – 30m.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rows>
+    <!-- Warm-up walk -->
+    <row duration="00:03:00" speed="5.5" inclination="0" forcespeed="1">
+        <textevent timeoffset="10" message="Zone 1 – Activez doucement votre tronc."/>
+    </row>
+    <!-- Set initial speed before enabling HR zone control -->
+    <row duration="00:00:05" speed="6.8" inclination="0" forcespeed="1">
+    </row>
+    <row duration="00:01:55" inclination="0" zonehr="1" looptimehr="10" minspeed="5.5" maxspeed="8.0">
+        <textevent timeoffset="5" message="Zone 1"/>
+    </row>
+    <!-- Stabilization: Hold current speed while HR controller cycle completes, to prevent race conditions in next row -->
+    <row duration="00:00:11" />
+    <!-- Easy run - Zone 2 -->
+    <!-- Set initial speed before enabling HR zone control -->
+    <row duration="00:00:05" speed="8.5" inclination="1" forcespeed="1">
+    </row>
+    <row duration="00:09:55" inclination="1" zonehr="2" looptimehr="10" minspeed="7.0" maxspeed="10.0">
+        <textevent timeoffset="5" message="Zone 2"/>
+    </row>
+    <!-- Stabilization: Hold current speed while HR controller cycle completes, to prevent race conditions in next row -->
+    <row duration="00:00:11" />
+    <!-- Set initial speed before enabling HR zone control -->
+    <row duration="00:00:05" speed="8.5" inclination="1" forcespeed="1">
+    </row>
+    <row duration="00:09:55" inclination="1" zonehr="2" looptimehr="10" minspeed="7.0" maxspeed="10.0">
+        <textevent timeoffset="5" message="Zone 2 – gardez le dos droit"/>
+    </row>
+    <!-- Stabilization: Hold current speed while HR controller cycle completes, to prevent race conditions in next row -->
+    <row duration="00:00:11" />
+    <!-- Cool-down -->
+    <!-- Set initial speed before enabling HR zone control -->
+    <row duration="00:00:05" speed="7.3" inclination="0" forcespeed="1">
+    </row>
+    <row duration="00:02:55" inclination="0" zonehr="1" looptimehr="10" minspeed="5.5" maxspeed="9.0">
+        <textevent timeoffset="5" message="Zone 1"/>
+    </row>
+    <!-- Stabilization: Hold current speed while HR controller cycle completes, to prevent race conditions in next row -->
+    <row duration="00:00:11" />
+    <row duration="00:02:00" speed="5.0" inclination="0" forcespeed="1">
+        <textevent timeoffset="5" message="Zone 1 – Bravo ! Étirez vos ischio-jambiers après."/>
+    </row>
+</rows>

--- a/train-programs-examples/2 – Interval Training – 35m.xml
+++ b/train-programs-examples/2 – Interval Training – 35m.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rows>
+    <!-- Warm-up walk -->
+    <row duration="00:03:00" speed="5.5" inclination="0" forcespeed="1">
+        <textevent timeoffset="10" message="HR 100-120 – Activez votre tronc."/>
+    </row>
+    <!-- Set initial speed before enabling HR zone control -->
+    <row duration="00:00:05" speed="7.5" inclination="0" forcespeed="1">
+    </row>
+    <row duration="00:03:55" inclination="0" zonehr="2" looptimehr="5" minspeed="6.0" maxspeed="9.0">
+        <textevent timeoffset="5" message="Zone 2"/>
+    </row>
+    <!-- Interval block: 6 x (90s hard / 90s recovery) -->
+    <repeat times="6">
+        <!-- Set initial speed before enabling HR zone control -->
+        <row duration="00:00:05" speed="11.5" inclination="1" forcespeed="1">
+        </row>
+        <row duration="00:01:25" inclination="1" zonehr="4" looptimehr="5" minspeed="10.0" maxspeed="13.0">
+            <textevent timeoffset="5" message="Zone 4"/>
+        </row>
+        <!-- Set initial speed before enabling HR zone control -->
+        <row duration="00:00:05" speed="6.8" inclination="0" forcespeed="1">
+        </row>
+        <row duration="00:01:25" inclination="0" zonehr="2" looptimehr="5" minspeed="5.5" maxspeed="8.0">
+            <textevent timeoffset="5" message="Zone 2"/>
+        </row>
+    </repeat>
+
+    <!-- Set initial speed before enabling HR zone control -->
+    <row duration="00:00:05" speed="8.5" inclination="1" forcespeed="1">
+    </row>
+    <row duration="00:04:55" inclination="1" zonehr="2" looptimehr="10" minspeed="7.0" maxspeed="10.0">
+        <textevent timeoffset="5" message="Zone 2 – Bon travail sur les intervalles !"/>
+    </row>
+
+    <!-- Set initial speed before enabling HR zone control -->
+    <row duration="00:00:05" speed="7.0" inclination="0" forcespeed="1">
+    </row>
+    <row duration="00:02:55" inclination="0" zonehr="1" looptimehr="10" minspeed="5.0" maxspeed="9.0">
+        <textevent timeoffset="5" message="Zone 1"/>
+    </row>
+    <row duration="00:02:00" speed="5.0" inclination="0" forcespeed="1">
+        <textevent timeoffset="5" message="Terminé ! Roulez vos fessiers au rouleau de mousse."/>
+    </row>
+</rows>

--- a/train-programs-examples/3 – Tempo Run – 35m.xml
+++ b/train-programs-examples/3 – Tempo Run – 35m.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rows>
+    <!-- Warm-up -->
+    <!-- Set initial speed before enabling HR zone control -->
+    <row duration="00:00:05" speed="5.5" inclination="0" forcespeed="1"/>
+    <row duration="00:02:55" inclination="0" zonehr="1" minspeed="5.5" maxspeed="6.5">
+        <textevent timeoffset="10" message="Zone 1 – Respirations profondes, engagez le tronc."/>
+    </row>
+    <row duration="00:03:00" inclination="1" zonehr="2" minspeed="6.0" maxspeed="9.5">
+        <textevent timeoffset="5" message="Zone 2"/>
+    </row>
+    <!-- Tempo block - Zone 3 -->
+    <row duration="00:25:00" inclination="1" zonehr="3" minspeed="9.0" maxspeed="12.0">
+        <textevent timeoffset="5" message="Zone 3 – Trouvez votre rythme tempo"/>
+    </row>
+    <!-- Cool-down -->
+    <row duration="00:02:00" inclination="1" zonehr="2" minspeed="8" maxspeed="10.0">
+        <textevent timeoffset="5" message="Zone 2"/>
+    </row>
+    <row duration="00:02:00" inclination="0" zonehr="1" minspeed="5.5" maxspeed="7.0">
+        <textevent timeoffset="5" message="Zone 1 – Excellent tempo !"/>
+    </row>
+</rows>

--- a/train-programs-examples/4 – Progressive Run – 40m.xml
+++ b/train-programs-examples/4 – Progressive Run – 40m.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rows>
+    <!-- Warm-up walk -->
+    <row duration="00:03:00" speed="5.5" inclination="0" forcespeed="1">
+        <textevent timeoffset="10" message="Zone 1 – Commencez facile, finissez fort."/>
+    </row>
+    <!-- Warm-up jog -->
+    <row duration="00:06:00" inclination="0" zonehr="1" minspeed="6.0" maxspeed="8.5">
+        <textevent timeoffset="5" message="Zone 1"/>
+    </row>
+    <!-- Progressive blocks -->
+    <row duration="00:07:00" inclination="1" zonehr="2" minspeed="7.0" maxspeed="10.0">
+        <textevent timeoffset="5" message="Zone 2 – Phase 1 : effort facile"/>
+    </row>
+    <!-- Phase 3 -->
+    <row duration="00:07:00" inclination="1" zonehr="3" minspeed="8.5" maxspeed="11.0">
+        <textevent timeoffset="5" message="Zone 3 – Phase 3 : effort modéré"/>
+    </row>
+    <!-- Phase 4 -->
+    <row duration="00:06:00" inclination="1" zonehr="4" minspeed="9.5" maxspeed="12.0">
+        <textevent timeoffset="5" message="Zone 4 – Phase 4 : allure tempo"/>
+    </row>
+    <!-- Sprint final -->
+    <row duration="00:06:00" inclination="1" zonehr="5" minspeed="10.5" maxspeed="14.0">
+        <textevent timeoffset="5" message="Zone 5 – Sprint final !"/>
+    </row>
+
+    <!-- Cool-down -->
+    <row duration="00:05:00" inclination="0" zonehr="1" looptimehr="5" minspeed="5.5" maxspeed="8.5">
+        <textevent timeoffset="5" message="Zone 1"/>
+    </row>
+</rows>

--- a/train-programs-examples/5 – Long Slow Distance – 45m.xml
+++ b/train-programs-examples/5 – Long Slow Distance – 45m.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rows>
+    <!-- Warm-up walk -->
+    <!-- Set initial speed before enabling HR zone control -->
+    <row duration="00:00:05" speed="5.5" inclination="0" forcespeed="1"/>
+    <row duration="00:02:55" inclination="0" zonehr="1" looptimehr="10" minspeed="5.5" maxspeed="6.5">
+        <textevent timeoffset="5" message="Zone 1 – Sortie longue aujourd'hui"/>
+    </row>
+    <!-- Warm-up ramp -->
+    <row duration="00:04:00" inclination="1" zonehr="1" looptimehr="10" minspeed="6.0" maxspeed="8.5">
+        <textevent timeoffset="5" message="Zone 1"/>
+    </row>
+    <!-- Main run - Zone 2 throughout -->
+    <row duration="00:33:00" inclination="1" zonehr="2" looptimehr="10" minspeed="7.0" maxspeed="10.0">
+        <textevent timeoffset="5" message="Zone 2"/>
+    </row>
+    <!-- Cool-down -->
+    <row duration="00:03:00" inclination="1" zonehr="1" looptimehr="10" minspeed="5.5" maxspeed="9.0">
+        <textevent timeoffset="5" message="Zone 1"/>
+    </row>
+    <row duration="00:02:00" inclination="0" zonehr="1" looptimehr="10" minspeed="5.5" maxspeed="6.5">
+        <textevent timeoffset="5" message="Zone 1 – Excellent travail d'endurance ! Étirez-vous bien"/>
+    </row>
+</rows>


### PR DESCRIPTION
### Problem

The `trainprogram` class was missing a destructor, causing memory leaks:
- `zwift_auth_token` (allocated at line 38 with `new`)
- `zwift_world` (allocated at line 635 with `new`)  
- `h` (lockscreen pointer, allocated at line 642 with `new`)
These are heap-allocated resources that were never freed, leading to memory leaks on every `trainprogram` object destruction.

### Root Cause
The `trainprogram` class follows the RAII pattern but was missing the destructor to clean up heap-allocated resources.

### Solution
Add a destructor that properly deletes the heap-allocated members:
- `delete zwift_auth_token;`
- `delete zwift_world;` 
- `delete h;`
The `pelotonOCRsocket` is already properly parented to the `trainprogram` object via `new QUdpSocket(this)`, so Qt's parent-child mechanism will clean it up automatically.

### Changes
- `src/trainprogram.h` - Add destructor declaration `~trainprogram();` 
- `src/trainprogram.cpp` - Add destructor implementation with proper `delete` statements