### PR TITLE
Add Fitshow treadmill cadence fallback

### DIFF
--- a/src/devices/fitshowtreadmill/fitshowtreadmill.cpp
+++ b/src/devices/fitshowtreadmill/fitshowtreadmill.cpp
@@ -324,6 +324,8 @@ void fitshowtreadmill::characteristicChanged(const QLowEnergyCharacteristic &cha
     bool disable_hr_frommachinery =
         settings.value(QZSettings::heart_ignore_builtin, QZSettings::default_heart_ignore_builtin).toBool();
     Q_UNUSED(characteristic);
+    bool cadenceAvailable = false;
+    bool stepCountAvailable = false;
     QByteArray value = newValue;
 
     emit debug(QStringLiteral(" << ") + QString::number(value.length()) + QStringLiteral(" ") + value.toHex(' '));
@@ -334,7 +336,9 @@ void fitshowtreadmill::characteristicChanged(const QLowEnergyCharacteristic &cha
     lastPacket = value;
 
     if(characteristic.uuid() == QBluetoothUuid((quint16)0x2a53) && value.length() >= 4) {
-        Cadence = value.at(3);
+        evaluateStepCount();
+        parseCadence(value.at(3));
+        cadenceAvailable = true;
         emit debug(QStringLiteral("Current cadence: ") + QString::number(Cadence.value()));
         return;
     }
@@ -476,7 +480,10 @@ void fitshowtreadmill::characteristicChanged(const QLowEnergyCharacteristic &cha
                     lastTimeCharacteristicChanged = QDateTime::currentDateTime();
                 }
 
-                StepCount = step_count;
+                if (step_count > 0) {
+                    StepCount = step_count;
+                    stepCountAvailable = true;
+                }
 
                 emit debug(QStringLiteral("Current elapsed from treadmill: ") + QString::number(seconds_elapsed));
                 emit debug(QStringLiteral("Current speed: ") + QString::number(speed));
@@ -618,7 +625,10 @@ void fitshowtreadmill::characteristicChanged(const QLowEnergyCharacteristic &cha
                 double distance = array[4] | array[5] << 8;
                 uint16_t step_count = array[8] | array[9] << 8;
 
-                StepCount = step_count;
+                if (step_count > 0) {
+                    StepCount = step_count;
+                    stepCountAvailable = true;
+                }
 
                 emit debug(QStringLiteral("Current elapsed from treadmill: ") + QString::number(seconds_elapsed));
                 emit debug(QStringLiteral("Current step countl: ") + QString::number(step_count));
@@ -628,6 +638,24 @@ void fitshowtreadmill::characteristicChanged(const QLowEnergyCharacteristic &cha
                 if (truetimer)
                     elapsed = seconds_elapsed;
                 // Distance = distance;
+            }
+        }
+    }
+
+    if (!cadenceFromAppleWatch() && !cadenceAvailable && Speed.value() > 0) {
+        bool garminCompanion =
+            settings.value(QZSettings::garmin_companion, QZSettings::default_garmin_companion).toBool();
+        bool hasPowerSensor = !settings.value(QZSettings::power_sensor_name, QZSettings::default_power_sensor_name)
+                                  .toString()
+                                  .startsWith(QStringLiteral("Disabled"));
+        if (!hasPowerSensor && !garminCompanion) {
+            double calculatedCadence = calculateCadenceFromSpeed(Speed.value());
+            if (calculatedCadence > 0) {
+                if (!stepCountAvailable)
+                    evaluateStepCount();
+                parseCadence(calculatedCadence);
+                emit debug(QStringLiteral("Current Cadence (calculated from speed): ") +
+                           QString::number(Cadence.value()));
             }
         }
     }


### PR DESCRIPTION
### Motivation
- Fitshow treadmill implementation did not provide the same cadence/step fallback logic used by other treadmill drivers, causing cadence and step counts to be missing when the treadmill packet lacked cadence or no external sensors were configured.

### Description
- Updated `src/devices/fitshowtreadmill/fitshowtreadmill.cpp` to track local availability flags `cadenceAvailable` and `stepCountAvailable` and route RSC cadence updates through `evaluateStepCount()` and `parseCadence()` instead of assigning `Cadence` directly.
- Preserved machine-provided `StepCount` only when it is greater than zero, and set `stepCountAvailable` so the code does not re-derive steps unnecessarily.
- Added fallback logic that, when no cadence is available from the treadmill or Apple/Android companion and no external power/Garmin sensor is configured, computes cadence from speed with `calculateCadenceFromSpeed()` and applies it via `parseCadence()` and `evaluateStepCount()` (but only if the treadmill did not already provide a valid step count).

### Testing
- Ran `git diff --check` which returned success (no whitespace errors reported).
- Attempted `qmake -v` to validate the build toolchain, but `qmake` is not available in this environment so a full build/test run could not be performed.
- No automated unit tests were executed in this environment due to missing `qmake`/build tooling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01bb73179c8325aad572aa0ff9227f)