### PR TITLE
Add rowing distance support and expand HealthKit types with availability checks

### DIFF
--- a/build-qdomyos-zwift-Qt_5_15_2_for_iOS-Debug/watchkit Extension/WatchWorkoutTracking.swift
+++ b/build-qdomyos-zwift-Qt_5_15_2_for_iOS-Debug/watchkit Extension/WatchWorkoutTracking.swift
@@ -162,7 +162,29 @@ extension WorkoutTracking: WorkoutTrackingProtocol {
             
             var infoToShare: Set<HKSampleType> = []
             
-            if #available(watchOSApplicationExtension 10.0, *) {
+            if #available(watchOSApplicationExtension 11.0, *) {
+                infoToShare = Set([
+                    HKSampleType.quantityType(forIdentifier: .stepCount)!,
+                    HKSampleType.quantityType(forIdentifier: .heartRate)!,
+                    HKSampleType.quantityType(forIdentifier: .distanceCycling)!,
+                    HKSampleType.quantityType(forIdentifier: .distanceWalkingRunning)!,
+                    HKSampleType.quantityType(forIdentifier: .activeEnergyBurned)!,
+                    HKSampleType.quantityType(forIdentifier: .basalEnergyBurned)!,
+                    HKSampleType.quantityType(forIdentifier: .cyclingPower)!,
+                    HKSampleType.quantityType(forIdentifier: .cyclingSpeed)!,
+                    HKSampleType.quantityType(forIdentifier: .cyclingCadence)!,
+                    HKSampleType.quantityType(forIdentifier: .runningPower)!,
+                    HKSampleType.quantityType(forIdentifier: .runningSpeed)!,
+                    HKSampleType.quantityType(forIdentifier: .runningStrideLength)!,
+                    HKSampleType.quantityType(forIdentifier: .runningVerticalOscillation)!,
+                    HKSampleType.quantityType(forIdentifier: .walkingSpeed)!,
+                    HKSampleType.quantityType(forIdentifier: .walkingStepLength)!,
+                    HKSampleType.quantityType(forIdentifier: .distanceRowing)!,
+                    HKSampleType.quantityType(forIdentifier: .rowingSpeed)!,
+                    HKSampleType.quantityType(forIdentifier: .flightsClimbed)!,
+                    HKSampleType.workoutType()
+                    ])
+            } else if #available(watchOSApplicationExtension 10.0, *) {
                 infoToShare = Set([
                     HKSampleType.quantityType(forIdentifier: .stepCount)!,
                     HKSampleType.quantityType(forIdentifier: .heartRate)!,
@@ -325,16 +347,10 @@ extension WorkoutTracking: WorkoutTrackingProtocol {
                  }
              }
              
-             // Per il rowing, HealthKit utilizza un tipo specifico di distanza
-             // Se non esiste un tipo specifico per il rowing, possiamo usare un tipo generico di distanza
-             var quantityTypeDistance: HKQuantityType?
-             
-             // In watchOS 10 e versioni successive, possiamo usare un tipo specifico se disponibile
-             if #available(watchOSApplicationExtension 10.0, *) {
-                 // Verifica se esiste un tipo specifico per il rowing, altrimenti utilizza un tipo generico
-                 quantityTypeDistance = HKQuantityType.quantityType(forIdentifier: .distanceSwimming)
+             let quantityTypeDistance: HKQuantityType?
+             if #available(watchOSApplicationExtension 11.0, *) {
+                 quantityTypeDistance = HKQuantityType.quantityType(forIdentifier: .distanceRowing)
              } else {
-                 // Nelle versioni precedenti, usa il tipo generico
                  quantityTypeDistance = HKQuantityType.quantityType(forIdentifier: .distanceWalkingRunning)
              }
              

--- a/src/ios/WorkoutTracking.swift
+++ b/src/ios/WorkoutTracking.swift
@@ -338,8 +338,22 @@ extension WorkoutTracking: WorkoutTrackingProtocol {
         let quantityMiles = HKQuantity(unit: unitDistance,
                                   doubleValue: miles)
         
-        if(WorkoutTracking.sport == 2 || WorkoutTracking.sport == 4) {
-            if WorkoutTracking.sport == 4 {
+        if(WorkoutTracking.sport == 2 || WorkoutTracking.sport == 3 || WorkoutTracking.sport == 4) {
+            if WorkoutTracking.sport == 3 {
+                if #available(iOS 18.0, *),
+                   let quantityTypeDistance = HKQuantityType.quantityType(forIdentifier: .distanceRowing) {
+                    let sampleDistance = HKCumulativeQuantitySeriesSample(type: quantityTypeDistance,
+                                                                  quantity: quantityMiles,
+                                                                  start: startDate,
+                                                                  end: Date())
+
+                    workoutBuilder.add([sampleDistance]) {(success, error) in
+                        if let error = error {
+                            SwiftDebug.qtDebug("WorkoutTracking: " + error.localizedDescription)
+                        }
+                    }
+                }
+            } else if WorkoutTracking.sport == 4 {
                 guard let quantityTypeDistance = HKQuantityType.quantityType(
                         forIdentifier: .distanceCycling) else {
                   return
@@ -371,7 +385,7 @@ extension WorkoutTracking: WorkoutTrackingProtocol {
                         if let error = error {
                             SwiftDebug.qtDebug("WorkoutTracking: " + error.localizedDescription)
                         }
-                        if WorkoutTracking.sport == 4 {
+                        if WorkoutTracking.sport == 3 || WorkoutTracking.sport == 4 {
                             workout?.setValue(quantityMiles, forKey: "totalDistance")
                         }
                         // Set total energy burned on the workout


### PR DESCRIPTION
### Motivation
- Expand HealthKit sharing and samples to cover additional metrics (including rowing) introduced in newer OS versions. 
- Ensure correct quantity types are used for rowing on newer watchOS/iOS while preserving fallbacks for older versions. 
- Align workout finish logic to set total distance for the newly-supported sport code and existing cycling case.

### Description
- Added broader `infoToShare` sets in the watch extension guarded by `#available(watchOSApplicationExtension 11.0, *)` to include many additional quantity types such as `distanceRowing`, `rowingSpeed`, `cyclingPower`, and other recent identifiers. 
- Updated watchkit extension rowing sample creation to prefer `distanceRowing` on watchOS 11 and above and fall back to `distanceWalkingRunning` on older watchOS. 
- In the iOS `WorkoutTracking` implementation, added handling for `sport == 3` to write a `distanceRowing` cumulative sample when available using `#available(iOS 18.0, *)`, kept cycling behavior for the other sport case, and set `totalDistance` for both sport `3` and `4`. 
- Added relevant availability checks (`#available(iOS 18.0, *)` and `#available(watchOSApplicationExtension 11.0, *)`) and preserved prior fallbacks for earlier OS versions.

### Testing
- Built the iOS and watchOS targets successfully with Xcode and verified there are no compile errors. 
- Ran the existing `WorkoutTracking` unit tests and HealthKit-related automated tests, which completed without failures. 
- Performed a smoke run of the workout finish flow in simulator/device to confirm samples and metadata are created for the updated sport cases.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03ea91929483258745352a0e0b9435)