### PR TITLE
Handle duplicate device names in gym mode

### DIFF
--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -13,6 +13,16 @@
 #include <QAndroidJniObject>
 #endif
 
+namespace {
+QString gymModeDeviceAddress(const QBluetoothDeviceInfo &device) {
+#if defined(Q_OS_IOS)
+    return device.deviceUuid().toString();
+#else
+    return device.address().toString();
+#endif
+}
+}
+
 bluetooth::bluetooth(const discoveryoptions &options)
     : bluetooth(options.logs, options.deviceName, options.noWriteResistance, options.noHeartService,
                 options.pollDeviceTime, options.noConsole, options.testResistance, options.bikeResistanceOffset,
@@ -754,6 +764,9 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
             if (!effectiveFilterDevice.isEmpty() && !effectiveFilterDevice.startsWith(QStringLiteral("Disabled"))) {
 
                 filter = (b.name().compare(effectiveFilterDevice, Qt::CaseInsensitive) == 0);
+                if (filter && !gymModeSessionDeviceAddress.isEmpty()) {
+                    filter = (gymModeDeviceAddress(b).compare(gymModeSessionDeviceAddress, Qt::CaseInsensitive) == 0);
+                }
             }
             const QString deviceName = b.name();
             const QString upperDeviceName = deviceName.toUpper();
@@ -3492,6 +3505,15 @@ void bluetooth::selectGymModeDevice(const QString &deviceName) {
     QString normalizedDeviceName = deviceName.trimmed();
     normalizedDeviceName.remove(QRegularExpression(QStringLiteral(" \\(\\d+%\\)$")));
 
+    QString selectedDeviceAddress;
+    QRegularExpressionMatch addressMatch =
+        QRegularExpression(QStringLiteral(" \\[([^\\]]+)\\]$")).match(normalizedDeviceName);
+    if (addressMatch.hasMatch()) {
+        selectedDeviceAddress = addressMatch.captured(1).trimmed();
+        normalizedDeviceName.remove(addressMatch.capturedStart(0), addressMatch.capturedLength(0));
+        normalizedDeviceName = normalizedDeviceName.trimmed();
+    }
+
     if (normalizedDeviceName.isEmpty() ||
         !normalizedDeviceName.compare(QStringLiteral("Disabled"), Qt::CaseInsensitive) ||
         !normalizedDeviceName.compare(QStringLiteral("Wifi"), Qt::CaseInsensitive)) {
@@ -3499,6 +3521,7 @@ void bluetooth::selectGymModeDevice(const QString &deviceName) {
     }
 
     gymModeSessionDevice = normalizedDeviceName;
+    gymModeSessionDeviceAddress = selectedDeviceAddress;
     onlyDiscover = false;
     restart();
 }

--- a/src/devices/bluetooth.h
+++ b/src/devices/bluetooth.h
@@ -322,6 +322,7 @@ class bluetooth : public QObject, public SignalHandler {
     elitesquarecontroller* eliteSquareController = nullptr;
     QString filterDevice = QLatin1String("");
     QString gymModeSessionDevice = QLatin1String("");
+    QString gymModeSessionDeviceAddress = QLatin1String("");
 
     bool testResistance = false;
     bool noWriteResistance = false;

--- a/src/homeform.cpp
+++ b/src/homeform.cpp
@@ -58,6 +58,14 @@ homeform *homeform::m_singleton = 0;
 using namespace std::chrono_literals;
 
 namespace {
+QString gymModeDeviceAddress(const QBluetoothDeviceInfo &device) {
+#if defined(Q_OS_IOS)
+    return device.deviceUuid().toString();
+#else
+    return device.address().toString();
+#endif
+}
+
 QString uploadActivityLabelFromSport(FIT_SPORT sport) {
     switch (sport) {
     case FIT_SPORT_RUNNING:
@@ -8572,6 +8580,9 @@ QStringList homeform::bluetoothDevices() {
     r.append(QStringLiteral("Disabled"));
     r.append(QStringLiteral("Wifi"));
 
+    QSettings settings;
+    const bool gymMode = settings.value(QZSettings::gym_mode, QZSettings::default_gym_mode).toBool();
+
     // Collect named devices and sort by RSSI descending (strongest signal first)
     QList<QBluetoothDeviceInfo> sorted;
     for (const QBluetoothDeviceInfo &b : qAsConst(bluetoothManager->devices)) {
@@ -8586,7 +8597,21 @@ QStringList homeform::bluetoothDevices() {
     for (const QBluetoothDeviceInfo &b : qAsConst(sorted)) {
         // Convert RSSI to proximity %: -40 dBm = 100%, -100 dBm = 0%
         int proximity = qBound(0, (int)((b.rssi() + 100) * 100 / 60), 100);
-        r.append(QString("%1 (%2%)").arg(b.name()).arg(proximity));
+        QString deviceName = b.name();
+        if (gymMode) {
+            bool duplicateName = false;
+            for (const QBluetoothDeviceInfo &other : qAsConst(sorted)) {
+                if (!SAME_BLUETOOTH_DEVICE(b, other) && !deviceName.compare(other.name(), Qt::CaseInsensitive)) {
+                    duplicateName = true;
+                    break;
+                }
+            }
+            const QString deviceAddress = gymModeDeviceAddress(b);
+            if (duplicateName && !deviceAddress.isEmpty()) {
+                deviceName = QStringLiteral("%1 [%2]").arg(deviceName, deviceAddress);
+            }
+        }
+        r.append(QString("%1 (%2%)").arg(deviceName).arg(proximity));
     }
     return r;
 }


### PR DESCRIPTION
### Motivation
- Gym mode can present multiple Bluetooth devices with the same display name but different addresses/UUIDs and users must be able to pick the exact unit for the session with minimal changes to existing logic.

### Description
- Add a helper `gymModeDeviceAddress()` to retrieve the device address (or device UUID on iOS) and reuse it for disambiguation in gym mode.
- Store a new `gymModeSessionDeviceAddress` field in `bluetooth` to keep the selected address/UUID separately from the selected device name (`src/devices/bluetooth.h`).
- Apply an additional address/UUID comparison when filtering devices during connection so a selected name plus address must match before connecting (`src/devices/bluetooth.cpp`).
- Enhance `selectGymModeDevice()` to parse optional address suffixes like `Device Name [AA:BB:CC:DD:EE:FF]` from the UI and save the parsed address for precise selection (`src/devices/bluetooth.cpp`).
- Modify the device-listing in `homeform::bluetoothDevices()` to append an address/UUID suffix only when gym mode is enabled and the same display name appears for multiple physical devices (`src/homeform.cpp`).

### Testing
- Ran `git diff --check` to ensure no whitespace/index issues; it passed successfully.
- Attempted `qmake -v` but `qmake` is not available in this environment so a full Qt build/test run could not be executed here.
- No other automated test runs were possible in the current environment (no CI/build executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04a7daf4288325918d0cd2e09f62cb)