### PR TITLE
Emit laps on segment boundaries (skip ramp micro-steps) and add unit test

### DIFF
--- a/src/trainprogram.cpp
+++ b/src/trainprogram.cpp
@@ -1054,13 +1054,31 @@ void trainprogram::scheduler() {
 
                 rows[currentStep].ended = QDateTime::currentDateTime();
 
-                // Emit lap for each completed row, but skip intermediate ramp steps
-                // Only emit lap when rampDuration is 0 (standalone row or end of ramp)
+                // Emit lap at segment boundaries while skipping intermediate ramp micro-steps.
+                // This yields laps for: warmup end, interval transitions, cooldown start, cooldown end.
                 if (settings.value(QZSettings::trainprogram_auto_lap_on_segment,
-                                   QZSettings::default_trainprogram_auto_lap_on_segment).toBool() &&
-                    QTime(0, 0, 0).secsTo(rows.at(currentStep).rampDuration) == 0) {
-                    qDebug() << "Emitting lap for completed row" << currentStep;
-                    emit lap();
+                                   QZSettings::default_trainprogram_auto_lap_on_segment).toBool()) {
+                    const bool hasNextRow = (currentStep + 1 < rows.length());
+                    const trainrow &currentRow = rows.at(currentStep);
+
+                    bool emitLapForBoundary = false;
+                    if (!hasNextRow) {
+                        // End of workout (including cooldown end).
+                        emitLapForBoundary = true;
+                    } else {
+                        const trainrow &nextRow = rows.at(currentStep + 1);
+                        const bool inRampNow = QTime(0, 0, 0).secsTo(currentRow.rampDuration) > 0;
+                        const bool nextIsRampContinuation = QTime(0, 0, 0).secsTo(nextRow.rampElapsed) > 0;
+                        const bool sameRampContinuation = inRampNow && nextIsRampContinuation;
+
+                        // Emit lap at every row transition except within the same ramp.
+                        emitLapForBoundary = !sameRampContinuation;
+                    }
+
+                    if (emitLapForBoundary) {
+                        qDebug() << "Emitting lap for completed row" << currentStep;
+                        emit lap();
+                    }
                 }
 
                 if (!distanceStep)

--- a/tst/ToolTests/zwiftworkoutlapsuite.cpp
+++ b/tst/ToolTests/zwiftworkoutlapsuite.cpp
@@ -1,0 +1,66 @@
+#include "zwiftworkoutlapsuite.h"
+
+#include <QFile>
+#include <QTemporaryDir>
+
+#include "zwiftworkout.h"
+
+namespace {
+
+static int countAutoLapBoundaries(const QList<trainrow> &rows) {
+    int laps = 0;
+    for (int i = 0; i < rows.size(); ++i) {
+        const bool hasNextRow = (i + 1 < rows.size());
+        bool emitLapForBoundary = false;
+
+        if (!hasNextRow) {
+            emitLapForBoundary = true;
+        } else {
+            const trainrow &currentRow = rows.at(i);
+            const trainrow &nextRow = rows.at(i + 1);
+            const bool inRampNow = QTime(0, 0, 0).secsTo(currentRow.rampDuration) > 0;
+            const bool nextIsRampContinuation = QTime(0, 0, 0).secsTo(nextRow.rampElapsed) > 0;
+            const bool sameRampContinuation = inRampNow && nextIsRampContinuation;
+            emitLapForBoundary = !sameRampContinuation;
+        }
+
+        if (emitLapForBoundary) {
+            ++laps;
+        }
+    }
+    return laps;
+}
+
+} // namespace
+
+TEST_F(ZwiftWorkoutLapSuite, WarmupIntervalsCooldownBoundaries) {
+    QTemporaryDir tempDir;
+    ASSERT_TRUE(tempDir.isValid());
+
+    const QString zwoPath = tempDir.filePath("lap_boundaries_test.zwo");
+    QFile zwoFile(zwoPath);
+    ASSERT_TRUE(zwoFile.open(QIODevice::WriteOnly | QIODevice::Text));
+
+    const QByteArray zwo = R"(<workout_file>
+    <author>test</author>
+    <name>lap boundaries</name>
+    <description>test</description>
+    <sportType>bike</sportType>
+    <workout>
+        <Warmup Duration="60" PowerLow="0.5" PowerHigh="0.75"/>
+        <IntervalsT Repeat="2" OnDuration="30" OffDuration="15" OnPower="1" OffPower="0.45"/>
+        <Cooldown Duration="40" PowerLow="0.45" PowerHigh="0.3"/>
+    </workout>
+</workout_file>)";
+    zwoFile.write(zwo);
+    zwoFile.close();
+
+    QString description;
+    QString tags;
+    const QList<trainrow> rows = zwiftworkout::load(zwoPath, &description, &tags);
+    ASSERT_FALSE(rows.isEmpty());
+
+    // Expected boundaries:
+    // warmup end, interval on->off (rep1), off->on (rep2), on->off (rep2), cooldown start, cooldown end.
+    EXPECT_EQ(countAutoLapBoundaries(rows), 6);
+}

--- a/tst/ToolTests/zwiftworkoutlapsuite.h
+++ b/tst/ToolTests/zwiftworkoutlapsuite.h
@@ -1,0 +1,9 @@
+#ifndef ZWIFTWORKOUTLAPSUITE_H
+#define ZWIFTWORKOUTLAPSUITE_H
+
+#include <gtest/gtest.h>
+
+class ZwiftWorkoutLapSuite : public ::testing::Test {
+};
+
+#endif // ZWIFTWORKOUTLAPSUITE_H

--- a/tst/qdomyos-zwift-tests.pro
+++ b/tst/qdomyos-zwift-tests.pro
@@ -24,6 +24,7 @@ SOURCES += \
         ToolTests/qfittestsuite.cpp \
         ToolTests/testsettingstestsuite.cpp \
         ToolTests/testtrainingloadtestsuite.cpp \
+        ToolTests/zwiftworkoutlapsuite.cpp \
         Tools/testsettings.cpp \
         Tools/typeidgenerator.cpp \
         Devices/TestSchwinn411510EParser.cpp \
@@ -63,6 +64,7 @@ HEADERS += \
     ToolTests/qfittestsuite.h \
     ToolTests/testsettingstestsuite.h \
     ToolTests/testtrainingloadtestsuite.h \
+    ToolTests/zwiftworkoutlapsuite.h \
     Tools/devicetypeid.h \
     Tools/testsettings.h \
     Tools/typeidgenerator.h


### PR DESCRIPTION
### Motivation

- Improve lap emission so laps are produced at meaningful workout segment boundaries rather than for intermediate ramp micro-steps.

### Description

- Replace the previous single-check (`rampDuration == 0`) lap emission with explicit boundary logic in `trainprogram::scheduler()` that emits a lap at the end of workout or at row transitions except when the next row is a continuation of the same ramp. 
- Preserve the settings gate via `QZSettings::trainprogram_auto_lap_on_segment` and add runtime checks for `hasNextRow`, `inRampNow`, `nextIsRampContinuation`, and `sameRampContinuation` to decide whether to `emit lap()`.
- Add a new unit test `ZwiftWorkoutLapSuite::WarmupIntervalsCooldownBoundaries` in `tst/ToolTests/zwiftworkoutlapsuite.cpp` and its header, which loads a sample ZWO and asserts the expected lap boundary count for warmup, intervals and cooldowns.
- Wire the new test into the test project by updating `tst/qdomyos-zwift-tests.pro`.

### Testing

- Added and ran the new unit test `ZwiftWorkoutLapSuite.WarmupIntervalsCooldownBoundaries` which validates lap boundary counting for a sample ZWO and it succeeded.
- Ran the existing test suite (via the project test target) and all unit tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3a0435b548325af30f8179fac9ad0)