### PR TITLE
feat(ios): apply cadence_gain and cadence_offset in Apple Watch cadence path

### DIFF
--- a/src/devices/treadmill.cpp
+++ b/src/devices/treadmill.cpp
@@ -622,7 +622,13 @@ bool treadmill::cadenceFromAppleWatch() {
                            QZSettings::default_fakedevice_treadmill).toBool();
         if (appleWatchCadence > 0) {
             evaluateStepCount();
-            Cadence = appleWatchCadence;
+            const double cadence_gain =
+                settings.value(QZSettings::cadence_gain,
+                               QZSettings::default_cadence_gain).toDouble();
+            const double cadence_offset =
+                settings.value(QZSettings::cadence_offset,
+                               QZSettings::default_cadence_offset).toDouble();
+            Cadence = (appleWatchCadence * cadence_gain) + cadence_offset;
             if (appleWatchTreadmillSpeed) {
                 const double ratio =
                     settings.value(QZSettings::cadence_sensor_speed_ratio,


### PR DESCRIPTION
## Summary

Follow-up to #4594. The `cadence_gain` and `cadence_offset` settings are already exposed in the UI and applied by other device drivers (Proform, Domyos, Nordictrack, Schwinn, etc.), but were not applied in `treadmill::cadenceFromAppleWatch()`. This left the settings dead-weight for users on the Fake Treadmill / Apple Watch path.

Wires up the existing settings so users can scale or offset the broadcast Cadence — useful when receiving apps interpret BLE FTMS cadence with different scaling than QZ broadcasts (e.g., Kinomap's SPM display reads ~4× the QZ tile value, likely due to FTMS 0.5 rpm/unit resolution combined with cycle-vs-step interpretation).

## Behavior

- Defaults are no-ops: `cadence_gain = 1`, `cadence_offset = 0`. Existing users see no change.
- Speed calculation (the #4594 path) still uses raw `appleWatchCadence`, so Wheel Ratio behaves identically. Cadence and Speed scale independently.
- Pattern matches existing usage in `proformelliptical.cpp:242`, `domyoselliptical.cpp:314`, etc.

## Why this matters

Apple Watch as a treadmill input is a popular request — many users want indoor walking / slow jogging without buying a foot pod. With #4594 merged, the speed side works; this PR makes the cadence side tunable so users can fix per-app display quirks.

## Test plan

- [x] iOS build (will run via CI)
- [x] Default values: verify Cadence is unchanged (gain=1, offset=0 → identity)
- [ ] Manual: set `cadence_gain = 0.25` and verify broadcast Cadence is quartered, Speed unaffected