### PR TITLE
Technogym elliptical D5CA

### DIFF
--- a/src/devices/ypooelliptical/ypooelliptical.cpp
+++ b/src/devices/ypooelliptical/ypooelliptical.cpp
@@ -304,11 +304,25 @@ void ypooelliptical::characteristicChanged(const QLowEnergyCharacteristic &chara
             lastPacket = newvalue;
         }
 
+        if (lastPacket.length() < 3) {
+            qDebug() << "packet malformed: too short for FTMS flags" << lastPacket.length();
+            return;
+        }
+
+        auto ensurePacketBytes = [&](int needed, const char *field) {
+            if (index + needed > lastPacket.length()) {
+                qDebug() << "packet malformed while parsing" << field << "index" << index << "needed" << needed << "len" << lastPacket.length();
+                return false;
+            }
+            return true;
+        };
+
         int index = 0;
         Flags.word_flags = (lastPacket.at(2) << 16) | (lastPacket.at(1) << 8) | lastPacket.at(0);
         index += 3;
 
         if (!Flags.moreData) {
+            if (!ensurePacketBytes(2, "instantaneousSpeed")) return;
             // For TRUE_ELLIPTICAL, skip instantaneous speed (will use avgSpeed instead)
             if(!TRUE_ELLIPTICAL && (E35 || SCH_590E || SCH_411_510E || KETTLER || CARDIOPOWER_EEGO || MYELLIPTICAL || SKANDIKA || DOMYOS || FEIER || MX_AS || FTMS || SOLE_E25)) {
                 Speed = ((double)(((uint16_t)((uint8_t)lastPacket.at(index + 1)) << 8) |
@@ -321,6 +335,7 @@ void ypooelliptical::characteristicChanged(const QLowEnergyCharacteristic &chara
 
         // this particular device, seems to send the actual speed here
         if (Flags.avgSpeed) {
+            if (!ensurePacketBytes(2, "avgSpeed")) return;
             double avgSpeed = ((double)(((uint16_t)((uint8_t)lastPacket.at(index + 1)) << 8) |
                                         (uint16_t)((uint8_t)lastPacket.at(index)))) /
                               100.0;
@@ -341,6 +356,7 @@ void ypooelliptical::characteristicChanged(const QLowEnergyCharacteristic &chara
         }
 
         if (Flags.totDistance) {
+            if (!ensurePacketBytes(3, "totDistance")) return;
             if(!E35 && !SCH_590E && !SCH_411_510E && !KETTLER && !CARDIOPOWER_EEGO && !MYELLIPTICAL && !SKANDIKA && !DOMYOS && !FEIER && !MX_AS && !TRUE_ELLIPTICAL && !FTMS && !SOLE_E25) {
                 Distance = ((double)((((uint32_t)((uint8_t)lastPacket.at(index + 2)) << 16) |
                                   (uint32_t)((uint8_t)lastPacket.at(index + 1)) << 8) |
@@ -359,6 +375,7 @@ void ypooelliptical::characteristicChanged(const QLowEnergyCharacteristic &chara
         emit debug(QStringLiteral("Current Distance: ") + QString::number(Distance.value()));
 
         if (Flags.stepCount) {
+            if (!ensurePacketBytes(4, "stepCount")) return;
             if (settings.value(QZSettings::cadence_sensor_name, QZSettings::default_cadence_sensor_name)
                     .toString()
                     .startsWith(QStringLiteral("Disabled"))) {
@@ -389,6 +406,7 @@ void ypooelliptical::characteristicChanged(const QLowEnergyCharacteristic &chara
         }
 
         if (Flags.strideCount) {
+            if (!ensurePacketBytes(2, "strideCount")) return;
             // Read current stride count (cumulative total)
             uint16_t currentStrideCount = ((uint16_t)((uint8_t)lastPacket.at(index + 1)) << 8) |
                                           (uint16_t)((uint8_t)lastPacket.at(index));
@@ -444,6 +462,7 @@ void ypooelliptical::characteristicChanged(const QLowEnergyCharacteristic &chara
         }
 
         if (Flags.rampAngle) {
+            if (!ensurePacketBytes(4, "rampAngle")) return;
             // Read Inclination (first field)
             Inclination = (((double)(((uint16_t)((uint8_t)lastPacket.at(index + 1)) << 8) |
                                    (uint16_t)((uint8_t)lastPacket.at(index))))) / 10.0;
@@ -460,6 +479,7 @@ void ypooelliptical::characteristicChanged(const QLowEnergyCharacteristic &chara
         }
         
         if (Flags.resistanceLvl) {
+            if (!ensurePacketBytes(2, "resistanceLvl")) return;
             Resistance = ((double)(((uint16_t)((uint8_t)lastPacket.at(index + 1)) << 8) |
                                    (uint16_t)((uint8_t)lastPacket.at(index))));
             
@@ -495,6 +515,7 @@ void ypooelliptical::characteristicChanged(const QLowEnergyCharacteristic &chara
         }
 
         if (Flags.instantPower) {
+            if (!ensurePacketBytes(2, "instantPower")) return;
             if (settings.value(QZSettings::power_sensor_name, QZSettings::default_power_sensor_name)
                     .toString()
                     .startsWith(QStringLiteral("Disabled"))) {
@@ -515,7 +536,7 @@ void ypooelliptical::characteristicChanged(const QLowEnergyCharacteristic &chara
 
         emit debug(QStringLiteral("Current Watt: ") + QString::number(m_watt.value()));
 
-        if (Flags.avgPower && lastPacket.length() > index + 1 && !E35 && !SCH_590E && !SCH_411_510E && !KETTLER && !CARDIOPOWER_EEGO && !MYELLIPTICAL && !SKANDIKA && !DOMYOS && !FEIER && !MX_AS && !FTMS && !SOLE_E25) { // E35 has a bug about this
+        if (Flags.avgPower && ensurePacketBytes(2, "avgPower") && !E35 && !SCH_590E && !SCH_411_510E && !KETTLER && !CARDIOPOWER_EEGO && !MYELLIPTICAL && !SKANDIKA && !DOMYOS && !FEIER && !MX_AS && !FTMS && !SOLE_E25) { // E35 has a bug about this
             double avgPower;
             avgPower = ((double)(((uint16_t)((uint8_t)lastPacket.at(index + 1)) << 8) |
                                  (uint16_t)((uint8_t)lastPacket.at(index))));
@@ -523,7 +544,7 @@ void ypooelliptical::characteristicChanged(const QLowEnergyCharacteristic &chara
             index += 2;
         }
 
-        if (Flags.expEnergy && lastPacket.length() > index + 1) {
+        if (Flags.expEnergy && ensurePacketBytes(5, "expEnergy")) {
             /*KCal = ((double)(((uint16_t)((uint8_t)lastPacket.at(index + 1)) << 8) |
                              (uint16_t)((uint8_t)lastPacket.at(index))));*/
             index += 2;
@@ -555,7 +576,7 @@ void ypooelliptical::characteristicChanged(const QLowEnergyCharacteristic &chara
             if (SCH_411_510E && lastPacket.length() > 23) {
                 heartRate((uint8_t)lastPacket.at(23));
                 emit debug(QStringLiteral("Current Heart: ") + QString::number(Heart.value()));
-            } else if (Flags.heartRate && !disable_hr_frommachinery && lastPacket.length() > index) {
+            } else if (Flags.heartRate && !disable_hr_frommachinery && ensurePacketBytes(1, "heartRate")) {
                 uint8_t hrValue = (uint8_t)lastPacket.at(index);
                 // 0xFF means heart rate not available/invalid in FTMS
                 if(hrValue != 0xFF) {
@@ -571,6 +592,7 @@ void ypooelliptical::characteristicChanged(const QLowEnergyCharacteristic &chara
         }
 
         if (Flags.metabolicEq) {
+            if (!ensurePacketBytes(1, "metabolicEq")) return;
             // FTMS metabolic equivalent is uint8 with 0.1 resolution
             if(E35 || SCH_590E || SCH_411_510E || KETTLER || CARDIOPOWER_EEGO || MYELLIPTICAL || SKANDIKA || DOMYOS || FEIER || MX_AS || TRUE_ELLIPTICAL || FTMS) {
                 uint8_t metabolicValue = (uint8_t)lastPacket.at(index);

--- a/src/devices/ypooelliptical/ypooelliptical.cpp
+++ b/src/devices/ypooelliptical/ypooelliptical.cpp
@@ -309,6 +309,7 @@ void ypooelliptical::characteristicChanged(const QLowEnergyCharacteristic &chara
             return;
         }
 
+        int index = 0;
         auto ensurePacketBytes = [&](int needed, const char *field) {
             if (index + needed > lastPacket.length()) {
                 qDebug() << "packet malformed while parsing" << field << "index" << index << "needed" << needed << "len" << lastPacket.length();
@@ -317,7 +318,6 @@ void ypooelliptical::characteristicChanged(const QLowEnergyCharacteristic &chara
             return true;
         };
 
-        int index = 0;
         Flags.word_flags = (lastPacket.at(2) << 16) | (lastPacket.at(1) << 8) | lastPacket.at(0);
         index += 3;
 


### PR DESCRIPTION
### Motivation
- A crash was reported while handling FTMS (`0x2ACE`) notifications where the parser read fields beyond the available bytes in truncated or malformed packets, so the parser must be hardened to avoid out-of-range accesses.

### Description
- Added an initial check to ensure `lastPacket` contains at least 3 bytes before reading FTMS flags in `ypooelliptical::characteristicChanged`.
- Introduced a local helper `ensurePacketBytes(int needed, const char *field)` that logs malformed packet details and returns false when insufficient bytes remain.
- Applied `ensurePacketBytes` guards before parsing the main flagged fields (instantaneousSpeed, avgSpeed, totDistance, stepCount, strideCount, rampAngle, resistanceLvl, instantPower, avgPower, expEnergy, heartRate, metabolicEq) and perform early return on failure.
- All changes are contained in `src/devices/ypooelliptical/ypooelliptical.cpp` around the FTMS parsing logic.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2d92456ec8325af33e1721b755217)