### PR TITLE
Add MRK-S38 FTMS bike detection

### DIFF
--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -1898,6 +1898,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                         (b.name().toUpper().startsWith("MRK-S26S-")) ||
                         (b.name().toUpper().startsWith("MRK-S26C-")) ||
                         (b.name().toUpper().startsWith("MRK-S28-")) ||
+                        (b.name().toUpper().startsWith("MRK-S38-")) ||
                         (b.name().toUpper().startsWith("ROBX")) ||
                         (b.name().toUpper().startsWith("ORLAUF_ARES")) ||
                         (b.name().toUpper().startsWith("SPEEDMAGPRO")) ||                        

--- a/tst/Devices/devicetestdataindex.cpp
+++ b/tst/Devices/devicetestdataindex.cpp
@@ -584,6 +584,7 @@ void DeviceTestDataIndex::Initialize() {
         "MRK-S26S-",
         "MRK-S26C-",
         "MRK-S28-",
+        "MRK-S38-",
         "SMB1",
         "UBIKE FTMS",
         "INRIDE"


### PR DESCRIPTION
### Motivation
- Ensure devices advertising as `MRK-S38-` are detected and treated as FTMS bikes so they match the existing `ftmsbike` handling and tests.

### Description
- Added a `b.name().toUpper().startsWith("MRK-S38-")` check to the FTMS bike detection logic in `src/devices/bluetooth.cpp`.
- Added the string `"MRK-S38-"` to the `acceptableFTMSNames` list in `tst/Devices/devicetestdataindex.cpp` so tests include the new prefix.
- This change only updates device name pattern matching and test data, without modifying device logic or runtime behaviour beyond detection.

### Testing
- Ran `git diff --check` and confirmed the diffs include the new pattern, and verified the new pattern with `rg` which reported the updated files successfully.
- Attempted to run unit tests but the test binary `tst/qdomyos-zwift-tests` was not present so tests could not be executed in this environment.
- `qmake` was not available in the environment so a full build could not be performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05fddd4b8883258835e7c9900913fe)