### PR TITLE
solebike: fallback a FTMS se manca il servizio principale (evita crash)

### DIFF
--- a/src/devices/solebike/solebike.cpp
+++ b/src/devices/solebike/solebike.cpp
@@ -3,6 +3,8 @@
 #include "keepawakehelper.h"
 #endif
 #include "virtualdevices/virtualbike.h"
+#include "homeform.h"
+#include "qzsettings.h"
 #include <QBluetoothLocalDevice>
 #include <QDateTime>
 #include <QFile>
@@ -515,6 +517,25 @@ void solebike::serviceScanDone(void) {
     QBluetoothUuid _gattCommunicationChannelServiceId(QStringLiteral("49535343-fe7d-4ae5-8fa9-9fafd205e455"));
 
     gattCommunicationChannelService = m_control->createServiceObject(_gattCommunicationChannelServiceId);
+
+    if (!gattCommunicationChannelService) {
+        // Main Sole service not found, try FTMS service as a fallback to avoid crashes.
+        QBluetoothUuid ftmsServiceId((quint16)0x1826);
+        QLowEnergyService *ftmsService = m_control->createServiceObject(ftmsServiceId);
+        if (ftmsService) {
+            QSettings settings;
+            settings.setValue(QZSettings::ftms_bike, bluetoothDevice.name());
+            qDebug() << "forcing FTMS bike since Sole main service is missing but FTMS service is available";
+            if (homeform::singleton()) {
+                homeform::singleton()->setToastRequested("FTMS bike found, restart the app to apply the change");
+            }
+            delete ftmsService;
+        } else {
+            qDebug() << "Sole main service and FTMS service not found, skipping service init to avoid crash";
+        }
+        return;
+    }
+
     connect(gattCommunicationChannelService, &QLowEnergyService::stateChanged, this, &solebike::stateChanged);
     gattCommunicationChannelService->discoverDetails();
 }


### PR DESCRIPTION
### Motivation
- Evitare un crash quando la `sole` bike non espone il servizio proprietario `49535343-fe7d-4ae5-8fa9-9fafd205e455` e comportarsi come altri dispositivi che fanno fallback su FTMS se disponibile.

### Description
- Aggiunto controllo null in `solebike::serviceScanDone()` e fallback che verifica la presenza del servizio FTMS (`0x1826`), imposta `QZSettings::ftms_bike` e mostra un toast tramite `homeform::singleton()`; se non c’è nulla viene loggato e la funzione ritorna senza dereferenziare il servizio (file modificato: `src/devices/solebike/solebike.cpp`).

### Testing
- Nessun test automatico è stato eseguito su questa modifica (sono state verificate le modifiche con `git diff`/`git status` e il commit è andato a buon fine).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91c9232ec8325a7e563f853edd742)