### PR TITLE
Cache speed requests when treadmill is stopped and set model-specific maxSpeed

### DIFF
--- a/src/devices/proformtreadmill/proformtreadmill.cpp
+++ b/src/devices/proformtreadmill/proformtreadmill.cpp
@@ -139,6 +139,34 @@ void proformtreadmill::update() {
         QSettings settings;
         update_metrics(true, watts(settings.value(QZSettings::weight, QZSettings::default_weight).toFloat()));
 
+        if (requestSpeed != -1 && requestSpeed > 0 && requestSpeed <= maxSpeed && currentSpeed().value() <= 0) {
+            cachedSpeedRequest = requestSpeed;
+            requestSpeed = -1;
+            requestStart = 1;
+            emit debug(QStringLiteral("speed request cached while treadmill is stopped: ") +
+                       QString::number(cachedSpeedRequest));
+
+            if (homeform::singleton()) {
+                homeform::singleton()->setToastRequested(
+                    QStringLiteral("Starting treadmill before applying requested speed ") +
+                    QString::number(cachedSpeedRequest, 'f', 1));
+            }
+        }
+
+        if (cachedSpeedRequest != -1 && currentSpeed().value() > 0) {
+            if (cachedSpeedRequest <= maxSpeed) {
+                emit debug(QStringLiteral("writing cached speed ") + QString::number(cachedSpeedRequest));
+                forceSpeed(cachedSpeedRequest);
+
+                if (homeform::singleton()) {
+                    homeform::singleton()->setToastRequested(
+                        QStringLiteral("Applying cached speed request ") +
+                        QString::number(cachedSpeedRequest, 'f', 1));
+                }
+            }
+            cachedSpeedRequest = -1;
+        }
+
         if (proform_treadmill_9_0 || proform_treadmill_z1300i) {
             uint8_t noOpData1[] = {0xfe, 0x02, 0x17, 0x03};
             uint8_t noOpData2[] = {0x00, 0x12, 0x02, 0x04, 0x02, 0x13, 0x04, 0x13, 0x02, 0x00,
@@ -3813,6 +3841,7 @@ void proformtreadmill::btinit() {
             .toBool();
     proform_treadmill_z1300i =
         settings.value(QZSettings::proform_treadmill_z1300i, QZSettings::default_proform_treadmill_z1300i).toBool();
+    maxSpeed = proform_treadmill_z1300i ? 19.3 : 22;
     nordictrack_treadmill_exp_5i = settings.value(QZSettings::nordictrack_treadmill_exp_5i, QZSettings::default_nordictrack_treadmill_exp_5i).toBool();
     proform_pro_1000_treadmill =
         settings.value(QZSettings::proform_pro_1000_treadmill, QZSettings::default_proform_pro_1000_treadmill).toBool();

--- a/src/devices/proformtreadmill/proformtreadmill.h
+++ b/src/devices/proformtreadmill/proformtreadmill.h
@@ -65,6 +65,8 @@ class proformtreadmill : public treadmill {
 
     bool initDone = false;
     bool initRequest = false;
+    double maxSpeed = 22;
+    double cachedSpeedRequest = -1;
 
     bool noWriteResistance = false;
     bool noHeartService = false;


### PR DESCRIPTION
### Motivation
- Ensure speed requests issued while the treadmill is stopped are not lost and are applied once the treadmill starts. 
- Ensure the maximum allowed speed is adjusted for specific treadmill models (z1300i) to avoid sending out-of-range speed values.

### Description
- Added `maxSpeed` and `cachedSpeedRequest` members to the `proformtreadmill` class and initialized them (`maxSpeed` defaulted to `22`, `cachedSpeedRequest` to `-1`).
- In `btinit()` set `maxSpeed` to `19.3` when `proform_treadmill_z1300i` is enabled, otherwise keep `22`.
- In `update()` detect when a speed request (`requestSpeed`) is made while the treadmill is stopped, cache it to `cachedSpeedRequest`, clear the original request, and emit debug logs and a UI toast via `homeform::singleton()->setToastRequested` informing the user that the treadmill is being started before applying the requested speed.
- When the treadmill becomes running (`currentSpeed().value() > 0`) and a cached request exists, apply the cached speed with `forceSpeed()` (subject to `maxSpeed`), emit debug logs, show a toast, and clear the cache.

### Testing
- Built the project and ran the existing automated test suite (`ctest`); all tests passed.
- No new automated tests were added for the cached-request behavior in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01cc18c50083259bdf0fbed4a2d320)