### PR TITLE
Add iOS native workout video recorder with QML integration

### DIFF
--- a/build-qdomyos-zwift-Qt_5_15_2_for_iOS-Debug/ci_scripts/ci_pre_xcodebuild.sh
+++ b/build-qdomyos-zwift-Qt_5_15_2_for_iOS-Debug/ci_scripts/ci_pre_xcodebuild.sh
@@ -129,7 +129,7 @@ echo "Fake xcodebuild removed from PATH"
 echo "Caching build results..."
 mkdir -p "$BUILD_CACHE_DIR/objects"
 # Cache compiled object files and MOC files
-find . -name "*.o" -o -name "moc_*.cpp" -o -name "moc_*.h" | while read file; do
+find . -name "*.o" -o -name "moc_*.cpp" -o -name "moc_*.mm" -o -name "moc_*.h" | while read file; do
     cp "$file" "$BUILD_CACHE_DIR/objects/" 2>/dev/null || echo "Could not cache $file"
 done
 
@@ -229,7 +229,7 @@ fi
 cd "$PROJECT_ROOT"
 
 # CRITICAL: Copy ALL generated files from src/ to build directory AFTER git restore
-# qmake/make generates many files (moc_*.cpp, qrc_*.cpp, *.o, *.json, qmltyperegistrations, etc.) in src/
+# qmake/make generates many files (moc_*.cpp, moc_*.mm, qrc_*.cpp, *.o, *.json, qmltyperegistrations, etc.) in src/
 # but Xcode project expects them in build-qdomyos-zwift-Qt_5_15_2_for_iOS-Debug/
 # This must happen AFTER git checkout to avoid wiping out the copied files
 echo "Copying ALL Qt-generated files from src/ to build directory..."
@@ -237,7 +237,7 @@ cd "$PROJECT_ROOT/src"
 
 # Copy all generated files (cpp, o, json, a) but exclude directories
 echo "Looking for generated files in: $(pwd)"
-find . -maxdepth 1 -type f \( -name "moc_*.cpp" -o -name "moc_*.cpp.json" -o -name "qrc_*.cpp" -o -name "*.o" -o -name "*.a" -o -name "*_qmltyperegistrations.*" -o -name "*.qmltypes" -o -name "*_metatypes.json" -o -name "*_plugin_import.cpp" \) -print -exec cp {} "$PROJECT_ROOT/build-qdomyos-zwift-Qt_5_15_2_for_iOS-Debug/" \;
+find . -maxdepth 1 -type f \( -name "moc_*.cpp" -o -name "moc_*.cpp.json" -o -name "moc_*.mm" -o -name "moc_*.mm.json" -o -name "qrc_*.cpp" -o -name "*.o" -o -name "*.a" -o -name "*_qmltyperegistrations.*" -o -name "*.qmltypes" -o -name "*_metatypes.json" -o -name "*_plugin_import.cpp" \) -print -exec cp {} "$PROJECT_ROOT/build-qdomyos-zwift-Qt_5_15_2_for_iOS-Debug/" \;
 
 echo "Generated files copied to build directory"
 

--- a/build-qdomyos-zwift-Qt_5_15_2_for_iOS-Debug/qdomyoszwift.xcodeproj/project.pbxproj
+++ b/build-qdomyos-zwift-Qt_5_15_2_for_iOS-Debug/qdomyoszwift.xcodeproj/project.pbxproj
@@ -125,6 +125,8 @@
 		87062646259480B200D06586 /* ViewController.swift in Compile Sources */ = {isa = PBXBuildFile; fileRef = 876E4E4F259479EE00BD5714 /* ViewController.swift */; };
 		87062647259480B400D06586 /* WatchKitConnection.swift in Compile Sources */ = {isa = PBXBuildFile; fileRef = 876E4E53259479EE00BD5714 /* WatchKitConnection.swift */; };
 		87062648259480B700D06586 /* WorkoutTracking.swift in Compile Sources */ = {isa = PBXBuildFile; fileRef = 876E4E50259479EE00BD5714 /* WorkoutTracking.swift */; };
+		870699782FB5AD9D00C2CDA0 /* moc_workoutvideorecorder.mm in Compile Sources */ = {isa = PBXBuildFile; fileRef = 870699772FB5AD9D00C2CDA0 /* moc_workoutvideorecorder.mm */; };
+		8706997B2FB5ADB200C2CDA0 /* workoutvideorecorder.mm in Compile Sources */ = {isa = PBXBuildFile; fileRef = 8706997A2FB5ADB200C2CDA0 /* workoutvideorecorder.mm */; };
 		87083D9626678EFA0072410D /* zwiftworkout.cpp in Compile Sources */ = {isa = PBXBuildFile; fileRef = 87083D9526678EFA0072410D /* zwiftworkout.cpp */; };
 		87097D2F275EA9A30020EE6F /* sportsplusbike.cpp in Compile Sources */ = {isa = PBXBuildFile; fileRef = 87097D2D275EA9A20020EE6F /* sportsplusbike.cpp */; };
 		87097D31275EA9AF0020EE6F /* moc_sportsplusbike.cpp in Compile Sources */ = {isa = PBXBuildFile; fileRef = 87097D30275EA9AE0020EE6F /* moc_sportsplusbike.cpp */; };
@@ -1007,6 +1009,9 @@
 		870613B7286D973B00D2446E /* libqsqlite.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libqsqlite.a; path = ../../Qt/5.15.2/ios/plugins/sqldrivers/libqsqlite.a; sourceTree = "<group>"; };
 		870613B9286D979000D2446E /* libqmapboxgl.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libqmapboxgl.a; path = ../../Qt/5.15.2/ios/lib/libqmapboxgl.a; sourceTree = "<group>"; };
 		870613BB286D97D100D2446E /* libQt5Sql.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libQt5Sql.a; path = ../../Qt/5.15.2/ios/lib/libQt5Sql.a; sourceTree = "<group>"; };
+		870699772FB5AD9D00C2CDA0 /* moc_workoutvideorecorder.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = moc_workoutvideorecorder.mm; sourceTree = "<group>"; };
+		870699792FB5ADB200C2CDA0 /* workoutvideorecorder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = workoutvideorecorder.h; path = ../src/ios/workoutvideorecorder.h; sourceTree = SOURCE_ROOT; };
+		8706997A2FB5ADB200C2CDA0 /* workoutvideorecorder.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = workoutvideorecorder.mm; path = ../src/ios/workoutvideorecorder.mm; sourceTree = SOURCE_ROOT; };
 		87083D9426678EFA0072410D /* zwiftworkout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = zwiftworkout.h; path = ../src/zwiftworkout.h; sourceTree = "<group>"; };
 		87083D9526678EFA0072410D /* zwiftworkout.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = zwiftworkout.cpp; path = ../src/zwiftworkout.cpp; sourceTree = "<group>"; };
 		87097D2D275EA9A20020EE6F /* sportsplusbike.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sportsplusbike.cpp; path = ../src/devices/sportsplusbike/sportsplusbike.cpp; sourceTree = "<group>"; };
@@ -2370,6 +2375,9 @@
 		2EB56BE3C2D93CDAB0C52E67 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				870699792FB5ADB200C2CDA0 /* workoutvideorecorder.h */,
+				8706997A2FB5ADB200C2CDA0 /* workoutvideorecorder.mm */,
+				870699772FB5AD9D00C2CDA0 /* moc_workoutvideorecorder.mm */,
 				877486E12FA8E79800A02AFD /* iconsolebike.h */,
 				877486E22FA8E79800A02AFD /* iconsolebike.cpp */,
 				877486DF2FA8E78600A02AFD /* moc_iconsolebike.cpp */,
@@ -3879,6 +3887,7 @@
 				878C9E6B28B77E9800669129 /* moc_nordictrackifitadbbike.cpp in Compile Sources */,
 				8768C8C82BBC11C80099DBE1 /* commandline.c in Compile Sources */,
 				878A331D25AB50C300BD13E1 /* moc_yesoulbike.cpp in Compile Sources */,
+				8706997B2FB5ADB200C2CDA0 /* workoutvideorecorder.mm in Compile Sources */,
 				952DBD14DF6369E885020EF4 /* fit_developer_field.cpp in Compile Sources */,
 				879F16482847E57400CE4945 /* moc_proformellipticaltrainer.cpp in Compile Sources */,
 				8718CBA2263063BD004BF4EE /* soleelliptical.cpp in Compile Sources */,
@@ -4244,6 +4253,7 @@
 				87A0771029B641D600A368BF /* wahookickrheadwind.cpp in Compile Sources */,
 				87EAC3D32D1D8D1D004FE975 /* moc_pitpatbike.cpp in Compile Sources */,
 				8791A8AB25C861BD003B50B2 /* inspirebike.cpp in Compile Sources */,
+				870699782FB5AD9D00C2CDA0 /* moc_workoutvideorecorder.mm in Compile Sources */,
 				87F1BD682DBFBCE700416506 /* moc_android_antbike.cpp in Compile Sources */,
 				87F1BD692DBFBCE700416506 /* android_antbike.cpp in Compile Sources */,
 				876BFC9D27BE35C5001D7645 /* bowflext216treadmill.cpp in Compile Sources */,

--- a/src/devices/ftmsbike/ftmsbike.cpp
+++ b/src/devices/ftmsbike/ftmsbike.cpp
@@ -210,6 +210,11 @@ void ftmsbike::zwiftPlayInit() {
 }
 
 void ftmsbike::forcePower(int16_t requestPower) {
+    if (ECHO_BIKE) {
+        qDebug() << QStringLiteral("ECHO_BIKE ignores power writes");
+        return;
+    }
+
     if((resistance_lvl_mode || TITAN_7000) && !MAGNUS && !SS2K) {
         forceResistance(resistanceFromPowerRequest(requestPower));
     } else {
@@ -238,6 +243,11 @@ resistance_t ftmsbike::resistanceFromPowerRequest(uint16_t power) {
 }
 
 void ftmsbike::forceResistance(resistance_t requestResistance) {
+    if (ECHO_BIKE) {
+        qDebug() << QStringLiteral("ECHO_BIKE ignores resistance writes");
+        return;
+    }
+
     if (DOMYOS) {
         lastDomyosResistanceCommand = QDateTime::currentDateTime();
         lastDomyosRequestedResistance = requestResistance;
@@ -298,6 +308,11 @@ void ftmsbike::forceResistance(resistance_t requestResistance) {
 }
 
 void ftmsbike::forceInclination(double requestInclination) {
+    if (ECHO_BIKE) {
+        qDebug() << QStringLiteral("ECHO_BIKE ignores inclination writes");
+        return;
+    }
+
     // FTMS SET_INDOOR_BIKE_SIMULATION_PARAMS command
     // Byte 0: OpCode
     // Byte 1-2: Wind Speed (sint16, 0.001 m/s)
@@ -1585,6 +1600,11 @@ void ftmsbike::stateChanged(QLowEnergyService::ServiceState state) {
                     qDebug() << QStringLiteral("descriptor uuid") << d.uuid() << QStringLiteral("handle") << d.handle();
                 }
 
+                if (ECHO_BIKE && c.uuid() != QBluetoothUuid((quint16)0x2AD2)) {
+                    qDebug() << QStringLiteral("ECHO_BIKE subscribes only to Indoor Bike Data") << c.uuid();
+                    continue;
+                }
+
                 if ((c.properties() & QLowEnergyCharacteristic::Notify) == QLowEnergyCharacteristic::Notify) {
                     QByteArray descriptor;
                     descriptor.append((char)0x01);
@@ -1861,6 +1881,11 @@ void ftmsbike::serviceScanDone(void) {
     QBluetoothUuid ftmsService((quint16)0x1826);
     bool JK_fitness_577 = bluetoothDevice.name().toUpper().startsWith("DHZ-");
     for (const QBluetoothUuid &s : qAsConst(services_list)) {
+        if (ECHO_BIKE && s != ftmsService) {
+            qDebug() << QStringLiteral("ECHO_BIKE skipping non-FTMS service discovery") << s;
+            continue;
+        }
+
         if ((JK_fitness_577 && s == ftmsService) || !JK_fitness_577) {
             QLowEnergyService *service = m_control->createServiceObject(s);
             if (!service) {
@@ -2039,6 +2064,8 @@ void ftmsbike::deviceDiscovered(const QBluetoothDeviceInfo &device) {
         } else if(device.name().toUpper().startsWith("ECHO_BIKE_")) {
             qDebug() << QStringLiteral("ECHO_BIKE found");
             ECHO_BIKE = true;
+            autoResistanceEnable = false;
+            ergModeSupported = false;
         } else if(device.name().toUpper().startsWith("YPBM") && device.name().length() == 10) {
             qDebug() << QStringLiteral("YPBM found");
             YPBM = true;

--- a/src/devices/ftmsbike/ftmsbike.cpp
+++ b/src/devices/ftmsbike/ftmsbike.cpp
@@ -131,6 +131,14 @@ void ftmsbike::init() {
     if (initDone)
         return;
 
+    // Rogue Echo Bike V3.0 already streams FTMS data after subscription and does not
+    // accept the usual request-control / start-resume initialization sequence.
+    if (ECHO_BIKE) {
+        initDone = true;
+        initRequest = false;
+        return;
+    }
+
     if(ICSE || HAMMER) {
         uint8_t write[] = {FTMS_REQUEST_CONTROL};
         bool ret = writeCharacteristic(write, sizeof(write), "requestControl", false, true);
@@ -1560,11 +1568,10 @@ void ftmsbike::stateChanged(QLowEnergyService::ServiceState state) {
                 }
             }
             
-            if (settings.value(QZSettings::hammer_racer_s, QZSettings::default_hammer_racer_s).toBool() || SCH_190U || SCH_290R || DOMYOS || SMB1 || FIT_BK || USDC_D700) {
+            if (settings.value(QZSettings::hammer_racer_s, QZSettings::default_hammer_racer_s).toBool() || ECHO_BIKE || SCH_190U || SCH_290R || DOMYOS || SMB1 || FIT_BK || USDC_D700) {
                 QBluetoothUuid ftmsService((quint16)0x1826);
                 if (s->serviceUuid() != ftmsService) {
-                    qDebug() << QStringLiteral("hammer racer bike wants to be subscribed only to FTMS service in order "
-                                               "to send metrics")
+                    qDebug() << QStringLiteral("bike wants to be subscribed only to FTMS service in order to send metrics")
                              << s->serviceUuid();
                     continue;
                 }
@@ -2029,6 +2036,9 @@ void ftmsbike::deviceDiscovered(const QBluetoothDeviceInfo &device) {
         } else if(device.name().toUpper().startsWith("HAMMER")) {
             qDebug() << QStringLiteral("HAMMER found");
             HAMMER = true;
+        } else if(device.name().toUpper().startsWith("ECHO_BIKE_")) {
+            qDebug() << QStringLiteral("ECHO_BIKE found");
+            ECHO_BIKE = true;
         } else if(device.name().toUpper().startsWith("YPBM") && device.name().length() == 10) {
             qDebug() << QStringLiteral("YPBM found");
             YPBM = true;

--- a/src/devices/ftmsbike/ftmsbike.h
+++ b/src/devices/ftmsbike/ftmsbike.h
@@ -177,6 +177,7 @@ class ftmsbike : public bike {
     bool MRK_S26C = false;
     bool MRK_S28 = false;
     bool HAMMER = false;
+    bool ECHO_BIKE = false;
     bool YPBM = false;
     bool SPORT01 = false;
     bool FS_YK = false;

--- a/src/ios/Info.plist
+++ b/src/ios/Info.plist
@@ -65,7 +65,9 @@
 		<string>_qz_iphone._tcp</string>
 	</array>
 	<key>NSCameraUsageDescription</key>
-	<string>This app use a QT framework in order to playback workout videos. This permission is required for this reason.</string>
+	<string>QZ uses the camera to record workout videos with workout metrics overlaid.</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>QZ saves recorded workout videos to the device video library.</string>
 	<key>NSDocumentsFolderUsageDescription</key>
 	<string>application needs Documents access in order to save logs and gpx file for the training sessions</string>
 	<key>NSHealthShareUsageDescription</key>

--- a/src/ios/Info.plist
+++ b/src/ios/Info.plist
@@ -66,6 +66,8 @@
 	</array>
 	<key>NSCameraUsageDescription</key>
 	<string>QZ uses the camera to record workout videos with workout metrics overlaid.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>QZ uses the microphone to record audio in workout videos.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>QZ saves recorded workout videos to the device video library.</string>
 	<key>NSDocumentsFolderUsageDescription</key>

--- a/src/ios/workoutvideorecorder.h
+++ b/src/ios/workoutvideorecorder.h
@@ -1,0 +1,39 @@
+#ifndef IOS_WORKOUT_VIDEO_RECORDER_H
+#define IOS_WORKOUT_VIDEO_RECORDER_H
+
+#include <QObject>
+#include <QString>
+#include <QStringList>
+
+class IOSWorkoutVideoRecorderPrivate;
+
+class IOSWorkoutVideoRecorder : public QObject {
+    Q_OBJECT
+    Q_PROPERTY(bool available READ available CONSTANT)
+    Q_PROPERTY(bool recording READ recording NOTIFY recordingChanged)
+    Q_PROPERTY(bool paused READ paused NOTIFY pausedChanged)
+
+  public:
+    explicit IOSWorkoutVideoRecorder(QObject *parent = nullptr);
+    ~IOSWorkoutVideoRecorder() override;
+
+    bool available() const;
+    bool recording() const;
+    bool paused() const;
+
+    Q_INVOKABLE bool startRecording(const QString &outputLocation, const QString &cameraPosition);
+    Q_INVOKABLE void updateMetrics(const QStringList &metrics);
+    Q_INVOKABLE void pauseRecording();
+    Q_INVOKABLE void stopRecording();
+
+  signals:
+    void recordingChanged();
+    void pausedChanged();
+    void errorOccurred(const QString &message);
+    void saved(const QString &outputLocation);
+
+  private:
+    IOSWorkoutVideoRecorderPrivate *d;
+};
+
+#endif // IOS_WORKOUT_VIDEO_RECORDER_H

--- a/src/ios/workoutvideorecorder.mm
+++ b/src/ios/workoutvideorecorder.mm
@@ -1,3 +1,4 @@
+#import <AudioToolbox/AudioToolbox.h>
 #import <AVFoundation/AVFoundation.h>
 #import <CoreImage/CoreImage.h>
 #import <Foundation/Foundation.h>
@@ -43,9 +44,11 @@ class IOSWorkoutVideoRecorderPrivate {
     NSURL *outputUrl = nil;
     AVCaptureSession *captureSession = nil;
     AVCaptureVideoDataOutput *videoOutput = nil;
+    AVCaptureAudioDataOutput *audioOutput = nil;
     dispatch_queue_t captureQueue = nil;
     AVAssetWriter *assetWriter = nil;
     AVAssetWriterInput *videoInput = nil;
+    AVAssetWriterInput *audioInput = nil;
     AVAssetWriterInputPixelBufferAdaptor *pixelBufferAdaptor = nil;
     CIContext *ciContext = nil;
     QZWorkoutVideoCaptureDelegate *captureDelegate = nil;
@@ -53,6 +56,9 @@ class IOSWorkoutVideoRecorderPrivate {
     void clearCaptureObjects() {
         if (videoOutput) {
             [videoOutput setSampleBufferDelegate:nil queue:nil];
+        }
+        if (audioOutput) {
+            [audioOutput setSampleBufferDelegate:nil queue:nil];
         }
         if (captureQueue && dispatch_get_specific(&QZWorkoutVideoCaptureQueueKey) != &QZWorkoutVideoCaptureQueueKey) {
             dispatch_sync(captureQueue, ^{
@@ -62,8 +68,10 @@ class IOSWorkoutVideoRecorderPrivate {
         QZObjcRelease(outputUrl);
         QZObjcRelease(captureSession);
         QZObjcRelease(videoOutput);
+        QZObjcRelease(audioOutput);
         QZObjcRelease(assetWriter);
         QZObjcRelease(videoInput);
+        QZObjcRelease(audioInput);
         QZObjcRelease(pixelBufferAdaptor);
         QZObjcRelease(ciContext);
         QZObjcRelease(captureDelegate);
@@ -71,9 +79,11 @@ class IOSWorkoutVideoRecorderPrivate {
         outputUrl = nil;
         captureSession = nil;
         videoOutput = nil;
+        audioOutput = nil;
         captureQueue = nil;
         assetWriter = nil;
         videoInput = nil;
+        audioInput = nil;
         pixelBufferAdaptor = nil;
         ciContext = nil;
         captureDelegate = nil;
@@ -180,7 +190,7 @@ static void drawMetrics(NSArray<NSString *> *metrics, CVPixelBufferRef pixelBuff
     QZObjcRelease(renderer);
 }
 
-@interface QZWorkoutVideoCaptureDelegate : NSObject <AVCaptureVideoDataOutputSampleBufferDelegate>
+@interface QZWorkoutVideoCaptureDelegate : NSObject <AVCaptureVideoDataOutputSampleBufferDelegate, AVCaptureAudioDataOutputSampleBufferDelegate>
 @property(nonatomic, assign) IOSWorkoutVideoRecorderPrivate *state;
 - (instancetype)initWithState:(IOSWorkoutVideoRecorderPrivate *)state;
 @end
@@ -197,11 +207,21 @@ static void drawMetrics(NSArray<NSString *> *metrics, CVPixelBufferRef pixelBuff
 - (void)captureOutput:(AVCaptureOutput *)output
     didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer
            fromConnection:(AVCaptureConnection *)connection {
-    Q_UNUSED(output)
     Q_UNUSED(connection)
 
     IOSWorkoutVideoRecorderPrivate *state = _state;
     if (!state || !state->recording || state->paused || !CMSampleBufferDataIsReady(sampleBuffer)) {
+        return;
+    }
+
+    AVAssetWriter *assetWriter = state->assetWriter;
+    if (output == state->audioOutput) {
+        AVAssetWriterInput *audioInput = state->audioInput;
+        if (!assetWriter || !audioInput || !state->writingStarted || assetWriter.status != AVAssetWriterStatusWriting ||
+            !audioInput.readyForMoreMediaData) {
+            return;
+        }
+        [audioInput appendSampleBuffer:sampleBuffer];
         return;
     }
 
@@ -210,7 +230,6 @@ static void drawMetrics(NSArray<NSString *> *metrics, CVPixelBufferRef pixelBuff
         return;
     }
 
-    AVAssetWriter *assetWriter = state->assetWriter;
     AVAssetWriterInput *videoInput = state->videoInput;
     AVAssetWriterInputPixelBufferAdaptor *pixelBufferAdaptor = state->pixelBufferAdaptor;
     CIContext *ciContext = state->ciContext;
@@ -303,9 +322,30 @@ bool IOSWorkoutVideoRecorder::startRecording(const QString &outputLocation, cons
         return false;
     }
 
+    AVAuthorizationStatus audioAuthorizationStatus = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeAudio];
+    if (audioAuthorizationStatus == AVAuthorizationStatusDenied || audioAuthorizationStatus == AVAuthorizationStatusRestricted) {
+        emit errorOccurred(QStringLiteral("Microphone permission is required for workout video recording."));
+        return false;
+    }
+    if (audioAuthorizationStatus == AVAuthorizationStatusNotDetermined) {
+        IOSWorkoutVideoRecorder *self = this;
+        [AVCaptureDevice requestAccessForMediaType:AVMediaTypeAudio completionHandler:^(BOOL granted) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                emit self->errorOccurred(granted ? QStringLiteral("Microphone permission granted. Press record again to start recording.")
+                                                : QStringLiteral("Microphone permission is required for workout video recording."));
+            });
+        }];
+        return false;
+    }
+
     AVCaptureDevice *device = cameraDevice(cameraPosition);
     if (!device) {
         emit errorOccurred(QStringLiteral("No iOS camera is available for workout video recording."));
+        return false;
+    }
+    AVCaptureDevice *audioDevice = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeAudio];
+    if (!audioDevice) {
+        emit errorOccurred(QStringLiteral("No iOS microphone is available for workout video recording."));
         return false;
     }
 
@@ -331,6 +371,15 @@ bool IOSWorkoutVideoRecorder::startRecording(const QString &outputLocation, cons
     }
     [d->captureSession addInput:input];
 
+    AVCaptureDeviceInput *audioDeviceInput = [AVCaptureDeviceInput deviceInputWithDevice:audioDevice error:&error];
+    if (!audioDeviceInput || error || ![d->captureSession canAddInput:audioDeviceInput]) {
+        emit errorOccurred(error ? QString::fromNSString(error.localizedDescription)
+                                : QStringLiteral("Unable to access the iOS microphone."));
+        d->clearCaptureObjects();
+        return false;
+    }
+    [d->captureSession addInput:audioDeviceInput];
+
     d->videoOutput = [[AVCaptureVideoDataOutput alloc] init];
     d->videoOutput.videoSettings = @{(__bridge NSString *)kCVPixelBufferPixelFormatTypeKey : @(kCVPixelFormatType_32BGRA)};
     d->videoOutput.alwaysDiscardsLateVideoFrames = YES;
@@ -344,6 +393,15 @@ bool IOSWorkoutVideoRecorder::startRecording(const QString &outputLocation, cons
         return false;
     }
     [d->captureSession addOutput:d->videoOutput];
+
+    d->audioOutput = [[AVCaptureAudioDataOutput alloc] init];
+    [d->audioOutput setSampleBufferDelegate:d->captureDelegate queue:d->captureQueue];
+    if (![d->captureSession canAddOutput:d->audioOutput]) {
+        emit errorOccurred(QStringLiteral("Unable to start the iOS microphone audio output."));
+        d->clearCaptureObjects();
+        return false;
+    }
+    [d->captureSession addOutput:d->audioOutput];
 
     AVCaptureConnection *videoConnection = [d->videoOutput connectionWithMediaType:AVMediaTypeVideo];
     if (videoConnection.supportsVideoOrientation) {
@@ -375,6 +433,22 @@ bool IOSWorkoutVideoRecorder::startRecording(const QString &outputLocation, cons
         return false;
     }
     [d->assetWriter addInput:d->videoInput];
+
+    NSDictionary *audioSettings = @{
+        AVFormatIDKey : @(kAudioFormatMPEG4AAC),
+        AVNumberOfChannelsKey : @(1),
+        AVSampleRateKey : @(44100),
+        AVEncoderBitRateKey : @(64000)
+    };
+    d->audioInput = [AVAssetWriterInput assetWriterInputWithMediaType:AVMediaTypeAudio outputSettings:audioSettings];
+    d->audioInput = QZObjcRetain(d->audioInput);
+    d->audioInput.expectsMediaDataInRealTime = YES;
+    if (![d->assetWriter canAddInput:d->audioInput]) {
+        emit errorOccurred(QStringLiteral("Unable to configure the workout audio writer."));
+        d->clearCaptureObjects();
+        return false;
+    }
+    [d->assetWriter addInput:d->audioInput];
 
     d->ciContext = QZObjcRetain([CIContext contextWithOptions:nil]);
     d->writingStarted = false;
@@ -415,13 +489,15 @@ void IOSWorkoutVideoRecorder::stopRecording() {
     [d->captureSession stopRunning];
 
     AVAssetWriter *writer = d->assetWriter;
-    AVAssetWriterInput *input = d->videoInput;
+    AVAssetWriterInput *videoInput = d->videoInput;
+    AVAssetWriterInput *audioInput = d->audioInput;
     NSURL *url = d->outputUrl;
     const QString outputLocation = QString::fromNSString(url.absoluteString);
     const bool hadFrames = d->writingStarted;
 
     QZObjcRetain(writer);
-    QZObjcRetain(input);
+    QZObjcRetain(videoInput);
+    QZObjcRetain(audioInput);
     QZObjcRetain(url);
 
     d->clearCaptureObjects();
@@ -429,12 +505,14 @@ void IOSWorkoutVideoRecorder::stopRecording() {
     if (!hadFrames || writer.status != AVAssetWriterStatusWriting) {
         emit errorOccurred(QStringLiteral("Workout video recording stopped before receiving video frames."));
         QZObjcRelease(writer);
-        QZObjcRelease(input);
+        QZObjcRelease(videoInput);
+        QZObjcRelease(audioInput);
         QZObjcRelease(url);
         return;
     }
 
-    [input markAsFinished];
+    [videoInput markAsFinished];
+    [audioInput markAsFinished];
     IOSWorkoutVideoRecorder *self = this;
     [writer finishWritingWithCompletionHandler:^{
         if (writer.status == AVAssetWriterStatusCompleted) {
@@ -450,7 +528,8 @@ void IOSWorkoutVideoRecorder::stopRecording() {
             });
         }
         QZObjcRelease(writer);
-        QZObjcRelease(input);
+        QZObjcRelease(videoInput);
+        QZObjcRelease(audioInput);
         QZObjcRelease(url);
     }];
 }

--- a/src/ios/workoutvideorecorder.mm
+++ b/src/ios/workoutvideorecorder.mm
@@ -16,6 +16,48 @@
 
 @class QZWorkoutVideoCaptureDelegate;
 
+@interface QZWorkoutVideoPreviewView : UIView
+- (instancetype)initWithFrame:(CGRect)frame;
+@end
+
+@implementation QZWorkoutVideoPreviewView
+- (instancetype)initWithFrame:(CGRect)frame {
+    self = [super initWithFrame:frame];
+    if (self) {
+        self.backgroundColor = UIColor.blackColor;
+        self.layer.cornerRadius = 12.0;
+        self.layer.borderColor = [UIColor colorWithWhite:1.0 alpha:0.75].CGColor;
+        self.layer.borderWidth = 1.0;
+        self.layer.masksToBounds = YES;
+        UIPanGestureRecognizer *panGesture = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(handlePan:)];
+        [self addGestureRecognizer:panGesture];
+#if !__has_feature(objc_arc)
+        [panGesture release];
+#endif
+    }
+    return self;
+}
+
+- (void)handlePan:(UIPanGestureRecognizer *)gesture {
+    UIView *superview = self.superview;
+    if (!superview) {
+        return;
+    }
+
+    CGPoint translation = [gesture translationInView:superview];
+    CGPoint center = CGPointMake(self.center.x + translation.x, self.center.y + translation.y);
+    UIEdgeInsets safeAreaInsets = superview.safeAreaInsets;
+    const CGFloat halfWidth = CGRectGetWidth(self.bounds) / 2.0;
+    const CGFloat halfHeight = CGRectGetHeight(self.bounds) / 2.0;
+    center.x = MIN(MAX(center.x, safeAreaInsets.left + halfWidth + 8.0),
+                   CGRectGetWidth(superview.bounds) - safeAreaInsets.right - halfWidth - 8.0);
+    center.y = MIN(MAX(center.y, safeAreaInsets.top + halfHeight + 8.0),
+                   CGRectGetHeight(superview.bounds) - safeAreaInsets.bottom - halfHeight - 8.0);
+    self.center = center;
+    [gesture setTranslation:CGPointZero inView:superview];
+}
+@end
+
 static inline id QZObjcRetain(id object) {
 #if !__has_feature(objc_arc)
     return [object retain];
@@ -34,11 +76,36 @@ static inline void QZObjcRelease(id object) {
 
 static char QZWorkoutVideoCaptureQueueKey;
 
+static UIWindow *activeApplicationWindow() {
+    UIApplication *application = UIApplication.sharedApplication;
+    if (@available(iOS 13.0, *)) {
+        for (UIScene *scene in application.connectedScenes) {
+            if (scene.activationState == UISceneActivationStateForegroundActive &&
+                [scene isKindOfClass:[UIWindowScene class]]) {
+                UIWindowScene *windowScene = (UIWindowScene *)scene;
+                for (UIWindow *window in windowScene.windows) {
+                    if (window.isKeyWindow) {
+                        return window;
+                    }
+                }
+                if (windowScene.windows.count > 0) {
+                    return windowScene.windows.firstObject;
+                }
+            }
+        }
+    }
+    return application.keyWindow;
+}
+
 class IOSWorkoutVideoRecorderPrivate {
   public:
     bool recording = false;
     bool paused = false;
     bool writingStarted = false;
+    bool loggedFirstVideoSample = false;
+    bool loggedFirstAudioSample = false;
+    bool loggedMissingVideoDependencies = false;
+    bool loggedMissingPixelBufferPool = false;
     QStringList metrics;
     QMutex metricsMutex;
     NSURL *outputUrl = nil;
@@ -52,6 +119,61 @@ class IOSWorkoutVideoRecorderPrivate {
     AVAssetWriterInputPixelBufferAdaptor *pixelBufferAdaptor = nil;
     CIContext *ciContext = nil;
     QZWorkoutVideoCaptureDelegate *captureDelegate = nil;
+    QZWorkoutVideoPreviewView *previewView = nil;
+    AVCaptureVideoPreviewLayer *previewLayer = nil;
+
+    void showPreviewOverlay(bool mirrored) {
+        void (^showBlock)(void) = ^{
+            UIWindow *window = activeApplicationWindow();
+            UIView *hostView = window.rootViewController.view ?: window;
+            if (!hostView || !captureSession || previewView) {
+                return;
+            }
+
+            UIEdgeInsets safeAreaInsets = hostView.safeAreaInsets;
+            const CGFloat previewWidth = 128.0;
+            const CGFloat previewHeight = 228.0;
+            const CGFloat margin = 14.0;
+            CGRect frame = CGRectMake(CGRectGetWidth(hostView.bounds) - previewWidth - safeAreaInsets.right - margin,
+                                      CGRectGetHeight(hostView.bounds) - previewHeight - safeAreaInsets.bottom - margin,
+                                      previewWidth,
+                                      previewHeight);
+            previewView = [[QZWorkoutVideoPreviewView alloc] initWithFrame:frame];
+            previewLayer = QZObjcRetain([AVCaptureVideoPreviewLayer layerWithSession:captureSession]);
+            previewLayer.videoGravity = AVLayerVideoGravityResizeAspectFill;
+            previewLayer.frame = previewView.bounds;
+            if (previewLayer.connection.supportsVideoOrientation) {
+                previewLayer.connection.videoOrientation = AVCaptureVideoOrientationPortrait;
+            }
+            if (previewLayer.connection.supportsVideoMirroring) {
+                previewLayer.connection.automaticallyAdjustsVideoMirroring = NO;
+                previewLayer.connection.videoMirrored = mirrored;
+            }
+            [previewView.layer addSublayer:previewLayer];
+            [hostView addSubview:previewView];
+        };
+        if (NSThread.isMainThread) {
+            showBlock();
+        } else {
+            dispatch_sync(dispatch_get_main_queue(), showBlock);
+        }
+    }
+
+    void hidePreviewOverlay() {
+        void (^hideBlock)(void) = ^{
+            [previewLayer removeFromSuperlayer];
+            [previewView removeFromSuperview];
+            QZObjcRelease(previewLayer);
+            QZObjcRelease(previewView);
+            previewLayer = nil;
+            previewView = nil;
+        };
+        if (NSThread.isMainThread) {
+            hideBlock();
+        } else {
+            dispatch_sync(dispatch_get_main_queue(), hideBlock);
+        }
+    }
 
     void clearCaptureObjects() {
         if (videoOutput) {
@@ -64,6 +186,7 @@ class IOSWorkoutVideoRecorderPrivate {
             dispatch_sync(captureQueue, ^{
             });
         }
+        hidePreviewOverlay();
 
         QZObjcRelease(outputUrl);
         QZObjcRelease(captureSession);
@@ -88,6 +211,10 @@ class IOSWorkoutVideoRecorderPrivate {
         ciContext = nil;
         captureDelegate = nil;
         writingStarted = false;
+        loggedFirstVideoSample = false;
+        loggedFirstAudioSample = false;
+        loggedMissingVideoDependencies = false;
+        loggedMissingPixelBufferPool = false;
     }
 };
 
@@ -216,6 +343,10 @@ static void drawMetrics(NSArray<NSString *> *metrics, CVPixelBufferRef pixelBuff
 
     AVAssetWriter *assetWriter = state->assetWriter;
     if (output == state->audioOutput) {
+        if (!state->loggedFirstAudioSample) {
+            qDebug() << "Workout video received first audio sample";
+            state->loggedFirstAudioSample = true;
+        }
         AVAssetWriterInput *audioInput = state->audioInput;
         if (!assetWriter || !audioInput || !state->writingStarted || assetWriter.status != AVAssetWriterStatusWriting ||
             !audioInput.readyForMoreMediaData) {
@@ -229,11 +360,23 @@ static void drawMetrics(NSArray<NSString *> *metrics, CVPixelBufferRef pixelBuff
     if (!imageBuffer) {
         return;
     }
+    if (!state->loggedFirstVideoSample) {
+        qDebug() << "Workout video received first video sample";
+        state->loggedFirstVideoSample = true;
+    }
 
     AVAssetWriterInput *videoInput = state->videoInput;
     AVAssetWriterInputPixelBufferAdaptor *pixelBufferAdaptor = state->pixelBufferAdaptor;
     CIContext *ciContext = state->ciContext;
     if (!assetWriter || !videoInput || !pixelBufferAdaptor || !ciContext) {
+        if (!state->loggedMissingVideoDependencies) {
+            qDebug() << "Workout video missing dependencies"
+                     << "assetWriter" << (assetWriter != nil)
+                     << "videoInput" << (videoInput != nil)
+                     << "pixelBufferAdaptor" << (pixelBufferAdaptor != nil)
+                     << "ciContext" << (ciContext != nil);
+            state->loggedMissingVideoDependencies = true;
+        }
         return;
     }
 
@@ -254,6 +397,10 @@ static void drawMetrics(NSArray<NSString *> *metrics, CVPixelBufferRef pixelBuff
 
     CVPixelBufferPoolRef pixelBufferPool = pixelBufferAdaptor.pixelBufferPool;
     if (!pixelBufferPool) {
+        if (!state->loggedMissingPixelBufferPool) {
+            qDebug() << "Workout video pixel buffer pool is not ready";
+            state->loggedMissingPixelBufferPool = true;
+        }
         return;
     }
 
@@ -452,8 +599,13 @@ bool IOSWorkoutVideoRecorder::startRecording(const QString &outputLocation, cons
 
     d->ciContext = QZObjcRetain([CIContext contextWithOptions:nil]);
     d->writingStarted = false;
+    d->loggedFirstVideoSample = false;
+    d->loggedFirstAudioSample = false;
+    d->loggedMissingVideoDependencies = false;
+    d->loggedMissingPixelBufferPool = false;
     d->paused = false;
     d->recording = true;
+    d->showPreviewOverlay(device.position == AVCaptureDevicePositionFront);
     [d->captureSession startRunning];
     emit recordingChanged();
     emit pausedChanged();
@@ -486,50 +638,71 @@ void IOSWorkoutVideoRecorder::stopRecording() {
     emit recordingChanged();
     emit pausedChanged();
 
-    [d->captureSession stopRunning];
-
-    AVAssetWriter *writer = d->assetWriter;
-    AVAssetWriterInput *videoInput = d->videoInput;
-    AVAssetWriterInput *audioInput = d->audioInput;
-    NSURL *url = d->outputUrl;
-    const QString outputLocation = QString::fromNSString(url.absoluteString);
-    const bool hadFrames = d->writingStarted;
-
-    QZObjcRetain(writer);
-    QZObjcRetain(videoInput);
-    QZObjcRetain(audioInput);
-    QZObjcRetain(url);
-
-    d->clearCaptureObjects();
-
-    if (!hadFrames || writer.status != AVAssetWriterStatusWriting) {
-        emit errorOccurred(QStringLiteral("Workout video recording stopped before receiving video frames."));
-        QZObjcRelease(writer);
-        QZObjcRelease(videoInput);
-        QZObjcRelease(audioInput);
-        QZObjcRelease(url);
-        return;
-    }
-
-    [videoInput markAsFinished];
-    [audioInput markAsFinished];
     IOSWorkoutVideoRecorder *self = this;
-    [writer finishWritingWithCompletionHandler:^{
-        if (writer.status == AVAssetWriterStatusCompleted) {
-            if (UIVideoAtPathIsCompatibleWithSavedPhotosAlbum(url.path)) {
-                UISaveVideoAtPathToSavedPhotosAlbum(url.path, nil, nil, nil);
-            }
-            dispatch_async(dispatch_get_main_queue(), ^{
-                emit self->saved(outputLocation);
-            });
-        } else if (writer.error) {
-            dispatch_async(dispatch_get_main_queue(), ^{
-                emit self->errorOccurred(QString::fromNSString(writer.error.localizedDescription));
-            });
+    IOSWorkoutVideoRecorderPrivate *state = d;
+    state->hidePreviewOverlay();
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [state->captureSession stopRunning];
+
+        AVAssetWriter *writer = state->assetWriter;
+        AVAssetWriterInput *videoInput = state->videoInput;
+        AVAssetWriterInput *audioInput = state->audioInput;
+        NSURL *url = state->outputUrl;
+        const QString outputLocation = QString::fromNSString(url.absoluteString);
+        const bool hadFrames = state->writingStarted;
+
+        QZObjcRetain(writer);
+        QZObjcRetain(videoInput);
+        QZObjcRetain(audioInput);
+        QZObjcRetain(url);
+
+        qDebug() << "Workout video stop requested"
+                 << "hadFrames" << hadFrames
+                 << "writerStatus" << writer.status
+                 << "writerError"
+                 << (writer.error ? QString::fromNSString(writer.error.localizedDescription) : QString());
+
+        state->clearCaptureObjects();
+
+        if (!hadFrames || writer.status != AVAssetWriterStatusWriting) {
+            emit self->errorOccurred(QStringLiteral("Workout video recording stopped before receiving video frames."));
+            QZObjcRelease(writer);
+            QZObjcRelease(videoInput);
+            QZObjcRelease(audioInput);
+            QZObjcRelease(url);
+            return;
         }
-        QZObjcRelease(writer);
-        QZObjcRelease(videoInput);
-        QZObjcRelease(audioInput);
-        QZObjcRelease(url);
-    }];
+
+        [videoInput markAsFinished];
+        [audioInput markAsFinished];
+        [writer finishWritingWithCompletionHandler:^{
+            qDebug() << "Workout video writer finished"
+                     << "status" << writer.status
+                     << "error"
+                     << (writer.error ? QString::fromNSString(writer.error.localizedDescription) : QString())
+                     << "path" << QString::fromNSString(url.path);
+            if (writer.status == AVAssetWriterStatusCompleted) {
+                const bool compatibleWithPhotos = UIVideoAtPathIsCompatibleWithSavedPhotosAlbum(url.path);
+                qDebug() << "Workout video Photos compatibility" << compatibleWithPhotos;
+                if (compatibleWithPhotos) {
+                    UISaveVideoAtPathToSavedPhotosAlbum(url.path, nil, nil, nil);
+                } else {
+                    dispatch_async(dispatch_get_main_queue(), ^{
+                        emit self->errorOccurred(QStringLiteral("Workout video was saved locally but is not compatible with the Photos library."));
+                    });
+                }
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    emit self->saved(outputLocation);
+                });
+            } else if (writer.error) {
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    emit self->errorOccurred(QString::fromNSString(writer.error.localizedDescription));
+                });
+            }
+            QZObjcRelease(writer);
+            QZObjcRelease(videoInput);
+            QZObjcRelease(audioInput);
+            QZObjcRelease(url);
+        }];
+    });
 }

--- a/src/ios/workoutvideorecorder.mm
+++ b/src/ios/workoutvideorecorder.mm
@@ -15,6 +15,24 @@
 
 @class QZWorkoutVideoCaptureDelegate;
 
+static inline id QZObjcRetain(id object) {
+#if !__has_feature(objc_arc)
+    return [object retain];
+#else
+    return object;
+#endif
+}
+
+static inline void QZObjcRelease(id object) {
+#if !__has_feature(objc_arc)
+    [object release];
+#else
+    Q_UNUSED(object)
+#endif
+}
+
+static char QZWorkoutVideoCaptureQueueKey;
+
 class IOSWorkoutVideoRecorderPrivate {
   public:
     bool recording = false;
@@ -31,6 +49,36 @@ class IOSWorkoutVideoRecorderPrivate {
     AVAssetWriterInputPixelBufferAdaptor *pixelBufferAdaptor = nil;
     CIContext *ciContext = nil;
     QZWorkoutVideoCaptureDelegate *captureDelegate = nil;
+
+    void clearCaptureObjects() {
+        if (videoOutput) {
+            [videoOutput setSampleBufferDelegate:nil queue:nil];
+        }
+        if (captureQueue && dispatch_get_specific(&QZWorkoutVideoCaptureQueueKey) != &QZWorkoutVideoCaptureQueueKey) {
+            dispatch_sync(captureQueue, ^{
+            });
+        }
+
+        QZObjcRelease(outputUrl);
+        QZObjcRelease(captureSession);
+        QZObjcRelease(videoOutput);
+        QZObjcRelease(assetWriter);
+        QZObjcRelease(videoInput);
+        QZObjcRelease(pixelBufferAdaptor);
+        QZObjcRelease(ciContext);
+        QZObjcRelease(captureDelegate);
+
+        outputUrl = nil;
+        captureSession = nil;
+        videoOutput = nil;
+        captureQueue = nil;
+        assetWriter = nil;
+        videoInput = nil;
+        pixelBufferAdaptor = nil;
+        ciContext = nil;
+        captureDelegate = nil;
+        writingStarted = false;
+    }
 };
 
 static NSURL *urlFromOutputLocation(const QString &outputLocation) {
@@ -152,27 +200,44 @@ static void drawMetrics(NSArray<NSString *> *metrics, CVPixelBufferRef pixelBuff
         return;
     }
 
+    AVAssetWriter *assetWriter = state->assetWriter;
+    AVAssetWriterInput *videoInput = state->videoInput;
+    AVAssetWriterInputPixelBufferAdaptor *pixelBufferAdaptor = state->pixelBufferAdaptor;
+    CIContext *ciContext = state->ciContext;
+    if (!assetWriter || !videoInput || !pixelBufferAdaptor || !ciContext) {
+        return;
+    }
+
     const CMTime presentationTime = CMSampleBufferGetPresentationTimeStamp(sampleBuffer);
     if (!state->writingStarted) {
-        [state->assetWriter startWriting];
-        [state->assetWriter startSessionAtSourceTime:presentationTime];
+        if (![assetWriter startWriting]) {
+            qDebug() << "Workout video writer failed to start"
+                     << (assetWriter.error ? QString::fromNSString(assetWriter.error.localizedDescription) : QString());
+            return;
+        }
+        [assetWriter startSessionAtSourceTime:presentationTime];
         state->writingStarted = true;
     }
 
-    if (!state->videoInput.readyForMoreMediaData) {
+    if (assetWriter.status != AVAssetWriterStatusWriting || !videoInput.readyForMoreMediaData) {
+        return;
+    }
+
+    CVPixelBufferPoolRef pixelBufferPool = pixelBufferAdaptor.pixelBufferPool;
+    if (!pixelBufferPool) {
         return;
     }
 
     CVPixelBufferRef outputBuffer = nil;
     CVReturn result = CVPixelBufferPoolCreatePixelBuffer(kCFAllocatorDefault,
-                                                         state->pixelBufferAdaptor.pixelBufferPool,
+                                                         pixelBufferPool,
                                                          &outputBuffer);
     if (result != kCVReturnSuccess || !outputBuffer) {
         return;
     }
 
     CIImage *sourceImage = [CIImage imageWithCVPixelBuffer:imageBuffer];
-    [state->ciContext render:sourceImage toCVPixelBuffer:outputBuffer];
+    [ciContext render:sourceImage toCVPixelBuffer:outputBuffer];
 
     QStringList metricLines;
     {
@@ -187,7 +252,7 @@ static void drawMetrics(NSArray<NSString *> *metrics, CVPixelBufferRef pixelBuff
     }
     drawMetrics(nativeMetrics, outputBuffer);
 
-    [state->pixelBufferAdaptor appendPixelBuffer:outputBuffer withPresentationTime:presentationTime];
+    [pixelBufferAdaptor appendPixelBuffer:outputBuffer withPresentationTime:presentationTime];
     CVPixelBufferRelease(outputBuffer);
 }
 @end
@@ -234,13 +299,13 @@ bool IOSWorkoutVideoRecorder::startRecording(const QString &outputLocation, cons
         return false;
     }
 
-    d->outputUrl = urlFromOutputLocation(outputLocation);
+    d->outputUrl = QZObjcRetain(urlFromOutputLocation(outputLocation));
     NSError *error = nil;
     d->assetWriter = [[AVAssetWriter alloc] initWithURL:d->outputUrl fileType:AVFileTypeQuickTimeMovie error:&error];
     if (!d->assetWriter || error) {
         emit errorOccurred(error ? QString::fromNSString(error.localizedDescription)
                                 : QStringLiteral("Unable to create the workout video file."));
-        d->outputUrl = nil;
+        d->clearCaptureObjects();
         return false;
     }
 
@@ -251,8 +316,7 @@ bool IOSWorkoutVideoRecorder::startRecording(const QString &outputLocation, cons
     if (!input || error || ![d->captureSession canAddInput:input]) {
         emit errorOccurred(error ? QString::fromNSString(error.localizedDescription)
                                 : QStringLiteral("Unable to access the selected iOS camera."));
-        d->assetWriter = nil;
-        d->captureSession = nil;
+        d->clearCaptureObjects();
         return false;
     }
     [d->captureSession addInput:input];
@@ -261,14 +325,12 @@ bool IOSWorkoutVideoRecorder::startRecording(const QString &outputLocation, cons
     d->videoOutput.videoSettings = @{(__bridge NSString *)kCVPixelBufferPixelFormatTypeKey : @(kCVPixelFormatType_32BGRA)};
     d->videoOutput.alwaysDiscardsLateVideoFrames = YES;
     d->captureQueue = dispatch_queue_create("org.cagnulein.qdomyoszwift.workoutVideo", DISPATCH_QUEUE_SERIAL);
+    dispatch_queue_set_specific(d->captureQueue, &QZWorkoutVideoCaptureQueueKey, &QZWorkoutVideoCaptureQueueKey, NULL);
     d->captureDelegate = [[QZWorkoutVideoCaptureDelegate alloc] initWithState:d];
     [d->videoOutput setSampleBufferDelegate:d->captureDelegate queue:d->captureQueue];
     if (![d->captureSession canAddOutput:d->videoOutput]) {
         emit errorOccurred(QStringLiteral("Unable to start the iOS camera video output."));
-        d->assetWriter = nil;
-        d->captureSession = nil;
-        d->videoOutput = nil;
-        d->captureDelegate = nil;
+        d->clearCaptureObjects();
         return false;
     }
     [d->captureSession addOutput:d->videoOutput];
@@ -287,6 +349,7 @@ bool IOSWorkoutVideoRecorder::startRecording(const QString &outputLocation, cons
         AVVideoHeightKey : @(1280)
     };
     d->videoInput = [AVAssetWriterInput assetWriterInputWithMediaType:AVMediaTypeVideo outputSettings:outputSettings];
+    d->videoInput = QZObjcRetain(d->videoInput);
     d->videoInput.expectsMediaDataInRealTime = YES;
     NSDictionary *sourceAttributes = @{
         (__bridge NSString *)kCVPixelBufferPixelFormatTypeKey : @(kCVPixelFormatType_32BGRA),
@@ -295,19 +358,15 @@ bool IOSWorkoutVideoRecorder::startRecording(const QString &outputLocation, cons
     };
     d->pixelBufferAdaptor = [AVAssetWriterInputPixelBufferAdaptor assetWriterInputPixelBufferAdaptorWithAssetWriterInput:d->videoInput
                                                                                              sourcePixelBufferAttributes:sourceAttributes];
+    d->pixelBufferAdaptor = QZObjcRetain(d->pixelBufferAdaptor);
     if (![d->assetWriter canAddInput:d->videoInput]) {
         emit errorOccurred(QStringLiteral("Unable to configure the workout video writer."));
-        d->assetWriter = nil;
-        d->captureSession = nil;
-        d->videoOutput = nil;
-        d->videoInput = nil;
-        d->pixelBufferAdaptor = nil;
-        d->captureDelegate = nil;
+        d->clearCaptureObjects();
         return false;
     }
     [d->assetWriter addInput:d->videoInput];
 
-    d->ciContext = [CIContext contextWithOptions:nil];
+    d->ciContext = QZObjcRetain([CIContext contextWithOptions:nil]);
     d->writingStarted = false;
     d->paused = false;
     d->recording = true;
@@ -344,7 +403,6 @@ void IOSWorkoutVideoRecorder::stopRecording() {
     emit pausedChanged();
 
     [d->captureSession stopRunning];
-    [d->videoOutput setSampleBufferDelegate:nil queue:nil];
 
     AVAssetWriter *writer = d->assetWriter;
     AVAssetWriterInput *input = d->videoInput;
@@ -352,18 +410,17 @@ void IOSWorkoutVideoRecorder::stopRecording() {
     const QString outputLocation = QString::fromNSString(url.absoluteString);
     const bool hadFrames = d->writingStarted;
 
-    d->assetWriter = nil;
-    d->videoInput = nil;
-    d->pixelBufferAdaptor = nil;
-    d->captureSession = nil;
-    d->videoOutput = nil;
-    d->captureDelegate = nil;
-    d->ciContext = nil;
-    d->outputUrl = nil;
-    d->writingStarted = false;
+    QZObjcRetain(writer);
+    QZObjcRetain(input);
+    QZObjcRetain(url);
+
+    d->clearCaptureObjects();
 
     if (!hadFrames || writer.status != AVAssetWriterStatusWriting) {
         emit errorOccurred(QStringLiteral("Workout video recording stopped before receiving video frames."));
+        QZObjcRelease(writer);
+        QZObjcRelease(input);
+        QZObjcRelease(url);
         return;
     }
 
@@ -382,5 +439,8 @@ void IOSWorkoutVideoRecorder::stopRecording() {
                 emit self->errorOccurred(QString::fromNSString(writer.error.localizedDescription));
             });
         }
+        QZObjcRelease(writer);
+        QZObjcRelease(input);
+        QZObjcRelease(url);
     }];
 }

--- a/src/ios/workoutvideorecorder.mm
+++ b/src/ios/workoutvideorecorder.mm
@@ -1,0 +1,386 @@
+#import <AVFoundation/AVFoundation.h>
+#import <CoreImage/CoreImage.h>
+#import <Foundation/Foundation.h>
+#import <Photos/Photos.h>
+#import <UIKit/UIKit.h>
+
+#include "ios/workoutvideorecorder.h"
+
+#include <QDebug>
+#include <QDir>
+#include <QFileInfo>
+#include <QMutex>
+#include <QMutexLocker>
+#include <QUrl>
+
+@class QZWorkoutVideoCaptureDelegate;
+
+class IOSWorkoutVideoRecorderPrivate {
+  public:
+    bool recording = false;
+    bool paused = false;
+    bool writingStarted = false;
+    QStringList metrics;
+    QMutex metricsMutex;
+    NSURL *outputUrl = nil;
+    AVCaptureSession *captureSession = nil;
+    AVCaptureVideoDataOutput *videoOutput = nil;
+    dispatch_queue_t captureQueue = nil;
+    AVAssetWriter *assetWriter = nil;
+    AVAssetWriterInput *videoInput = nil;
+    AVAssetWriterInputPixelBufferAdaptor *pixelBufferAdaptor = nil;
+    CIContext *ciContext = nil;
+    QZWorkoutVideoCaptureDelegate *captureDelegate = nil;
+};
+
+static NSURL *urlFromOutputLocation(const QString &outputLocation) {
+    const QUrl qurl(outputLocation);
+    const QString localPath = qurl.isLocalFile() ? qurl.toLocalFile() : outputLocation;
+    QDir().mkpath(QFileInfo(localPath).absolutePath());
+    [[NSFileManager defaultManager] removeItemAtURL:[NSURL fileURLWithPath:localPath.toNSString()] error:nil];
+    return [NSURL fileURLWithPath:localPath.toNSString()];
+}
+
+static AVCaptureDevice *cameraDevice(const QString &cameraPosition) {
+    AVCaptureDevicePosition requestedPosition = cameraPosition.compare(QStringLiteral("front"), Qt::CaseInsensitive) == 0
+                                                   ? AVCaptureDevicePositionFront
+                                                   : AVCaptureDevicePositionBack;
+    NSArray<AVCaptureDevice *> *devices = [AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo];
+    for (AVCaptureDevice *device in devices) {
+        if (device.position == requestedPosition) {
+            return device;
+        }
+    }
+    return devices.count > 0 ? devices.firstObject : nil;
+}
+
+static void drawMetrics(NSArray<NSString *> *metrics, CVPixelBufferRef pixelBuffer) {
+    if (metrics.count == 0) {
+        return;
+    }
+
+    CVPixelBufferLockBaseAddress(pixelBuffer, 0);
+    void *baseAddress = CVPixelBufferGetBaseAddress(pixelBuffer);
+    const size_t width = CVPixelBufferGetWidth(pixelBuffer);
+    const size_t height = CVPixelBufferGetHeight(pixelBuffer);
+    const size_t bytesPerRow = CVPixelBufferGetBytesPerRow(pixelBuffer);
+
+    CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
+    CGContextRef context = CGBitmapContextCreate(baseAddress, width, height, 8, bytesPerRow, colorSpace,
+                                                 kCGBitmapByteOrder32Little | kCGImageAlphaPremultipliedFirst);
+    CGColorSpaceRelease(colorSpace);
+
+    if (!context) {
+        CVPixelBufferUnlockBaseAddress(pixelBuffer, 0);
+        return;
+    }
+
+    UIGraphicsPushContext(context);
+
+    UIFont *font = [UIFont boldSystemFontOfSize:28.0];
+    NSDictionary *attributes = @{
+        NSFontAttributeName : font,
+        NSForegroundColorAttributeName : UIColor.whiteColor
+    };
+
+    NSMutableArray<NSValue *> *lineSizes = [NSMutableArray arrayWithCapacity:metrics.count];
+    CGFloat maxWidth = 0.0;
+    CGFloat totalHeight = 0.0;
+    for (NSString *line in metrics) {
+        CGSize lineSize = [line sizeWithAttributes:attributes];
+        [lineSizes addObject:[NSValue valueWithCGSize:lineSize]];
+        maxWidth = MAX(maxWidth, lineSize.width);
+        totalHeight += lineSize.height + 8.0;
+    }
+    totalHeight = MAX(0.0, totalHeight - 8.0);
+
+    const CGFloat padding = 18.0;
+    const CGFloat margin = 24.0;
+    CGRect backgroundRect = CGRectMake(width - maxWidth - padding * 2.0 - margin,
+                                       height - totalHeight - padding * 2.0 - margin,
+                                       maxWidth + padding * 2.0,
+                                       totalHeight + padding * 2.0);
+
+    UIBezierPath *path = [UIBezierPath bezierPathWithRoundedRect:backgroundRect cornerRadius:14.0];
+    [[UIColor colorWithWhite:0.0 alpha:0.62] setFill];
+    [path fill];
+
+    CGFloat y = backgroundRect.origin.y + padding;
+    for (NSUInteger i = 0; i < metrics.count; i++) {
+        NSString *line = metrics[i];
+        CGSize lineSize = [lineSizes[i] CGSizeValue];
+        CGRect textRect = CGRectMake(backgroundRect.origin.x + backgroundRect.size.width - padding - lineSize.width,
+                                     y,
+                                     lineSize.width,
+                                     lineSize.height);
+        [line drawInRect:textRect withAttributes:attributes];
+        y += lineSize.height + 8.0;
+    }
+
+    UIGraphicsPopContext();
+    CGContextRelease(context);
+    CVPixelBufferUnlockBaseAddress(pixelBuffer, 0);
+}
+
+@interface QZWorkoutVideoCaptureDelegate : NSObject <AVCaptureVideoDataOutputSampleBufferDelegate>
+@property(nonatomic, assign) IOSWorkoutVideoRecorderPrivate *state;
+- (instancetype)initWithState:(IOSWorkoutVideoRecorderPrivate *)state;
+@end
+
+@implementation QZWorkoutVideoCaptureDelegate
+- (instancetype)initWithState:(IOSWorkoutVideoRecorderPrivate *)state {
+    self = [super init];
+    if (self) {
+        _state = state;
+    }
+    return self;
+}
+
+- (void)captureOutput:(AVCaptureOutput *)output
+    didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer
+           fromConnection:(AVCaptureConnection *)connection {
+    Q_UNUSED(output)
+    Q_UNUSED(connection)
+
+    IOSWorkoutVideoRecorderPrivate *state = _state;
+    if (!state || !state->recording || state->paused || !CMSampleBufferDataIsReady(sampleBuffer)) {
+        return;
+    }
+
+    CVImageBufferRef imageBuffer = CMSampleBufferGetImageBuffer(sampleBuffer);
+    if (!imageBuffer) {
+        return;
+    }
+
+    const CMTime presentationTime = CMSampleBufferGetPresentationTimeStamp(sampleBuffer);
+    if (!state->writingStarted) {
+        [state->assetWriter startWriting];
+        [state->assetWriter startSessionAtSourceTime:presentationTime];
+        state->writingStarted = true;
+    }
+
+    if (!state->videoInput.readyForMoreMediaData) {
+        return;
+    }
+
+    CVPixelBufferRef outputBuffer = nil;
+    CVReturn result = CVPixelBufferPoolCreatePixelBuffer(kCFAllocatorDefault,
+                                                         state->pixelBufferAdaptor.pixelBufferPool,
+                                                         &outputBuffer);
+    if (result != kCVReturnSuccess || !outputBuffer) {
+        return;
+    }
+
+    CIImage *sourceImage = [CIImage imageWithCVPixelBuffer:imageBuffer];
+    [state->ciContext render:sourceImage toCVPixelBuffer:outputBuffer];
+
+    QStringList metricLines;
+    {
+        QMutexLocker locker(&state->metricsMutex);
+        metricLines = state->metrics;
+    }
+    NSMutableArray<NSString *> *nativeMetrics = [NSMutableArray arrayWithCapacity:metricLines.size()];
+    for (const QString &line : metricLines) {
+        if (!line.trimmed().isEmpty()) {
+            [nativeMetrics addObject:line.toNSString()];
+        }
+    }
+    drawMetrics(nativeMetrics, outputBuffer);
+
+    [state->pixelBufferAdaptor appendPixelBuffer:outputBuffer withPresentationTime:presentationTime];
+    CVPixelBufferRelease(outputBuffer);
+}
+@end
+
+IOSWorkoutVideoRecorder::IOSWorkoutVideoRecorder(QObject *parent) : QObject(parent), d(new IOSWorkoutVideoRecorderPrivate) {}
+
+IOSWorkoutVideoRecorder::~IOSWorkoutVideoRecorder() {
+    stopRecording();
+    delete d;
+}
+
+bool IOSWorkoutVideoRecorder::available() const {
+    return [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeVideo] != nil;
+}
+
+bool IOSWorkoutVideoRecorder::recording() const { return d->recording; }
+
+bool IOSWorkoutVideoRecorder::paused() const { return d->paused; }
+
+bool IOSWorkoutVideoRecorder::startRecording(const QString &outputLocation, const QString &cameraPosition) {
+    if (d->recording) {
+        return true;
+    }
+
+    AVAuthorizationStatus authorizationStatus = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo];
+    if (authorizationStatus == AVAuthorizationStatusDenied || authorizationStatus == AVAuthorizationStatusRestricted) {
+        emit errorOccurred(QStringLiteral("Camera permission is required for workout video recording."));
+        return false;
+    }
+    if (authorizationStatus == AVAuthorizationStatusNotDetermined) {
+        IOSWorkoutVideoRecorder *self = this;
+        [AVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo completionHandler:^(BOOL granted) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                emit self->errorOccurred(granted ? QStringLiteral("Camera permission granted. Press record again to start recording.")
+                                                : QStringLiteral("Camera permission is required for workout video recording."));
+            });
+        }];
+        return false;
+    }
+
+    AVCaptureDevice *device = cameraDevice(cameraPosition);
+    if (!device) {
+        emit errorOccurred(QStringLiteral("No iOS camera is available for workout video recording."));
+        return false;
+    }
+
+    d->outputUrl = urlFromOutputLocation(outputLocation);
+    NSError *error = nil;
+    d->assetWriter = [[AVAssetWriter alloc] initWithURL:d->outputUrl fileType:AVFileTypeQuickTimeMovie error:&error];
+    if (!d->assetWriter || error) {
+        emit errorOccurred(error ? QString::fromNSString(error.localizedDescription)
+                                : QStringLiteral("Unable to create the workout video file."));
+        d->outputUrl = nil;
+        return false;
+    }
+
+    d->captureSession = [[AVCaptureSession alloc] init];
+    d->captureSession.sessionPreset = AVCaptureSessionPreset1280x720;
+
+    AVCaptureDeviceInput *input = [AVCaptureDeviceInput deviceInputWithDevice:device error:&error];
+    if (!input || error || ![d->captureSession canAddInput:input]) {
+        emit errorOccurred(error ? QString::fromNSString(error.localizedDescription)
+                                : QStringLiteral("Unable to access the selected iOS camera."));
+        d->assetWriter = nil;
+        d->captureSession = nil;
+        return false;
+    }
+    [d->captureSession addInput:input];
+
+    d->videoOutput = [[AVCaptureVideoDataOutput alloc] init];
+    d->videoOutput.videoSettings = @{(__bridge NSString *)kCVPixelBufferPixelFormatTypeKey : @(kCVPixelFormatType_32BGRA)};
+    d->videoOutput.alwaysDiscardsLateVideoFrames = YES;
+    d->captureQueue = dispatch_queue_create("org.cagnulein.qdomyoszwift.workoutVideo", DISPATCH_QUEUE_SERIAL);
+    d->captureDelegate = [[QZWorkoutVideoCaptureDelegate alloc] initWithState:d];
+    [d->videoOutput setSampleBufferDelegate:d->captureDelegate queue:d->captureQueue];
+    if (![d->captureSession canAddOutput:d->videoOutput]) {
+        emit errorOccurred(QStringLiteral("Unable to start the iOS camera video output."));
+        d->assetWriter = nil;
+        d->captureSession = nil;
+        d->videoOutput = nil;
+        d->captureDelegate = nil;
+        return false;
+    }
+    [d->captureSession addOutput:d->videoOutput];
+
+    AVCaptureConnection *videoConnection = [d->videoOutput connectionWithMediaType:AVMediaTypeVideo];
+    if (videoConnection.supportsVideoOrientation) {
+        videoConnection.videoOrientation = AVCaptureVideoOrientationPortrait;
+    }
+    if (videoConnection.supportsVideoMirroring && device.position == AVCaptureDevicePositionFront) {
+        videoConnection.videoMirrored = YES;
+    }
+
+    NSDictionary *outputSettings = @{
+        AVVideoCodecKey : AVVideoCodecTypeH264,
+        AVVideoWidthKey : @(720),
+        AVVideoHeightKey : @(1280)
+    };
+    d->videoInput = [AVAssetWriterInput assetWriterInputWithMediaType:AVMediaTypeVideo outputSettings:outputSettings];
+    d->videoInput.expectsMediaDataInRealTime = YES;
+    NSDictionary *sourceAttributes = @{
+        (__bridge NSString *)kCVPixelBufferPixelFormatTypeKey : @(kCVPixelFormatType_32BGRA),
+        (__bridge NSString *)kCVPixelBufferWidthKey : @(720),
+        (__bridge NSString *)kCVPixelBufferHeightKey : @(1280)
+    };
+    d->pixelBufferAdaptor = [AVAssetWriterInputPixelBufferAdaptor assetWriterInputPixelBufferAdaptorWithAssetWriterInput:d->videoInput
+                                                                                             sourcePixelBufferAttributes:sourceAttributes];
+    if (![d->assetWriter canAddInput:d->videoInput]) {
+        emit errorOccurred(QStringLiteral("Unable to configure the workout video writer."));
+        d->assetWriter = nil;
+        d->captureSession = nil;
+        d->videoOutput = nil;
+        d->videoInput = nil;
+        d->pixelBufferAdaptor = nil;
+        d->captureDelegate = nil;
+        return false;
+    }
+    [d->assetWriter addInput:d->videoInput];
+
+    d->ciContext = [CIContext contextWithOptions:nil];
+    d->writingStarted = false;
+    d->paused = false;
+    d->recording = true;
+    [d->captureSession startRunning];
+    emit recordingChanged();
+    emit pausedChanged();
+    qDebug() << "Native iOS camera workout recording started" << outputLocation << cameraPosition;
+    return true;
+}
+
+void IOSWorkoutVideoRecorder::updateMetrics(const QStringList &metrics) {
+    QMutexLocker locker(&d->metricsMutex);
+    d->metrics = metrics;
+}
+
+void IOSWorkoutVideoRecorder::pauseRecording() {
+    if (!d->recording || d->paused) {
+        return;
+    }
+
+    d->paused = true;
+    emit pausedChanged();
+    qDebug() << "Native iOS camera workout recording paused";
+}
+
+void IOSWorkoutVideoRecorder::stopRecording() {
+    if (!d->recording) {
+        return;
+    }
+
+    d->recording = false;
+    d->paused = false;
+    emit recordingChanged();
+    emit pausedChanged();
+
+    [d->captureSession stopRunning];
+    [d->videoOutput setSampleBufferDelegate:nil queue:nil];
+
+    AVAssetWriter *writer = d->assetWriter;
+    AVAssetWriterInput *input = d->videoInput;
+    NSURL *url = d->outputUrl;
+    const QString outputLocation = QString::fromNSString(url.absoluteString);
+    const bool hadFrames = d->writingStarted;
+
+    d->assetWriter = nil;
+    d->videoInput = nil;
+    d->pixelBufferAdaptor = nil;
+    d->captureSession = nil;
+    d->videoOutput = nil;
+    d->captureDelegate = nil;
+    d->ciContext = nil;
+    d->outputUrl = nil;
+    d->writingStarted = false;
+
+    if (!hadFrames || writer.status != AVAssetWriterStatusWriting) {
+        emit errorOccurred(QStringLiteral("Workout video recording stopped before receiving video frames."));
+        return;
+    }
+
+    [input markAsFinished];
+    IOSWorkoutVideoRecorder *self = this;
+    [writer finishWritingWithCompletionHandler:^{
+        if (writer.status == AVAssetWriterStatusCompleted) {
+            if (UIVideoAtPathIsCompatibleWithSavedPhotosAlbum(url.path)) {
+                UISaveVideoAtPathToSavedPhotosAlbum(url.path, nil, nil, nil);
+            }
+            dispatch_async(dispatch_get_main_queue(), ^{
+                emit self->saved(outputLocation);
+            });
+        } else if (writer.error) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                emit self->errorOccurred(QString::fromNSString(writer.error.localizedDescription));
+            });
+        }
+    }];
+}

--- a/src/ios/workoutvideorecorder.mm
+++ b/src/ios/workoutvideorecorder.mm
@@ -107,23 +107,8 @@ static void drawMetrics(NSArray<NSString *> *metrics, CVPixelBufferRef pixelBuff
         return;
     }
 
-    CVPixelBufferLockBaseAddress(pixelBuffer, 0);
-    void *baseAddress = CVPixelBufferGetBaseAddress(pixelBuffer);
     const size_t width = CVPixelBufferGetWidth(pixelBuffer);
     const size_t height = CVPixelBufferGetHeight(pixelBuffer);
-    const size_t bytesPerRow = CVPixelBufferGetBytesPerRow(pixelBuffer);
-
-    CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
-    CGContextRef context = CGBitmapContextCreate(baseAddress, width, height, 8, bytesPerRow, colorSpace,
-                                                 kCGBitmapByteOrder32Little | kCGImageAlphaPremultipliedFirst);
-    CGColorSpaceRelease(colorSpace);
-
-    if (!context) {
-        CVPixelBufferUnlockBaseAddress(pixelBuffer, 0);
-        return;
-    }
-
-    UIGraphicsPushContext(context);
 
     UIFont *font = [UIFont boldSystemFontOfSize:28.0];
     NSDictionary *attributes = @{
@@ -149,25 +134,50 @@ static void drawMetrics(NSArray<NSString *> *metrics, CVPixelBufferRef pixelBuff
                                        maxWidth + padding * 2.0,
                                        totalHeight + padding * 2.0);
 
-    UIBezierPath *path = [UIBezierPath bezierPathWithRoundedRect:backgroundRect cornerRadius:14.0];
-    [[UIColor colorWithWhite:0.0 alpha:0.62] setFill];
-    [path fill];
+    UIGraphicsImageRendererFormat *format = [UIGraphicsImageRendererFormat defaultFormat];
+    format.opaque = NO;
+    format.scale = 1.0;
+    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:CGSizeMake(width, height)
+                                                                               format:format];
+    UIImage *overlay = [renderer imageWithActions:^(UIGraphicsImageRendererContext *rendererContext) {
+        Q_UNUSED(rendererContext);
 
-    CGFloat y = backgroundRect.origin.y + padding;
-    for (NSUInteger i = 0; i < metrics.count; i++) {
-        NSString *line = metrics[i];
-        CGSize lineSize = [lineSizes[i] CGSizeValue];
-        CGRect textRect = CGRectMake(backgroundRect.origin.x + backgroundRect.size.width - padding - lineSize.width,
-                                     y,
-                                     lineSize.width,
-                                     lineSize.height);
-        [line drawInRect:textRect withAttributes:attributes];
-        y += lineSize.height + 8.0;
+        UIBezierPath *path = [UIBezierPath bezierPathWithRoundedRect:backgroundRect cornerRadius:14.0];
+        [[UIColor colorWithWhite:0.0 alpha:0.62] setFill];
+        [path fill];
+
+        CGFloat y = backgroundRect.origin.y + padding;
+        for (NSUInteger i = 0; i < metrics.count; i++) {
+            NSString *line = metrics[i];
+            CGSize lineSize = [lineSizes[i] CGSizeValue];
+            CGRect textRect = CGRectMake(backgroundRect.origin.x + backgroundRect.size.width - padding - lineSize.width,
+                                         y,
+                                         lineSize.width,
+                                         lineSize.height);
+            [line drawInRect:textRect withAttributes:attributes];
+            y += lineSize.height + 8.0;
+        }
+    }];
+
+    CVPixelBufferLockBaseAddress(pixelBuffer, 0);
+    void *baseAddress = CVPixelBufferGetBaseAddress(pixelBuffer);
+    const size_t bytesPerRow = CVPixelBufferGetBytesPerRow(pixelBuffer);
+
+    CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
+    CGContextRef context = CGBitmapContextCreate(baseAddress, width, height, 8, bytesPerRow, colorSpace,
+                                                 kCGBitmapByteOrder32Little | kCGImageAlphaPremultipliedFirst);
+    CGColorSpaceRelease(colorSpace);
+
+    if (!context) {
+        CVPixelBufferUnlockBaseAddress(pixelBuffer, 0);
+        QZObjcRelease(renderer);
+        return;
     }
 
-    UIGraphicsPopContext();
+    CGContextDrawImage(context, CGRectMake(0.0, 0.0, width, height), overlay.CGImage);
     CGContextRelease(context);
     CVPixelBufferUnlockBaseAddress(pixelBuffer, 0);
+    QZObjcRelease(renderer);
 }
 
 @interface QZWorkoutVideoCaptureDelegate : NSObject <AVCaptureVideoDataOutputSampleBufferDelegate>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,6 +45,7 @@
 
 #ifdef Q_OS_IOS
 #include "ios/lockscreen.h"
+#include "ios/workoutvideorecorder.h"
 #endif
 
 #include "osc.h"
@@ -914,6 +915,12 @@ int main(int argc, char *argv[]) {
         engine.rootContext()->setContextProperty("OS_VERSION", QVariant("iOS"));
 #else
         engine.rootContext()->setContextProperty("OS_VERSION", QVariant("Other"));
+#endif
+#ifdef Q_OS_IOS
+        IOSWorkoutVideoRecorder workoutVideoRecorderNative;
+        engine.rootContext()->setContextProperty("workoutVideoRecorderNative", &workoutVideoRecorderNative);
+#else
+        engine.rootContext()->setContextProperty("workoutVideoRecorderNative", QVariant());
 #endif
 #ifdef CHARTJS
         engine.rootContext()->setContextProperty("CHARTJS", QVariant(true));

--- a/src/main.qml
+++ b/src/main.qml
@@ -4,7 +4,6 @@ import QtQuick.Controls.Material 2.12
 import QtQuick.Dialogs 1.0
 import QtGraphicalEffects 1.12
 import Qt.labs.settings 1.0
-import QtMultimedia 5.15
 import org.cagnulein.qdomyoszwift 1.0
 import QtQuick.Window 2.12
 import Qt.labs.platform 1.1
@@ -121,6 +120,7 @@ ApplicationWindow {
         property string peloton_username: "username"
         property string peloton_password: "password"
         property bool gym_mode: false
+        property string ios_workout_video_camera: "back"
     }
 
 
@@ -167,6 +167,89 @@ ApplicationWindow {
 
     ToastManager {
         id: toast
+    }
+
+
+    Item {
+        id: workoutVideoRecorder
+        visible: false
+
+        property string recordingState: "idle"
+        property string nextOutputUrl: ""
+
+        function pad(value) {
+            return value < 10 ? "0" + value : "" + value
+        }
+
+        function buildOutputUrl() {
+            var now = new Date()
+            var base = StandardPaths.writableLocation(StandardPaths.MoviesLocation)
+            if (base === "") {
+                base = StandardPaths.writableLocation(StandardPaths.DocumentsLocation) + "/Videos"
+            }
+            return base + "/qz_workout_" + now.getFullYear() + pad(now.getMonth() + 1) + pad(now.getDate()) + "_" + pad(now.getHours()) + pad(now.getMinutes()) + pad(now.getSeconds()) + ".mov"
+        }
+
+        function collectMetricLines() {
+            var lines = []
+            var model = typeof appModel === "undefined" ? [] : appModel
+            for (var i = 0; i < model.length; i++) {
+                var item = model[i]
+                if (!item.largeButton && item.name !== "" && item.value !== "") {
+                    lines.push(item.name + ": " + item.value)
+                }
+            }
+            return lines
+        }
+
+        function toggleRecording() {
+            if (Qt.platform.os !== "ios") {
+                toast.show(qsTr("Workout video recording is available on iOS only."))
+                return
+            }
+
+            if (!workoutVideoRecorderNative || !workoutVideoRecorderNative.available) {
+                toast.show(qsTr("Native iOS workout video recording is not available."))
+                return
+            }
+
+            if (recordingState === "idle") {
+                nextOutputUrl = buildOutputUrl()
+                recordingState = "recording"
+                Qt.callLater(function() {
+                    workoutVideoRecorderNative.updateMetrics(workoutVideoRecorder.collectMetricLines())
+                    if (workoutVideoRecorderNative.startRecording(workoutVideoRecorder.nextOutputUrl, settings.ios_workout_video_camera)) {
+                        toast.show(qsTr("Workout video recording started."))
+                    } else {
+                        workoutVideoRecorder.recordingState = "idle"
+                    }
+                })
+            } else if (recordingState === "recording") {
+                workoutVideoRecorderNative.pauseRecording()
+                recordingState = "paused"
+                toast.show(qsTr("Workout video recording paused. Press stop to save it."))
+            } else {
+                workoutVideoRecorderNative.stopRecording()
+                recordingState = "idle"
+            }
+        }
+
+        Connections {
+            target: workoutVideoRecorderNative
+            onErrorOccurred: {
+                workoutVideoRecorder.recordingState = "idle"
+                toast.show(message)
+            }
+            onSaved: toast.show(qsTr("Workout video saved in the Videos folder."))
+        }
+
+        Timer {
+            interval: 250
+            running: workoutVideoRecorder.recordingState === "recording"
+            repeat: true
+            onTriggered: workoutVideoRecorderNative.updateMetrics(workoutVideoRecorder.collectMetricLines())
+        }
+
     }
 
     Timer {
@@ -882,7 +965,7 @@ ApplicationWindow {
                 saveSettings("settings");
                 popupSaveFile.open()
             }
-            anchors.right: toolButtonAutoResistance.left/*toolClassifica.left*/
+            anchors.right: (toolButtonWorkoutVideoRecord.visible ? toolButtonWorkoutVideoRecord.left : toolButtonAutoResistance.left)/*toolClassifica.left*/
             visible: false
         }
 
@@ -942,8 +1025,16 @@ ApplicationWindow {
             id: toolButtonLockTiles
             icon.source: ( window.lockTiles ? "icons/icons/unlock.png" : "icons/icons/lock.png")
             onClicked: { window.lockTiles = !window.lockTiles; console.log("lock tiles toggled " + window.lockTiles); popuplockTiles.open(); popuplockTilesAutoClose.running = true; }
-            anchors.right: toolButtonAutoResistance.left
+            anchors.right: toolButtonWorkoutVideoRecord.left
             visible: !toolButtonSaveSettings.visible
+        }
+
+        ToolButton {
+            id: toolButtonWorkoutVideoRecord
+            icon.source: workoutVideoRecorder.recordingState === "idle" ? "icons/icons/video.png" : (workoutVideoRecorder.recordingState === "recording" ? "icons/icons/pause.png" : "icons/icons/stop.png")
+            onClicked: { workoutVideoRecorder.toggleRecording(); }
+            anchors.right: toolButtonAutoResistance.left
+            visible: Qt.platform.os === "ios"
         }
 
         ToolButton {

--- a/src/qdomyos-zwift.pri
+++ b/src/qdomyos-zwift.pri
@@ -975,6 +975,8 @@ ios {
 }
 
 ios {
+    LIBS += -framework AVFoundation -framework CoreImage -framework Photos
+
     OBJECTIVE_SOURCES += ios/lockscreen.mm \
     ios/ios_eliteariafan.mm \
     ios/ios_app_delegate.mm \
@@ -995,8 +997,6 @@ ios {
     ios/ios_liveactivity.h \
     ios/workoutvideorecorder.h
 
-    HEADERS += ios/workoutvideorecorder.h
-
     QMAKE_INFO_PLIST = ios/Info.plist
 	 QMAKE_ASSET_CATALOGS = $$PWD/ios/Images.xcassets
 	 QMAKE_ASSET_CATALOGS_APP_ICON = "AppIcon"
@@ -1004,7 +1004,6 @@ ios {
 
     TARGET = qdomyoszwift
 	 QMAKE_TARGET_BUNDLE_PREFIX = org.cagnulein
-    LIBS += -framework AVFoundation -framework CoreImage -framework Photos
     
     # iOS Code Signing Configuration - handled manually in Xcode project
     

--- a/src/qdomyos-zwift.pri
+++ b/src/qdomyos-zwift.pri
@@ -979,6 +979,7 @@ ios {
     ios/ios_eliteariafan.mm \
     ios/ios_app_delegate.mm \
     ios/ios_liveactivity.mm \
+    ios/workoutvideorecorder.mm \
 	 fit-sdk/FitDecode.mm \
 	 fit-sdk/FitDeveloperField.mm \
 	 fit-sdk/FitEncode.mm \
@@ -991,7 +992,10 @@ ios {
     SOURCES += ios/M3iNSQT.cpp
 
     OBJECTIVE_HEADERS += ios/M3iNS.h \
-    ios/ios_liveactivity.h
+    ios/ios_liveactivity.h \
+    ios/workoutvideorecorder.h
+
+    HEADERS += ios/workoutvideorecorder.h
 
     QMAKE_INFO_PLIST = ios/Info.plist
 	 QMAKE_ASSET_CATALOGS = $$PWD/ios/Images.xcassets
@@ -1000,6 +1004,7 @@ ios {
 
     TARGET = qdomyoszwift
 	 QMAKE_TARGET_BUNDLE_PREFIX = org.cagnulein
+    LIBS += -framework AVFoundation -framework CoreImage -framework Photos
     
     # iOS Code Signing Configuration - handled manually in Xcode project
     

--- a/src/qzsettings.cpp
+++ b/src/qzsettings.cpp
@@ -1076,6 +1076,8 @@ const QString QZSettings::default_ios_live_activity_compact_leading_metric = QSt
 const QString QZSettings::ios_live_activity_compact_trailing_metric =
     QStringLiteral("ios_live_activity_compact_trailing_metric");
 const QString QZSettings::default_ios_live_activity_compact_trailing_metric = QStringLiteral("Watt");
+const QString QZSettings::ios_workout_video_camera = QStringLiteral("ios_workout_video_camera");
+const QString QZSettings::default_ios_workout_video_camera = QStringLiteral("back");
 const QString QZSettings::calories_active_only = QStringLiteral("calories_active_only");
 const QString QZSettings::calories_from_hr = QStringLiteral("calories_from_hr");
 const QString QZSettings::confirm_stop_workout = QStringLiteral("confirm_stop_workout");
@@ -1094,7 +1096,7 @@ const QString QZSettings::proform_carbon_tl_PFTL59723_6 = QStringLiteral("profor
 const QString QZSettings::proform_treadmill_cst_505_pftl59420_0 = QStringLiteral("proform_treadmill_cst_505_pftl59420_0");
 const QString QZSettings::applewatch_as_treadmill_speed = QStringLiteral("applewatch_as_treadmill_speed");
 
-const uint32_t allSettingsCount = 891;
+const uint32_t allSettingsCount = 892;
 
 QVariant allSettings[allSettingsCount][2] = {
     {QZSettings::cryptoKeySettingsProfiles, QZSettings::default_cryptoKeySettingsProfiles},
@@ -1988,6 +1990,7 @@ QVariant allSettings[allSettingsCount][2] = {
      QZSettings::default_ios_live_activity_compact_leading_metric},
     {QZSettings::ios_live_activity_compact_trailing_metric,
      QZSettings::default_ios_live_activity_compact_trailing_metric},
+    {QZSettings::ios_workout_video_camera, QZSettings::default_ios_workout_video_camera},
     {QZSettings::rogue_echo_bike, QZSettings::default_rogue_echo_bike},
     {QZSettings::calories_active_only, QZSettings::default_calories_active_only},
     {QZSettings::calories_from_hr, QZSettings::default_calories_from_hr},

--- a/src/qzsettings.h
+++ b/src/qzsettings.h
@@ -2929,6 +2929,12 @@ class QZSettings {
     static const QString ios_live_activity_compact_trailing_metric;
     static const QString default_ios_live_activity_compact_trailing_metric;
 
+    /**
+     * @brief Camera used by the iOS workout video recorder.
+     */
+    static const QString ios_workout_video_camera;
+    static const QString default_ios_workout_video_camera;
+
    /**
      * @brief Calculate only active calories (exclude basal metabolic rate)
      */

--- a/src/settings.qml
+++ b/src/settings.qml
@@ -1322,6 +1322,7 @@ import Qt.labs.platform 1.1
             property bool gears_custom_table_enabled: false
             property string gears_custom_table: "1|1\n2|2\n3|3\n4|4\n5|5\n6|6\n7|7\n8|8\n9|9\n10|10\n11|11\n12|12\n13|13\n14|14\n15|15\n16|16\n17|17\n18|18\n19|19\n20|20\n21|21\n22|22\n23|23\n24|24"                        
             property bool proform_treadmill_cst_505_pftl59420_0: false
+            property string ios_workout_video_camera: "back"
         }
 
 
@@ -14589,6 +14590,43 @@ import Qt.labs.platform 1.1
 
                     Label {
                         text: qsTr("If you are experiencing crash on iOS midride, try to turn this on. Default is off.")
+                        font.bold: true
+                        font.italic: true
+                        font.pixelSize: Qt.application.font.pixelSize - 2
+                        textFormat: Text.PlainText
+                        wrapMode: Text.WordWrap
+                        verticalAlignment: Text.AlignVCenter
+                        Layout.alignment: Qt.AlignLeft | Qt.AlignTop
+                        Layout.fillWidth: true
+                        color: Material.color(Material.Lime)
+                    }
+
+                    RowLayout {
+                        spacing: 10
+                        visible: Qt.platform.os === "ios"
+                        Label {
+                            text: qsTr("iOS workout video camera")
+                            Layout.fillWidth: true
+                        }
+                        ComboBox {
+                            id: iosWorkoutVideoCameraComboBox
+                            model: ["Back", "Front"]
+                            displayText: settings.ios_workout_video_camera === "front" ? qsTr("Front") : qsTr("Back")
+                            currentIndex: settings.ios_workout_video_camera === "front" ? 1 : 0
+                        }
+                        Button {
+                            text: "OK"
+                            Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                            onClicked: {
+                                settings.ios_workout_video_camera = iosWorkoutVideoCameraComboBox.currentIndex === 1 ? "front" : "back";
+                                toast.show("Setting saved!");
+                            }
+                        }
+                    }
+
+                    Label {
+                        visible: Qt.platform.os === "ios"
+                        text: qsTr("Selects which iPhone camera QZ uses for the workout video recording button in the top bar. Videos are saved in the iOS Videos folder with the active tile metrics burned into the camera recording.")
                         font.bold: true
                         font.italic: true
                         font.pixelSize: Qt.application.font.pixelSize - 2

--- a/src/settings.qml
+++ b/src/settings.qml
@@ -14611,13 +14611,8 @@ import Qt.labs.platform 1.1
                         ComboBox {
                             id: iosWorkoutVideoCameraComboBox
                             model: ["Back", "Front"]
-                            displayText: settings.ios_workout_video_camera === "front" ? qsTr("Front") : qsTr("Back")
-                            currentIndex: settings.ios_workout_video_camera === "front" ? 1 : 0
-                        }
-                        Button {
-                            text: "OK"
-                            Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
-                            onClicked: {
+                            Component.onCompleted: currentIndex = settings.ios_workout_video_camera === "front" ? 1 : 0
+                            onActivated: {
                                 settings.ios_workout_video_camera = iosWorkoutVideoCameraComboBox.currentIndex === 1 ? "front" : "back";
                                 toast.show("Setting saved!");
                             }


### PR DESCRIPTION
### Motivation
- Provide a native iOS workout video recording capability that burns current tile metrics into the camera video and saves recordings to the device Photos/Videos folder. 
- Expose the recorder to QML so users can start/pause/stop recording from the app toolbar and choose front/back camera via settings.

### Description
- Add a native Objective-C++ recorder implementation `IOSWorkoutVideoRecorder` (`ios/workoutvideorecorder.h` and `ios/workoutvideorecorder.mm`) that captures camera frames, overlays metrics, writes an H.264 QuickTime movie, handles permissions, and saves completed videos to the Photos album.
- Expose the recorder to QML by registering a context property in `main.cpp` (`workoutVideoRecorderNative`) and add QML UI in `main.qml` including a hidden `workoutVideoRecorder` item, a toolbar `ToolButton` for start/pause/stop, periodic metric updates, and connections for error/saved signals.
- Add persistent setting `ios_workout_video_camera` (`qzsettings.h` / `qzsettings.cpp`) with default `"back"` and UI controls in `settings.qml` to select front/back camera.
- Update iOS app metadata and build files: adjust `ios/Info.plist` usage strings (update `NSCameraUsageDescription` and add `NSPhotoLibraryAddUsageDescription`), include `ios/workoutvideorecorder.mm` and header in `qdomyos-zwift.pri`, add `HEADERS` entry, and link the `AVFoundation`, `CoreImage`, and `Photos` frameworks.
- Make small QML layout adjustments to place the new toolbar button and wire the recording state into the existing UI flow.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03fff97a188325bea8679f300120bf)