### PR TITLE
Add Suunto FIT upload integration

### DIFF
--- a/src/WebSuuntoAuth.qml
+++ b/src/WebSuuntoAuth.qml
@@ -1,0 +1,58 @@
+import QtQuick 2.12
+import QtQuick.Controls 2.5
+import QtQuick.Controls.Material 2.12
+import QtQuick.Dialogs 1.0
+import QtGraphicalEffects 1.12
+import Qt.labs.settings 1.0
+import QtMultimedia 5.15
+import QtQuick.Layouts 1.3
+import QtWebView 1.1
+
+Item {
+    anchors.fill: parent
+    height: parent.height
+    width: parent.width
+    visible: true
+
+    WebView {
+        anchors.fill: parent
+        height: parent.height
+        width: parent.width
+        visible: !rootItem.generalPopupVisible
+        url: rootItem.getSuuntoAuthUrl
+    }
+
+    Popup {
+        id: popupSuuntoConnectedWeb
+        parent: Overlay.overlay
+        enabled: rootItem.generalPopupVisible
+        onEnabledChanged: { if(rootItem.generalPopupVisible) popupSuuntoConnectedWeb.open() }
+        onClosed: { rootItem.generalPopupVisible = false; }
+
+        x: Math.round((parent.width - width) / 2)
+        y: Math.round((parent.height - height) / 2)
+        width: 380
+        height: 120
+        modal: true
+        focus: true
+        palette.text: "white"
+        closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+        enter: Transition
+        {
+            NumberAnimation { property: "opacity"; from: 0.0; to: 1.0 }
+        }
+        exit: Transition
+        {
+            NumberAnimation { property: "opacity"; from: 1.0; to: 0.0 }
+        }
+        Column {
+            anchors.horizontalCenter: parent.horizontalCenter
+            Label {
+                anchors.horizontalCenter: parent.horizontalCenter
+                width: 370
+                height: 120
+                text: qsTr("Your Suunto account is now connected!<br><br>When you will press STOP on QZ a file<br>will be automatically uploaded to Suunto!")
+            }
+        }
+    }
+}

--- a/src/WorkoutsHistory.qml
+++ b/src/WorkoutsHistory.qml
@@ -48,7 +48,8 @@ Page {
         return rootItem &&
                (rootItem.isStravaLoggedIn() ||
                 rootItem.isGarminUploadConfigured() ||
-                rootItem.isIntervalsICUUploadConfigured())
+                rootItem.isIntervalsICUUploadConfigured() ||
+                rootItem.isSuuntoUploadConfigured())
     }
 
     function openUploadMenu(delegateItem, workoutId, workoutTitle) {
@@ -480,6 +481,12 @@ Page {
             text: "Upload to Intervals.icu"
             visible: rootItem && rootItem.isIntervalsICUUploadConfigured()
             onTriggered: rootItem.uploadHistoricalWorkoutToIntervalsICU(uploadMenu.filePath)
+        }
+
+        MenuItem {
+            text: "Upload to Suunto"
+            visible: rootItem && rootItem.isSuuntoUploadConfigured()
+            onTriggered: rootItem.uploadHistoricalWorkoutToSuunto(uploadMenu.filePath)
         }
     }
 

--- a/src/homeform.cpp
+++ b/src/homeform.cpp
@@ -32,6 +32,7 @@
 #include <QHttpMultiPart>
 #include <QImageWriter>
 #include <QJsonDocument>
+#include <QJsonObject>
 #include <QNetworkAccessManager>
 #include <QNetworkCookieJar>
 #include <QNetworkInterface>
@@ -266,6 +267,8 @@ homeform::homeform(QQmlApplicationEngine *engine, bluetooth *bl) {
     stravaWebVisibleChanged(stravaAuthWebVisible);
     intervalsicuAuthWebVisible = false;
     intervalsicuWebVisibleChanged(intervalsicuAuthWebVisible);
+    suuntoAuthWebVisible = false;
+    suuntoWebVisibleChanged(suuntoAuthWebVisible);
 
     QString innerId = QStringLiteral("inner");
     QString sKey = QStringLiteral("template_") + innerId + QStringLiteral("_" TEMPLATE_PRIVATE_WEBSERVER_ID "_");
@@ -751,7 +754,9 @@ homeform::homeform(QQmlApplicationEngine *engine, bluetooth *bl) {
     QObject::connect(stack, SIGNAL(openFloatingWindowBrowser()), this, SLOT(openFloatingWindowBrowser()));
     QObject::connect(stack, SIGNAL(strava_upload_file_prepare()), this, SLOT(strava_upload_file_prepare()));
     QObject::connect(stack, SIGNAL(intervalsicu_connect_clicked()), this, SLOT(intervalsicu_connect_clicked()));
+    QObject::connect(stack, SIGNAL(suunto_connect_clicked()), this, SLOT(suunto_connect_clicked()));
     QObject::connect(stack, SIGNAL(intervalsicu_upload_file_prepare()), this, SLOT(intervalsicu_upload_file_prepare()));
+    QObject::connect(stack, SIGNAL(suunto_upload_file_prepare()), this, SLOT(suunto_upload_file_prepare()));
     QObject::connect(stack, SIGNAL(intervalsicu_download_todays_workout_clicked()), this, SLOT(intervalsicu_download_todays_workout_clicked()));
 
     qDebug() << "homeform constructor events linked";
@@ -8428,6 +8433,13 @@ void homeform::fit_save_clicked() {
                 intervalsicu_upload_file_prepare();
             }
         }
+
+        // Suunto upload (OAuth + subscription key)
+        bool suunto_enabled = settings.value(QZSettings::suunto_upload_enabled, QZSettings::default_suunto_upload_enabled).toBool();
+        if (suunto_enabled &&
+            !settings.value(QZSettings::suunto_accesstoken, QZSettings::default_suunto_accesstoken).toString().isEmpty()) {
+            suunto_upload_file_prepare();
+        }
     }
 }
 
@@ -9259,11 +9271,25 @@ bool homeform::isIntervalsICULoggedIn() {
     return !settings.value(QZSettings::intervalsicu_accesstoken, QZSettings::default_intervalsicu_accesstoken).toString().isEmpty();
 }
 
+bool homeform::isSuuntoLoggedIn() {
+    QSettings settings;
+    return !settings.value(QZSettings::suunto_accesstoken, QZSettings::default_suunto_accesstoken).toString().isEmpty();
+}
+
 bool homeform::isIntervalsICUUploadConfigured() {
     QSettings settings;
     return settings.value(QZSettings::intervalsicu_upload_enabled, QZSettings::default_intervalsicu_upload_enabled).toBool() &&
            !settings.value(QZSettings::intervalsicu_accesstoken, QZSettings::default_intervalsicu_accesstoken).toString().isEmpty() &&
            !settings.value(QZSettings::intervalsicu_athlete_id, QZSettings::default_intervalsicu_athlete_id).toString().isEmpty();
+}
+
+bool homeform::isSuuntoUploadConfigured() {
+    QSettings settings;
+    const QString subscriptionKey = settings.value(QZSettings::suunto_subscription_key, QZSettings::default_suunto_subscription_key).toString();
+    return settings.value(QZSettings::suunto_upload_enabled, QZSettings::default_suunto_upload_enabled).toBool() &&
+           !settings.value(QZSettings::suunto_accesstoken, QZSettings::default_suunto_accesstoken).toString().isEmpty() &&
+           !subscriptionKey.isEmpty() &&
+           subscriptionKey != QZSettings::default_suunto_subscription_key;
 }
 
 void homeform::uploadHistoricalWorkoutToStrava(const QString &filePath) {
@@ -9312,6 +9338,16 @@ void homeform::uploadHistoricalWorkoutToIntervalsICU(const QString &filePath) {
     intervalsicu_upload_file(f.readAll(), filePath);
 }
 
+void homeform::uploadHistoricalWorkoutToSuunto(const QString &filePath) {
+    QFile f(filePath);
+    if (!f.open(QFile::OpenModeFlag::ReadOnly)) {
+        setToastRequested("Suunto: unable to open FIT file");
+        return;
+    }
+
+    suunto_upload_file(f.readAll(), filePath);
+}
+
 void homeform::strava_logout() {
     qDebug() << "Strava logout requested";
     QSettings settings;
@@ -9353,6 +9389,22 @@ void homeform::intervalsicu_logout() {
     }
     clearWebViewCache();
     qDebug() << "Intervals.icu: tokens cleared";
+}
+
+void homeform::suunto_logout() {
+    qDebug() << "Suunto logout requested";
+    QSettings settings;
+    settings.setValue(QZSettings::suunto_accesstoken, QStringLiteral(""));
+    settings.setValue(QZSettings::suunto_refreshtoken, QStringLiteral(""));
+    if (suunto) {
+        suunto->setToken(QStringLiteral(""));
+        suunto->setRefreshToken(QStringLiteral(""));
+    }
+    if (suuntoManager) {
+        suuntoManager->setCookieJar(new QNetworkCookieJar(suuntoManager));
+    }
+    clearWebViewCache();
+    qDebug() << "Suunto: tokens cleared";
 }
 
 void homeform::clearWebViewCache() {
@@ -10165,12 +10217,429 @@ void homeform::videoSeekPosition(int ms) {
 #endif
 #define INTERVALSICU_CLIENT_SECRET_S STRINGIFY(INTERVALSICU_CLIENT_SECRET)
 
+#ifndef SUUNTO_CLIENT_ID
+#define SUUNTO_CLIENT_ID "YOUR_SUUNTO_CLIENT_ID"
+#pragma message("DEFINE SUUNTO_CLIENT_ID!!!")
+#endif
+#define SUUNTO_CLIENT_ID_S STRINGIFY(SUUNTO_CLIENT_ID)
+
+#ifndef SUUNTO_CLIENT_SECRET
+#define SUUNTO_CLIENT_SECRET "YOUR_SUUNTO_CLIENT_SECRET"
+#pragma message("DEFINE SUUNTO_CLIENT_SECRET!!!")
+#endif
+#define SUUNTO_CLIENT_SECRET_S STRINGIFY(SUUNTO_CLIENT_SECRET)
+
 static QString normalizeOAuthMacroValue(const QString &value) {
     QString normalized = value;
     if (normalized.size() >= 2 && normalized.startsWith('\"') && normalized.endsWith('\"')) {
         normalized = normalized.mid(1, normalized.size() - 2);
     }
     return normalized;
+}
+
+
+
+// ========== Suunto Implementation ==========
+
+void homeform::suunto_connect_clicked() {
+    QLoggingCategory::setFilterRules(QStringLiteral("qt.networkauth.*=true"));
+
+    QOAuth2AuthorizationCodeFlow *oauth = suunto_connect();
+    if (oauth) {
+        connect(oauth, &QOAuth2AuthorizationCodeFlow::granted,
+                this, &homeform::onSuuntoGranted, Qt::UniqueConnection);
+        connect(oauth, &QOAuth2AuthorizationCodeFlow::authorizeWithBrowser,
+                this, &homeform::onSuuntoAuthorizeWithBrowser, Qt::UniqueConnection);
+        oauth->grant();
+    }
+}
+
+QOAuth2AuthorizationCodeFlow *homeform::suunto_connect() {
+    QSettings settings;
+
+    if (!settings.value(QZSettings::suunto_accesstoken).toString().isEmpty()) {
+        qDebug() << "Suunto already authenticated";
+        setGeneralPopupVisible(true);
+        return nullptr;
+    }
+
+    if (!suunto) {
+        if (suuntoManager) {
+            delete suuntoManager;
+            suuntoManager = nullptr;
+        }
+        suuntoManager = new QNetworkAccessManager(this);
+
+        suunto = new QOAuth2AuthorizationCodeFlow(suuntoManager, this);
+        suunto->setAuthorizationUrl(QUrl(QStringLiteral("https://cloudapi-oauth.suunto.com/oauth/authorize")));
+        suunto->setAccessTokenUrl(QUrl(QStringLiteral("https://cloudapi-oauth.suunto.com/oauth/token")));
+        suunto->setClientIdentifier(normalizeOAuthMacroValue(QStringLiteral(SUUNTO_CLIENT_ID_S)));
+        suunto->setClientIdentifierSharedKey(normalizeOAuthMacroValue(QStringLiteral(SUUNTO_CLIENT_SECRET_S)));
+        suunto->setScope(QStringLiteral("workout"));
+        suunto->setModifyParametersFunction(
+            buildModifyParametersFunction(QUrl(QLatin1String("")), QUrl(QLatin1String(""))));
+
+        if (!suuntoReplyHandler) {
+            suuntoReplyHandler = new QOAuthHttpServerReplyHandler(QHostAddress(QStringLiteral("127.0.0.1")), 8495, this);
+            connect(suuntoReplyHandler, &QOAuthHttpServerReplyHandler::replyDataReceived,
+                    this, &homeform::replyDataReceivedSuunto);
+            connect(suuntoReplyHandler, &QOAuthHttpServerReplyHandler::callbackReceived,
+                    this, &homeform::callbackReceivedSuunto);
+        }
+        suunto->setReplyHandler(suuntoReplyHandler);
+    }
+
+    return suunto;
+}
+
+void homeform::onSuuntoGranted() {
+    suuntoAuthWebVisible = false;
+    emit suuntoWebVisibleChanged(suuntoAuthWebVisible);
+
+    QSettings settings;
+    settings.setValue(QZSettings::suunto_accesstoken, suunto->token());
+    settings.setValue(QZSettings::suunto_refreshtoken, suunto->refreshToken());
+
+    qDebug() << "Suunto authenticated successfully";
+    setGeneralPopupVisible(true);
+}
+
+void homeform::onSuuntoAuthorizeWithBrowser(const QUrl &url) {
+    QSettings settings;
+    bool externalBrowser =
+        settings.value(QZSettings::strava_auth_external_webbrowser, QZSettings::default_strava_auth_external_webbrowser)
+            .toBool();
+#if defined(Q_OS_WIN) || (defined(Q_OS_MAC) && !defined(Q_OS_IOS))
+    externalBrowser = true;
+#endif
+    suuntoAuthUrl = url.toString();
+    emit suuntoAuthUrlChanged(suuntoAuthUrl);
+
+    if (externalBrowser)
+        QDesktopServices::openUrl(url);
+    else {
+        suuntoAuthWebVisible = true;
+        emit suuntoWebVisibleChanged(suuntoAuthWebVisible);
+    }
+}
+
+void homeform::callbackReceivedSuunto(const QVariantMap &values) {
+    if (values.contains("code")) {
+        suuntoAuthCode = values.value("code").toString();
+        qDebug() << "Suunto: Authorization code received";
+
+        const QString clientId = normalizeOAuthMacroValue(QStringLiteral(SUUNTO_CLIENT_ID_S));
+        const QString clientSecret = normalizeOAuthMacroValue(QStringLiteral(SUUNTO_CLIENT_SECRET_S));
+        qDebug() << "Suunto: OAuth client diagnostics"
+                 << "client_id_is_default=" << (clientId == QStringLiteral("YOUR_SUUNTO_CLIENT_ID"))
+                 << "secret_is_default=" << (clientSecret == QStringLiteral("YOUR_SUUNTO_CLIENT_SECRET"));
+
+        QNetworkRequest request(QUrl(QStringLiteral("https://cloudapi-oauth.suunto.com/oauth/token")));
+        request.setHeader(QNetworkRequest::ContentTypeHeader, QStringLiteral("application/x-www-form-urlencoded"));
+        request.setRawHeader("Authorization", QByteArray("Basic ") + QStringLiteral("%1:%2").arg(clientId, clientSecret).toUtf8().toBase64());
+
+        QUrl redirectUri(QStringLiteral("http://127.0.0.1:8495/"));
+        QUrlQuery params;
+        params.addQueryItem(QStringLiteral("grant_type"), QStringLiteral("authorization_code"));
+        params.addQueryItem(QStringLiteral("redirect_uri"), redirectUri.toString());
+        params.addQueryItem(QStringLiteral("code"), suuntoAuthCode);
+
+        if (suuntoManager) {
+            delete suuntoManager;
+            suuntoManager = nullptr;
+        }
+        suuntoManager = new QNetworkAccessManager(this);
+        QNetworkReply *reply = suuntoManager->post(request, params.query(QUrl::FullyEncoded).toUtf8());
+        connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+            QByteArray response = reply->readAll();
+            int statusCode = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+            qDebug() << "Suunto: Token exchange status code:" << statusCode;
+
+            QJsonDocument jsonResponse = QJsonDocument::fromJson(response);
+            QJsonObject obj = jsonResponse.object();
+            if (statusCode >= 200 && statusCode < 300 && obj.contains("access_token")) {
+                QSettings settings;
+                settings.setValue(QZSettings::suunto_accesstoken, obj["access_token"].toString());
+                if (obj.contains("refresh_token")) {
+                    settings.setValue(QZSettings::suunto_refreshtoken, obj["refresh_token"].toString());
+                }
+                suuntoAuthWebVisible = false;
+                emit suuntoWebVisibleChanged(suuntoAuthWebVisible);
+                setGeneralPopupVisible(true);
+                qDebug() << "Suunto: Authentication completed successfully";
+            } else {
+                qDebug() << "Suunto: Token exchange failed" << response;
+                setToastRequested(QString("Suunto: Authentication failed (HTTP %1)").arg(statusCode));
+            }
+            reply->deleteLater();
+        });
+    }
+
+    if (values.contains("error")) {
+        const QString error = values.value("error").toString();
+        qDebug() << "Suunto: OAuth error occurred" << error;
+        setToastRequested("Suunto error: " + error);
+    }
+}
+
+void homeform::replyDataReceivedSuunto(const QByteArray &v) {
+    qDebug() << "Suunto: replyDataReceived";
+    QJsonDocument jsonResponse = QJsonDocument::fromJson(v);
+    QJsonObject obj = jsonResponse.object();
+    if (obj.contains("access_token")) {
+        QSettings settings;
+        settings.setValue(QZSettings::suunto_accesstoken, obj["access_token"].toString());
+        if (obj.contains("refresh_token")) {
+            settings.setValue(QZSettings::suunto_refreshtoken, obj["refresh_token"].toString());
+        }
+    }
+}
+
+void homeform::suunto_refreshtoken() {
+    QSettings settings;
+    const QString refreshToken = settings.value(QZSettings::suunto_refreshtoken).toString();
+    if (refreshToken.isEmpty()) {
+        qDebug() << "No Suunto refresh token available";
+        return;
+    }
+
+    const QString clientId = normalizeOAuthMacroValue(QStringLiteral(SUUNTO_CLIENT_ID_S));
+    const QString clientSecret = normalizeOAuthMacroValue(QStringLiteral(SUUNTO_CLIENT_SECRET_S));
+
+    QNetworkRequest request(QUrl(QStringLiteral("https://cloudapi-oauth.suunto.com/oauth/token")));
+    request.setHeader(QNetworkRequest::ContentTypeHeader, QStringLiteral("application/x-www-form-urlencoded"));
+    request.setRawHeader("Authorization", QByteArray("Basic ") + QStringLiteral("%1:%2").arg(clientId, clientSecret).toUtf8().toBase64());
+
+    QUrlQuery params;
+    params.addQueryItem(QStringLiteral("grant_type"), QStringLiteral("refresh_token"));
+    params.addQueryItem(QStringLiteral("refresh_token"), refreshToken);
+
+    if (suuntoManager) {
+        delete suuntoManager;
+        suuntoManager = nullptr;
+    }
+    suuntoManager = new QNetworkAccessManager(this);
+    QNetworkReply *reply = suuntoManager->post(request, params.query(QUrl::FullyEncoded).toUtf8());
+
+    QEventLoop loop;
+    connect(reply, &QNetworkReply::finished, &loop, &QEventLoop::quit);
+    loop.exec();
+
+    QByteArray response = reply->readAll();
+    QJsonDocument jsonResponse = QJsonDocument::fromJson(response);
+    QJsonObject obj = jsonResponse.object();
+    if (reply->error() == QNetworkReply::NoError && obj.contains("access_token")) {
+        settings.setValue(QZSettings::suunto_accesstoken, obj["access_token"].toString());
+        if (obj.contains("refresh_token")) {
+            settings.setValue(QZSettings::suunto_refreshtoken, obj["refresh_token"].toString());
+        }
+        qDebug() << "Suunto token refreshed successfully";
+    } else {
+        qDebug() << "Suunto refresh HTTP status:" << reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+        qDebug() << "Suunto refresh error string:" << reply->errorString();
+        qDebug() << "Suunto refresh response body:" << QString::fromUtf8(response);
+    }
+    reply->deleteLater();
+}
+
+QString homeform::suuntoActivityName(const QString &remotename) {
+    QSettings settings;
+    QString prefix;
+    if (settings.value(QZSettings::suunto_date_prefix, QZSettings::default_suunto_date_prefix).toBool()) {
+        prefix = QDate::currentDate().toString(Qt::TextDate) + " ";
+    }
+
+    QString activityName;
+    if (!stravaPelotonActivityName.isEmpty()) {
+        activityName = stravaPelotonActivityName + QStringLiteral(" - ") + stravaPelotonInstructorName;
+    } else if (bluetoothManager && bluetoothManager->device()) {
+        if (bluetoothManager->device()->deviceType() == TREADMILL) {
+            activityName = prefix + QStringLiteral("Run");
+        } else if (bluetoothManager->device()->deviceType() == ROWING) {
+            activityName = prefix + QStringLiteral("Row");
+        } else {
+            activityName = prefix + QStringLiteral("Ride");
+        }
+    } else {
+        activityName = prefix + uploadActivityLabelFromFitFile(remotename);
+    }
+
+    const QString suffix = settings.value(QZSettings::suunto_suffix, QZSettings::default_suunto_suffix).toString();
+    if (!suffix.isEmpty()) {
+        activityName += " " + suffix;
+    }
+    return activityName;
+}
+
+void homeform::suunto_upload_file_prepare() {
+    qDebug() << "Suunto upload file prepare" << lastFitFileSaved;
+    QFile f(lastFitFileSaved);
+    if (!f.open(QFile::OpenModeFlag::ReadOnly)) {
+        setToastRequested("Suunto: unable to open FIT file");
+        return;
+    }
+
+    suunto_upload_file(f.readAll(), lastFitFileSaved);
+}
+
+bool homeform::suunto_upload_file(const QByteArray &data, const QString &remotename) {
+    suunto_refreshtoken();
+
+    QSettings settings;
+    const QString token = settings.value(QZSettings::suunto_accesstoken).toString();
+    const QString subscriptionKey = settings.value(QZSettings::suunto_subscription_key, QZSettings::default_suunto_subscription_key).toString();
+
+    if (token.isEmpty()) {
+        setToastRequested("Suunto: Not authenticated");
+        return false;
+    }
+    if (subscriptionKey.isEmpty() || subscriptionKey == QZSettings::default_suunto_subscription_key) {
+        setToastRequested("Suunto: subscription key placeholder must be replaced in settings");
+        return false;
+    }
+
+    QJsonObject payload;
+    const QString activityName = suuntoActivityName(remotename);
+    if (!activityName.isEmpty()) {
+        payload.insert(QStringLiteral("description"), activityName);
+    }
+    if (!activityDescription.isEmpty()) {
+        payload.insert(QStringLiteral("comment"), activityDescription);
+    }
+    payload.insert(QStringLiteral("privacy"), settings.value(QZSettings::suunto_privacy, QZSettings::default_suunto_privacy).toString());
+
+    QNetworkRequest request(QUrl(QStringLiteral("https://cloudapi.suunto.com/v2/upload")));
+    request.setHeader(QNetworkRequest::ContentTypeHeader, QStringLiteral("application/json"));
+    request.setRawHeader("Authorization", QStringLiteral("Bearer %1").arg(token).toUtf8());
+    request.setRawHeader("Ocp-Apim-Subscription-Key", subscriptionKey.toUtf8());
+
+    if (suuntoManager) {
+        delete suuntoManager;
+        suuntoManager = nullptr;
+    }
+    suuntoManager = new QNetworkAccessManager(this);
+    QNetworkReply *initReply = suuntoManager->post(request, QJsonDocument(payload).toJson(QJsonDocument::Compact));
+    replySuunto = initReply;
+
+    connect(initReply, &QNetworkReply::finished, this, [this, initReply, data]() {
+        QByteArray response = initReply->readAll();
+        int statusCode = initReply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+        if (initReply->error() != QNetworkReply::NoError || statusCode < 200 || statusCode >= 300) {
+            qDebug() << "Suunto upload initialization failed" << statusCode << response;
+            setToastRequested(QString("Suunto upload init failed (HTTP %1)").arg(statusCode));
+            initReply->deleteLater();
+            return;
+        }
+
+        QJsonDocument jsonResponse = QJsonDocument::fromJson(response);
+        QJsonObject obj = jsonResponse.object();
+        const QString uploadId = obj[QStringLiteral("id")].toString();
+        const QString uploadUrl = obj[QStringLiteral("url")].toString();
+        const QString method = obj[QStringLiteral("method")].toString(QStringLiteral("PUT"));
+        const QJsonObject headers = obj[QStringLiteral("headers")].toObject();
+
+        if (uploadId.isEmpty() || uploadUrl.isEmpty()) {
+            qDebug() << "Suunto upload initialization response missing id or url" << response;
+            setToastRequested("Suunto upload init failed: missing upload URL");
+            initReply->deleteLater();
+            return;
+        }
+
+        QNetworkRequest uploadRequest(QUrl(uploadUrl));
+        for (auto it = headers.constBegin(); it != headers.constEnd(); ++it) {
+            uploadRequest.setRawHeader(it.key().toUtf8(), it.value().toString().toUtf8());
+        }
+        uploadRequest.setHeader(QNetworkRequest::ContentTypeHeader, QStringLiteral("application/octet-stream"));
+
+        QNetworkReply *uploadReply = nullptr;
+        if (method.compare(QStringLiteral("PUT"), Qt::CaseInsensitive) == 0) {
+            uploadReply = suuntoManager->put(uploadRequest, data);
+        } else {
+            uploadReply = suuntoManager->sendCustomRequest(uploadRequest, method.toUtf8(), data);
+        }
+        replySuunto = uploadReply;
+
+        connect(uploadReply, &QNetworkReply::uploadProgress,
+                [](qint64 bytesSent, qint64 bytesTotal) {
+                    qDebug() << "Suunto upload progress:" << bytesSent << "/" << bytesTotal;
+                });
+        connect(uploadReply, &QNetworkReply::finished, this, [this, uploadReply, uploadId]() {
+            int uploadStatus = uploadReply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+            QByteArray uploadResponse = uploadReply->readAll();
+            if (uploadReply->error() == QNetworkReply::NoError && uploadStatus >= 200 && uploadStatus < 300) {
+                setToastRequested("Suunto: FIT file uploaded, processing...");
+                suunto_check_upload_status(uploadId);
+            } else {
+                qDebug() << "Suunto file upload failed" << uploadStatus << uploadResponse;
+                setToastRequested(QString("Suunto upload failed (HTTP %1)").arg(uploadStatus));
+            }
+            uploadReply->deleteLater();
+        });
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 13, 0))
+        connect(uploadReply, &QNetworkReply::errorOccurred,
+                this, &homeform::errorOccurredUploadSuunto);
+#endif
+        initReply->deleteLater();
+    });
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 13, 0))
+    connect(initReply, &QNetworkReply::errorOccurred,
+            this, &homeform::errorOccurredUploadSuunto);
+#endif
+
+    qDebug() << "Suunto upload initialization started";
+    return true;
+}
+
+void homeform::suunto_check_upload_status(const QString &uploadId) {
+    QSettings settings;
+    const QString token = settings.value(QZSettings::suunto_accesstoken).toString();
+    const QString subscriptionKey = settings.value(QZSettings::suunto_subscription_key, QZSettings::default_suunto_subscription_key).toString();
+
+    QNetworkRequest request(QUrl(QStringLiteral("https://cloudapi.suunto.com/v2/upload/%1").arg(uploadId)));
+    request.setRawHeader("Authorization", QStringLiteral("Bearer %1").arg(token).toUtf8());
+    request.setRawHeader("Ocp-Apim-Subscription-Key", subscriptionKey.toUtf8());
+
+    QNetworkReply *statusReply = suuntoManager->get(request);
+    replySuunto = statusReply;
+    connect(statusReply, &QNetworkReply::finished, this, &homeform::writeFileCompletedSuunto);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 13, 0))
+    connect(statusReply, &QNetworkReply::errorOccurred,
+            this, &homeform::errorOccurredUploadSuunto);
+#endif
+}
+
+void homeform::writeFileCompletedSuunto() {
+    QNetworkReply *reply = static_cast<QNetworkReply *>(QObject::sender());
+    QByteArray response = reply->readAll();
+    int statusCode = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+
+    QJsonDocument jsonResponse = QJsonDocument::fromJson(response);
+    QJsonObject obj = jsonResponse.object();
+    const QString status = obj[QStringLiteral("status")].toString();
+    if (statusCode >= 200 && statusCode < 300 && (status == QStringLiteral("PROCESSED") || status == QStringLiteral("ACCEPTED") || status == QStringLiteral("NEW"))) {
+        if (status == QStringLiteral("PROCESSED")) {
+            setToastRequested("Suunto upload successful!");
+        } else {
+            setToastRequested("Suunto upload accepted, still processing");
+        }
+    } else {
+        const QString message = obj[QStringLiteral("message")].toString();
+        qDebug() << "Suunto upload status failed" << statusCode << status << message << response;
+        setToastRequested(QString("Suunto upload failed (HTTP %1)").arg(statusCode));
+    }
+    reply->deleteLater();
+}
+
+void homeform::errorOccurredUploadSuunto(QNetworkReply::NetworkError code) {
+    qDebug() << "Suunto upload error details:";
+    qDebug() << "Error code:" << code;
+    if (replySuunto) {
+        qDebug() << "Error string:" << replySuunto->errorString();
+        qDebug() << "HTTP status code:" << replySuunto->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+        setToastRequested("Suunto upload failed: " + replySuunto->errorString());
+    } else {
+        setToastRequested("Suunto upload failed");
+    }
 }
 
 void homeform::intervalsicu_connect_clicked() {

--- a/src/homeform.h
+++ b/src/homeform.h
@@ -225,6 +225,10 @@ class homeform : public QObject {
     bool intervalsicuWebVisible() { return intervalsicuAuthWebVisible; }
     Q_PROPERTY(QString getIntervalsICUAuthUrl READ getIntervalsICUAuthUrl NOTIFY intervalsicuAuthUrlChanged)
     Q_PROPERTY(bool intervalsicuWebVisible READ intervalsicuWebVisible NOTIFY intervalsicuWebVisibleChanged)
+    QString getSuuntoAuthUrl() { return suuntoAuthUrl; }
+    bool suuntoWebVisible() { return suuntoAuthWebVisible; }
+    Q_PROPERTY(QString getSuuntoAuthUrl READ getSuuntoAuthUrl NOTIFY suuntoAuthUrlChanged)
+    Q_PROPERTY(bool suuntoWebVisible READ suuntoWebVisible NOTIFY suuntoWebVisibleChanged)
 
   public:
     static homeform *singleton() { return m_singleton; }
@@ -585,14 +589,18 @@ class homeform : public QObject {
     Q_INVOKABLE bool isStravaLoggedIn();
     Q_INVOKABLE bool isPelotonLoggedIn();
     Q_INVOKABLE bool isIntervalsICULoggedIn();
+    Q_INVOKABLE bool isSuuntoLoggedIn();
     Q_INVOKABLE bool isGarminUploadConfigured();
     Q_INVOKABLE bool isIntervalsICUUploadConfigured();
+    Q_INVOKABLE bool isSuuntoUploadConfigured();
     Q_INVOKABLE void uploadHistoricalWorkoutToStrava(const QString &filePath);
     Q_INVOKABLE void uploadHistoricalWorkoutToGarmin(const QString &filePath);
     Q_INVOKABLE void uploadHistoricalWorkoutToIntervalsICU(const QString &filePath);
+    Q_INVOKABLE void uploadHistoricalWorkoutToSuunto(const QString &filePath);
     Q_INVOKABLE void strava_logout();
     Q_INVOKABLE void peloton_logout();
     Q_INVOKABLE void intervalsicu_logout();
+    Q_INVOKABLE void suunto_logout();
     Q_INVOKABLE void handleOAuthCallbackFromQml(const QString &callbackUrl);
     Q_INVOKABLE void selectGymModeDevice(const QString &deviceName);
     Q_INVOKABLE bool hasConnectedDevice() const;
@@ -920,6 +928,13 @@ public:
     QString intervalsicuAthleteId;
     QString intervalsicuAuthCode;
 
+    // Suunto OAuth and upload
+    QOAuth2AuthorizationCodeFlow *suunto = nullptr;
+    QNetworkAccessManager *suuntoManager = nullptr;
+    QOAuthHttpServerReplyHandler *suuntoReplyHandler = nullptr;
+    QNetworkReply *replySuunto = nullptr;
+    QString suuntoAuthCode;
+
     bool paused = false;
     bool stopped = false;
     bool lapTrigger = false;
@@ -999,6 +1014,15 @@ public:
     void intervalsicu_download_workout_completed(QNetworkReply *reply);
     QString intervalsicuAuthUrl;
     bool intervalsicuAuthWebVisible;
+
+    // Suunto methods
+    QOAuth2AuthorizationCodeFlow *suunto_connect();
+    void suunto_refreshtoken();
+    bool suunto_upload_file(const QByteArray &data, const QString &remotename);
+    void suunto_check_upload_status(const QString &uploadId);
+    QString suuntoActivityName(const QString &remotename);
+    QString suuntoAuthUrl;
+    bool suuntoAuthWebVisible;
 
     static quint64 cryptoKeySettingsProfiles();
 
@@ -1104,7 +1128,9 @@ public:
     void errorOccurredUploadStrava(QNetworkReply::NetworkError code);
     // Intervals.icu slots
     void intervalsicu_connect_clicked();
+    void suunto_connect_clicked();
     void intervalsicu_upload_file_prepare();
+    void suunto_upload_file_prepare();
     void intervalsicu_download_todays_workout_clicked();
     void onIntervalsICUGranted();
     void onIntervalsICUAuthorizeWithBrowser(const QUrl &url);
@@ -1112,6 +1138,12 @@ public:
     void callbackReceivedIntervalsICU(const QVariantMap &values);
     void writeFileCompletedIntervalsICU();
     void errorOccurredUploadIntervalsICU(QNetworkReply::NetworkError code);
+    void onSuuntoGranted();
+    void onSuuntoAuthorizeWithBrowser(const QUrl &url);
+    void replyDataReceivedSuunto(const QByteArray &v);
+    void callbackReceivedSuunto(const QVariantMap &values);
+    void writeFileCompletedSuunto();
+    void errorOccurredUploadSuunto(QNetworkReply::NetworkError code);
     void pelotonWorkoutStarted(const QString &name, const QString &instructor);
     void pelotonWorkoutChanged(const QString &name, const QString &instructor);
     void pelotonLoginState(bool ok);
@@ -1213,6 +1245,8 @@ public:
     void pelotonWebVisibleChanged(bool value);
     void intervalsicuAuthUrlChanged(QString value);
     void intervalsicuWebVisibleChanged(bool value);
+    void suuntoAuthUrlChanged(QString value);
+    void suuntoWebVisibleChanged(bool value);
 
     void restoreDefaultWheelDiameter();
 

--- a/src/icons.qrc
+++ b/src/icons.qrc
@@ -36,5 +36,6 @@
         <file>icons/Button_Connect_Rect_DarkMode.png</file>
         <file>icons/garmin-connect-badge.png</file>
         <file>icons/intervals-logo-with-name.png</file>
+        <file>icons/suunto-logo.svg</file>
     </qresource>
 </RCC>

--- a/src/icons/suunto-logo.svg
+++ b/src/icons/suunto-logo.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="160" viewBox="0 0 600 160">
+  <rect x="10" y="10" width="580" height="140" rx="20" fill="#000"/>
+  <g transform="translate(92 80)" fill="none" stroke="#fff" stroke-linejoin="round">
+    <circle r="48" stroke-width="4"/>
+    <circle r="32" stroke-width="3"/>
+    <path d="M0 -58 L12 -12 L0 -22 L-12 -12 Z" fill="#fff" stroke="none"/>
+    <path d="M0 58 L12 12 L0 22 L-12 12 Z" fill="#fff" stroke="none"/>
+    <path d="M-58 0 L-12 -12 L-22 0 L-12 12 Z" fill="#fff" stroke="none"/>
+    <path d="M58 0 L12 -12 L22 0 L12 12 Z" fill="#fff" stroke="none"/>
+  </g>
+  <text x="170" y="103" font-family="Arial, Helvetica, sans-serif" font-size="72" font-weight="700" fill="#fff">SUUNTO</text>
+</svg>

--- a/src/main.qml
+++ b/src/main.qml
@@ -94,6 +94,7 @@ ApplicationWindow {
     signal strava_connect_clicked()
     signal peloton_connect_clicked()
     signal intervalsicu_connect_clicked()
+    signal suunto_connect_clicked()
     signal intervalsicu_download_todays_workout_clicked()
     signal loadSettings(url name)
     signal saveSettings(url name)
@@ -108,6 +109,7 @@ ApplicationWindow {
     signal floatingOpen()
     signal openFloatingWindowBrowser();
     signal strava_upload_file_prepare();
+    signal suunto_upload_file_prepare();
 
     property bool lockTiles: false
     property bool settings_restart_to_apply: false
@@ -748,6 +750,16 @@ ApplicationWindow {
         visible: false
     }
 
+    MessageDialog {
+        id: suuntoLogoutConfirm
+        text: qsTr("Suunto")
+        informativeText: qsTr("You are already connected to Suunto. Do you want to log out?")
+        buttons: (MessageDialog.Yes | MessageDialog.No)
+        onYesClicked: { rootItem.suunto_logout(); }
+        onNoClicked: this.visible = false
+        visible: false
+    }
+
     header: ToolBar {
         contentHeight: toolButton.implicitHeight
         Material.primary: settings.theme_status_bar_background_color
@@ -1244,7 +1256,30 @@ ApplicationWindow {
                     }
                 }
 
-				ItemDelegate {
+                ItemDelegate {
+                    Image {
+                        anchors.left: parent.left;
+                        anchors.verticalCenter: parent.verticalCenter
+                        source: "icons/icons/suunto-logo.svg"
+                        fillMode: Image.PreserveAspectFit
+                        visible: true
+                        width: parent.width
+                        height: 48
+                    }
+                    width: parent.width
+                    onClicked: {
+                        if (rootItem.isSuuntoLoggedIn()) {
+                            suuntoLogoutConfirm.visible = true
+                            drawer.close()
+                        } else {
+                            stackView.push("WebSuuntoAuth.qml")
+                            suunto_connect_clicked()
+                            drawer.close()
+                        }
+                    }
+                }
+
+                ItemDelegate {
                     Image {
                         anchors.left: parent.left;
                         anchors.verticalCenter: parent.verticalCenter

--- a/src/qml.qrc
+++ b/src/qml.qrc
@@ -133,5 +133,6 @@
         <file>WebPelotonAuth.qml</file>
         <file>inner_templates/floating/hfloating.htm</file>
         <file>WebIntervalsICUAuth.qml</file>
+        <file>WebSuuntoAuth.qml</file>
     </qresource>
 </RCC>

--- a/src/qzsettings.cpp
+++ b/src/qzsettings.cpp
@@ -67,6 +67,18 @@ const QString QZSettings::intervalsicu_refreshtoken = QStringLiteral("intervalsi
 const QString QZSettings::default_intervalsicu_refreshtoken = QStringLiteral("");
 const QString QZSettings::intervalsicu_athlete_id = QStringLiteral("intervalsicu_athlete_id");
 const QString QZSettings::default_intervalsicu_athlete_id = QStringLiteral("");
+const QString QZSettings::suunto_accesstoken = QStringLiteral("suunto_accesstoken");
+const QString QZSettings::default_suunto_accesstoken = QStringLiteral("");
+const QString QZSettings::suunto_refreshtoken = QStringLiteral("suunto_refreshtoken");
+const QString QZSettings::default_suunto_refreshtoken = QStringLiteral("");
+const QString QZSettings::suunto_upload_enabled = QStringLiteral("suunto_upload_enabled");
+const QString QZSettings::suunto_subscription_key = QStringLiteral("suunto_subscription_key");
+const QString QZSettings::default_suunto_subscription_key = QStringLiteral("YOUR_SUUNTO_SUBSCRIPTION_KEY");
+const QString QZSettings::suunto_privacy = QStringLiteral("suunto_privacy");
+const QString QZSettings::default_suunto_privacy = QStringLiteral("DEFAULT");
+const QString QZSettings::suunto_suffix = QStringLiteral("suunto_suffix");
+const QString QZSettings::default_suunto_suffix = QStringLiteral("#QZ");
+const QString QZSettings::suunto_date_prefix = QStringLiteral("suunto_date_prefix");
 const QString QZSettings::code = QStringLiteral("code");
 const QString QZSettings::default_code = QStringLiteral("");
 //--------------------------------------------------------------------------------------------
@@ -1094,7 +1106,7 @@ const QString QZSettings::proform_carbon_tl_PFTL59723_6 = QStringLiteral("profor
 const QString QZSettings::proform_treadmill_cst_505_pftl59420_0 = QStringLiteral("proform_treadmill_cst_505_pftl59420_0");
 const QString QZSettings::applewatch_as_treadmill_speed = QStringLiteral("applewatch_as_treadmill_speed");
 
-const uint32_t allSettingsCount = 891;
+const uint32_t allSettingsCount = 898;
 
 QVariant allSettings[allSettingsCount][2] = {
     {QZSettings::cryptoKeySettingsProfiles, QZSettings::default_cryptoKeySettingsProfiles},
@@ -1131,6 +1143,13 @@ QVariant allSettings[allSettingsCount][2] = {
     {QZSettings::intervalsicu_accesstoken, QZSettings::default_intervalsicu_accesstoken},
     {QZSettings::intervalsicu_refreshtoken, QZSettings::default_intervalsicu_refreshtoken},
     {QZSettings::intervalsicu_athlete_id, QZSettings::default_intervalsicu_athlete_id},
+    {QZSettings::suunto_accesstoken, QZSettings::default_suunto_accesstoken},
+    {QZSettings::suunto_refreshtoken, QZSettings::default_suunto_refreshtoken},
+    {QZSettings::suunto_upload_enabled, QZSettings::default_suunto_upload_enabled},
+    {QZSettings::suunto_subscription_key, QZSettings::default_suunto_subscription_key},
+    {QZSettings::suunto_privacy, QZSettings::default_suunto_privacy},
+    {QZSettings::suunto_suffix, QZSettings::default_suunto_suffix},
+    {QZSettings::suunto_date_prefix, QZSettings::default_suunto_date_prefix},
     {QZSettings::intervalsicu_upload_enabled, QZSettings::default_intervalsicu_upload_enabled},
     {QZSettings::intervalsicu_suffix, QZSettings::default_intervalsicu_suffix},
     {QZSettings::intervalsicu_date_prefix, QZSettings::default_intervalsicu_date_prefix},

--- a/src/qzsettings.h
+++ b/src/qzsettings.h
@@ -127,6 +127,27 @@ class QZSettings {
     static const QString intervalsicu_athlete_id;
     static const QString default_intervalsicu_athlete_id;
 
+    static const QString suunto_accesstoken;
+    static const QString default_suunto_accesstoken;
+
+    static const QString suunto_refreshtoken;
+    static const QString default_suunto_refreshtoken;
+
+    static const QString suunto_upload_enabled;
+    static constexpr bool default_suunto_upload_enabled = false;
+
+    static const QString suunto_subscription_key;
+    static const QString default_suunto_subscription_key;
+
+    static const QString suunto_privacy;
+    static const QString default_suunto_privacy;
+
+    static const QString suunto_suffix;
+    static const QString default_suunto_suffix;
+
+    static const QString suunto_date_prefix;
+    static constexpr bool default_suunto_date_prefix = false;
+
     static const QString code;
     static const QString default_code;
 

--- a/src/settings.qml
+++ b/src/settings.qml
@@ -1322,6 +1322,13 @@ import Qt.labs.platform 1.1
             property bool gears_custom_table_enabled: false
             property string gears_custom_table: "1|1\n2|2\n3|3\n4|4\n5|5\n6|6\n7|7\n8|8\n9|9\n10|10\n11|11\n12|12\n13|13\n14|14\n15|15\n16|16\n17|17\n18|18\n19|19\n20|20\n21|21\n22|22\n23|23\n24|24"                        
             property bool proform_treadmill_cst_505_pftl59420_0: false
+            property string suunto_accesstoken: ""
+            property string suunto_refreshtoken: ""
+            property bool suunto_upload_enabled: false
+            property string suunto_subscription_key: "YOUR_SUUNTO_SUBSCRIPTION_KEY"
+            property string suunto_privacy: "DEFAULT"
+            property string suunto_suffix: "#QZ"
+            property bool suunto_date_prefix: false
         }
 
 
@@ -7535,6 +7542,168 @@ import Qt.labs.platform 1.1
 
                     Label {
                         text: qsTr("IMPORTANT: You must set your real Garmin device UNIT ID here to see your actual device in Garmin Connect. You can find your device UNIT ID in the Garmin Connect app. The default value (3313379353) is just a placeholder. If you want to see also the Acute load in Garmin Connect leave the default Unit ID here.")
+                        font.bold: true
+                        font.italic: true
+                        font.pixelSize: Qt.application.font.pixelSize - 2
+                        textFormat: Text.PlainText
+                        wrapMode: Text.WordWrap
+                        verticalAlignment: Text.AlignVCenter
+                        Layout.alignment: Qt.AlignLeft | Qt.AlignTop
+                        Layout.fillWidth: true
+                        color: Material.color(Material.Orange)
+                    }
+                }
+            }
+
+
+
+            AccordionElement {
+                id: suuntoOptionsAccordion
+                title: qsTr("Suunto Options") + " ⛰️"
+                indicatRectColor: Material.color(Material.Grey)
+                textColor: Material.color(Material.Grey)
+                color: Material.backgroundColor
+                accordionContent: ColumnLayout {
+                    spacing: 0
+
+                    Label {
+                        text: qsTr("Suunto Workout Upload")
+                        textFormat: Text.PlainText
+                        wrapMode: Text.WordWrap
+                        verticalAlignment: Text.AlignVCenter
+                    }
+
+                    IndicatorOnlySwitch {
+                        text: qsTr("Enable Suunto Upload")
+                        spacing: 0
+                        bottomPadding: 0
+                        topPadding: 0
+                        rightPadding: 0
+                        leftPadding: 0
+                        clip: false
+                        checked: settings.suunto_upload_enabled
+                        Layout.alignment: Qt.AlignLeft | Qt.AlignTop
+                        Layout.fillWidth: true
+                        onClicked: { settings.suunto_upload_enabled = checked; }
+                    }
+
+                    Label {
+                        text: qsTr("Enable automatic upload of FIT files to Suunto after workouts. You must connect your Suunto account and replace the subscription key placeholder first.")
+                        font.bold: true
+                        font.italic: true
+                        font.pixelSize: Qt.application.font.pixelSize - 2
+                        textFormat: Text.PlainText
+                        wrapMode: Text.WordWrap
+                        verticalAlignment: Text.AlignVCenter
+                        Layout.alignment: Qt.AlignLeft | Qt.AlignTop
+                        Layout.fillWidth: true
+                        color: Material.color(Material.Lime)
+                    }
+
+                    RowLayout {
+                        spacing: 10
+                        Label {
+                            text: qsTr("Suunto API Key:")
+                            Layout.fillWidth: true
+                        }
+                        TextField {
+                            id: suuntoSubscriptionKeyTextField
+                            text: settings.suunto_subscription_key
+                            horizontalAlignment: Text.AlignRight
+                            Layout.fillHeight: false
+                            Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                            onAccepted: settings.suunto_subscription_key = text
+                            onActiveFocusChanged: if(this.focus) this.cursorPosition = this.text.length
+                        }
+                        Button {
+                            text: "OK"
+                            Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                            onClicked: {
+                                settings.suunto_subscription_key = suuntoSubscriptionKeyTextField.text;
+                                toast.show("Setting saved!");
+                            }
+                        }
+                    }
+
+                    Label {
+                        text: qsTr("Placeholder: YOUR_SUUNTO_SUBSCRIPTION_KEY. Replace it with the Suunto API subscription key from the Suunto developer portal.")
+                        font.bold: true
+                        font.italic: true
+                        font.pixelSize: Qt.application.font.pixelSize - 2
+                        textFormat: Text.PlainText
+                        wrapMode: Text.WordWrap
+                        verticalAlignment: Text.AlignVCenter
+                        Layout.alignment: Qt.AlignLeft | Qt.AlignTop
+                        Layout.fillWidth: true
+                        color: Material.color(Material.Orange)
+                    }
+
+                    RowLayout {
+                        spacing: 10
+                        Label {
+                            text: qsTr("Suunto Privacy:")
+                            Layout.fillWidth: true
+                        }
+                        ComboBox {
+                            id: suuntoPrivacyComboBox
+                            Layout.fillHeight: false
+                            Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                            model: ["DEFAULT", "PRIVATE", "FOLLOWERS", "PUBLIC"]
+                            currentIndex: Math.max(0, model.indexOf(settings.suunto_privacy))
+                            onCurrentIndexChanged: settings.suunto_privacy = currentValue
+                        }
+                    }
+
+                    RowLayout {
+                        spacing: 10
+                        Label {
+                            text: qsTr("Suunto Suffix:")
+                            Layout.fillWidth: true
+                        }
+                        TextField {
+                            id: suuntoSuffixTextField
+                            text: settings.suunto_suffix
+                            horizontalAlignment: Text.AlignRight
+                            Layout.fillHeight: false
+                            Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                            onAccepted: settings.suunto_suffix = text
+                            onActiveFocusChanged: if(this.focus) this.cursorPosition = this.text.length
+                        }
+                        Button {
+                            text: "OK"
+                            Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                            onClicked: { settings.suunto_suffix = suuntoSuffixTextField.text; toast.show("Setting saved!"); }
+                        }
+                    }
+
+                    IndicatorOnlySwitch {
+                        text: qsTr("Date Prefix on Suunto Workout")
+                        spacing: 0
+                        bottomPadding: 0
+                        topPadding: 0
+                        rightPadding: 0
+                        leftPadding: 0
+                        clip: false
+                        checked: settings.suunto_date_prefix
+                        Layout.alignment: Qt.AlignLeft | Qt.AlignTop
+                        Layout.fillWidth: true
+                        onClicked: settings.suunto_date_prefix = checked
+                    }
+
+                    Button {
+                        text: rootItem.isSuuntoLoggedIn() ? qsTr("Logout Suunto") : qsTr("Connect Suunto")
+                        Layout.alignment: Qt.AlignHCenter
+                        onClicked: {
+                            if (rootItem.isSuuntoLoggedIn()) {
+                                rootItem.suunto_logout();
+                            } else {
+                                toast.show("Use the Suunto logo in the main menu to connect.");
+                            }
+                        }
+                    }
+
+                    Label {
+                        text: qsTr("OAuth client id/secret placeholders are compiled in until you add the real Suunto app credentials in secret.h. The redirect URI for this implementation is http://127.0.0.1:8495/.")
                         font.bold: true
                         font.italic: true
                         font.pixelSize: Qt.application.font.pixelSize - 2


### PR DESCRIPTION
### Motivation
- Provide an upload path for FIT files to Suunto Cloud like existing Strava/Garmin support, with OAuth authentication, subscription-key support and the multi-stage upload workflow (init → PUT → status). 

### Description
- Added Suunto OAuth and upload plumbing in `homeform`: new methods `suunto_connect`, `suunto_connect_clicked`, `callbackReceivedSuunto`, `suunto_refreshtoken`, `suunto_upload_file`, `suunto_check_upload_status`, `suunto_upload_file_prepare`, `writeFileCompletedSuunto`, and `errorOccurredUploadSuunto` to implement token exchange and the Suunto multi-stage upload flow. 
- Added persistent settings and configuration: new `QZSettings` keys (`suunto_accesstoken`, `suunto_refreshtoken`, `suunto_upload_enabled`, `suunto_subscription_key`, `suunto_privacy`, `suunto_suffix`, `suunto_date_prefix`) in `src/qzsettings.h/cpp` and QML bindings in `src/settings.qml` (with placeholder `YOUR_SUUNTO_SUBSCRIPTION_KEY`).
- UI and resources: added main menu entry and logo (`src/icons/suunto-logo.svg`, QRC updates), a WebView auth page `src/WebSuuntoAuth.qml`, logout dialog and connect actions in `src/main.qml`, and Suunto options accordion in `src/settings.qml`; also added `Upload to Suunto` entry in `src/WorkoutsHistory.qml`. 
- Added OAuth placeholders `SUUNTO_CLIENT_ID` / `SUUNTO_CLIENT_SECRET` and used a local redirect handler (port 8495) mirroring existing OAuth flows; upload uses `https://cloudapi.suunto.com/v2/upload` and status polling. 

### Testing
- Ran `git diff --check` with no issues reported. 
- Executed a Python verification that the `QZSettings` `allSettingsCount` matches the actual settings table (result: `allSettingsCount == 898`). 
- Attempted build checks: `qmake` was not available in the environment and `make -n` could not run because no Makefile was generated, so full compilation was not performed. 
- Created commit containing the changes (message: `Add Suunto FIT upload integration`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02ad7dc304832586d4d4aed903ea82)