### PR TITLE
Add disablehrpid XML attribute to suppress HR PID for specific traini…

### DIFF
--- a/src/homeform.cpp
+++ b/src/homeform.cpp
@@ -7417,10 +7417,11 @@ void homeform::update() {
                     }
                 }
             }
-        } else if (!settings.value(QZSettings::treadmill_pid_heart_zone, QZSettings::default_treadmill_pid_heart_zone)
+        } else if (!(trainProgram && trainProgram->currentRow().disableHRPID) &&
+                  (!settings.value(QZSettings::treadmill_pid_heart_zone, QZSettings::default_treadmill_pid_heart_zone)
                         .toString()
                         .contains(QStringLiteral("Disabled")) ||
-                   (trainProgram && trainProgram->currentRow().zoneHR >= 0)) {
+                   (trainProgram && trainProgram->currentRow().zoneHR >= 0))) {
             static uint32_t last_seconds_pid_heart_zone = 0;
             static uint32_t pid_heart_zone_small_inc_counter = 0;
             uint32_t seconds = bluetoothManager->device()->elapsedTime().second() +

--- a/src/trainprogram.cpp
+++ b/src/trainprogram.cpp
@@ -1708,6 +1708,9 @@ QList<trainrow> trainprogram::loadXML(const QString &filename, BLUETOOTH_TYPE de
             if (atts.hasAttribute(QStringLiteral("forcespeed"))) {
                 row.forcespeed = atts.value(QStringLiteral("forcespeed")).toInt() ? true : false;
             }
+            if (atts.hasAttribute(QStringLiteral("disablehrpid"))) {
+                row.disableHRPID = atts.value(QStringLiteral("disablehrpid")).toInt() ? true : false;
+            }
             if (atts.hasAttribute(QStringLiteral("powerzone"))) {
                 QSettings settings;
                 if(device_type == TREADMILL) {

--- a/src/trainprogram.h
+++ b/src/trainprogram.h
@@ -48,6 +48,7 @@ class trainrow {
     int16_t average_cadence = -1; // used for peloton
     int16_t upper_cadence = -1;
     bool forcespeed = false;
+    bool disableHRPID = false;
     int8_t loopTimeHR = 10;
     int8_t zoneHR = -1;
     int16_t HRmin = -1;


### PR DESCRIPTION
# Add `disablehrpid` XML attribute to suppress HR PID for specific training programme rows

## Problem

When a training programme transitions from an HR-zone row to a non-HR-zone row (e.g. a cool-down with explicit speed), the HR PID controller can continue running with a stale zone target, pushing speed away from the programme's intended value.

## Solution

Adds a per-row `disablehrpid` XML attribute. When set to `1`, the HR PID controller is entirely suppressed for that row — giving programme authors explicit control over PID behaviour per segment.

This is a more backward compatible alternative for https://github.com/cagnulein/qdomyos-zwift/pull/4671

### Usage

```xml
<row duration="3:00" speed="5.5" forcespeed="1" disablehrpid="1" />
```

## Changes

- **`src/trainprogram.h`** — Added `bool disableHRPID = false;` field to `trainrow`
- **`src/trainprogram.cpp`** — Parse `disablehrpid` attribute (same pattern as `forcespeed`)
- **`src/homeform.cpp`** — Guard the HR PID block: skip entirely when the current row has `disableHRPID` set

## Design

- No global settings change — this is a per-row XML attribute only
- No behaviour change for existing XML files (default is `false`)
- Follows the same pattern as existing row attributes (`forcespeed`, `zonehr`, `looptimehr`)
- Explicit opt-in gives programme authors full control without surprising existing users