### PR TITLE
Add Omega Z toggle under Horizon Treadmill Options

### DIFF
--- a/src/devices/horizontreadmill/horizontreadmill.cpp
+++ b/src/devices/horizontreadmill/horizontreadmill.cpp
@@ -105,8 +105,10 @@ void horizontreadmill::btinit() {
     horizon_treadmill_profile_users.append(
         settings.value(QZSettings::horizon_treadmill_profile_user5, QZSettings::default_horizon_treadmill_profile_user5)
             .toString());
+    bool horizon_treadmill_omega_z =
+        settings.value(QZSettings::horizon_treadmill_omega_z, QZSettings::default_horizon_treadmill_omega_z).toBool();
     bool horizon_paragon_x =
-        settings.value(QZSettings::horizon_paragon_x, QZSettings::default_horizon_paragon_x).toBool();
+        settings.value(QZSettings::horizon_paragon_x, QZSettings::default_horizon_paragon_x).toBool() || horizon_treadmill_omega_z;
     bool miles_unit =
         settings.value(QZSettings::miles_unit, QZSettings::default_miles_unit).toBool();
     static const QBluetoothUuid merachUnlockCharId(
@@ -927,10 +929,12 @@ void horizontreadmill::update() {
                /*initDone*/) {
 
         QSettings settings;
+        bool horizon_treadmill_omega_z =
+            settings.value(QZSettings::horizon_treadmill_omega_z, QZSettings::default_horizon_treadmill_omega_z).toBool();
         bool horizon_treadmill_7_8 =
-            settings.value(QZSettings::horizon_treadmill_7_8, QZSettings::default_horizon_treadmill_7_8).toBool();
+            settings.value(QZSettings::horizon_treadmill_7_8, QZSettings::default_horizon_treadmill_7_8).toBool() || horizon_treadmill_omega_z;
         bool horizon_paragon_x =
-            settings.value(QZSettings::horizon_paragon_x, QZSettings::default_horizon_paragon_x).toBool();
+            settings.value(QZSettings::horizon_paragon_x, QZSettings::default_horizon_paragon_x).toBool() || horizon_treadmill_omega_z;
         bool treadmill_direct_distance =
             settings.value(QZSettings::treadmill_direct_distance, QZSettings::default_treadmill_direct_distance).toBool();
         update_metrics(!powerReceivedFromPowerSensor, watts(settings.value(QZSettings::weight, QZSettings::default_weight).toFloat()));
@@ -1208,8 +1212,10 @@ bool horizontreadmill::checkIfForceSpeedNeeding(double requestSpeed) {
 void horizontreadmill::forceSpeed(double requestSpeed) {
     QSettings settings;
     const double miles_conversion = 0.621371;
+    bool horizon_treadmill_omega_z =
+        settings.value(QZSettings::horizon_treadmill_omega_z, QZSettings::default_horizon_treadmill_omega_z).toBool();
     bool horizon_paragon_x =
-        settings.value(QZSettings::horizon_paragon_x, QZSettings::default_horizon_paragon_x).toBool();
+        settings.value(QZSettings::horizon_paragon_x, QZSettings::default_horizon_paragon_x).toBool() || horizon_treadmill_omega_z;
 
     if (gattCustomService) {
         if (!horizon_paragon_x) {
@@ -1291,8 +1297,10 @@ void horizontreadmill::forceSpeed(double requestSpeed) {
 // example frame: 55aa3800030603005d0b0a0000
 void horizontreadmill::forceIncline(double requestIncline) {
     QSettings settings;
+    bool horizon_treadmill_omega_z =
+        settings.value(QZSettings::horizon_treadmill_omega_z, QZSettings::default_horizon_treadmill_omega_z).toBool();
     bool horizon_paragon_x =
-        settings.value(QZSettings::horizon_paragon_x, QZSettings::default_horizon_paragon_x).toBool();
+        settings.value(QZSettings::horizon_paragon_x, QZSettings::default_horizon_paragon_x).toBool() || horizon_treadmill_omega_z;
 
     if(tunturi_t60_treadmill)
         Inclination = treadmillInclinationOverride(requestIncline);
@@ -1845,7 +1853,8 @@ void horizontreadmill::characteristicChanged(const QLowEnergyCharacteristic &cha
 
     } else if (characteristic.uuid() == QBluetoothUuid((quint16)0x2ACD)) {
         bool horizon_treadmill_7_0_at_24 = settings.value(QZSettings::horizon_treadmill_7_0_at_24, QZSettings::default_horizon_treadmill_7_0_at_24).toBool();
-        bool horizon_treadmill_7_8 = settings.value(QZSettings::horizon_treadmill_7_8, QZSettings::default_horizon_treadmill_7_8).toBool();
+        bool horizon_treadmill_omega_z = settings.value(QZSettings::horizon_treadmill_omega_z, QZSettings::default_horizon_treadmill_omega_z).toBool();
+        bool horizon_treadmill_7_8 = settings.value(QZSettings::horizon_treadmill_7_8, QZSettings::default_horizon_treadmill_7_8).toBool() || horizon_treadmill_omega_z;
         bool miles = settings.value(QZSettings::miles_unit, QZSettings::default_miles_unit).toBool();
         lastPacket = newValue;
 
@@ -2885,10 +2894,12 @@ bool horizontreadmill::autoPauseWhenSpeedIsZero() {
 
 bool horizontreadmill::autoStartWhenSpeedIsGreaterThenZero() {
     QSettings settings;
+    bool horizon_treadmill_omega_z =
+        settings.value(QZSettings::horizon_treadmill_omega_z, QZSettings::default_horizon_treadmill_omega_z).toBool();
     bool horizon_treadmill_7_8 =
-        settings.value(QZSettings::horizon_treadmill_7_8, QZSettings::default_horizon_treadmill_7_8).toBool();
+        settings.value(QZSettings::horizon_treadmill_7_8, QZSettings::default_horizon_treadmill_7_8).toBool() || horizon_treadmill_omega_z;
     bool horizon_paragon_x =
-        settings.value(QZSettings::horizon_paragon_x, QZSettings::default_horizon_paragon_x).toBool();
+        settings.value(QZSettings::horizon_paragon_x, QZSettings::default_horizon_paragon_x).toBool() || horizon_treadmill_omega_z;
 
     // the horizon starts with a strange speed, since that i can auto start (maybe the best way to solve this
     // is to understand why it's starting with this strange speed)

--- a/src/qzsettings.cpp
+++ b/src/qzsettings.cpp
@@ -1094,6 +1094,7 @@ const QString QZSettings::proform_carbon_tlx_v84_314_treadmill = QStringLiteral(
 const QString QZSettings::proform_carbon_tl_PFTL59723_6 = QStringLiteral("proform_carbon_tl_PFTL59723_6");
 const QString QZSettings::proform_treadmill_cst_505_pftl59420_0 = QStringLiteral("proform_treadmill_cst_505_pftl59420_0");
 const QString QZSettings::applewatch_as_treadmill_speed = QStringLiteral("applewatch_as_treadmill_speed");
+const QString QZSettings::horizon_treadmill_omega_z = QStringLiteral("horizon_treadmill_omega_z");
 
 const QString QZSettings::shortcuts_enabled = QStringLiteral("shortcuts_enabled");
 const QString QZSettings::shortcut_speed_plus = QStringLiteral("shortcut_speed_plus");
@@ -1225,7 +1226,7 @@ const QString QZSettings::default_shortcut_lap = QStringLiteral("");
 const QString QZSettings::shortcut_start_stop = QStringLiteral("shortcut_start_stop");
 const QString QZSettings::default_shortcut_start_stop = QStringLiteral("");
 
-const uint32_t allSettingsCount = 957;
+const uint32_t allSettingsCount = 958;
 
 QVariant allSettings[allSettingsCount][2] = {
     {QZSettings::cryptoKeySettingsProfiles, QZSettings::default_cryptoKeySettingsProfiles},
@@ -2206,6 +2207,7 @@ QVariant allSettings[allSettingsCount][2] = {
     {QZSettings::proform_carbon_tl_PFTL59723_6, QZSettings::default_proform_carbon_tl_PFTL59723_6},
     {QZSettings::proform_treadmill_cst_505_pftl59420_0, QZSettings::default_proform_treadmill_cst_505_pftl59420_0},
     {QZSettings::applewatch_as_treadmill_speed, QZSettings::default_applewatch_as_treadmill_speed},
+    {QZSettings::horizon_treadmill_omega_z, QZSettings::default_horizon_treadmill_omega_z},
 };
 
 void QZSettings::qDebugAllSettings(bool showDefaults) {

--- a/src/qzsettings.h
+++ b/src/qzsettings.h
@@ -3170,6 +3170,9 @@ class QZSettings {
     static const QString applewatch_as_treadmill_speed;
     static constexpr bool default_applewatch_as_treadmill_speed = false;
 
+    static const QString horizon_treadmill_omega_z;
+    static constexpr bool default_horizon_treadmill_omega_z = false;
+
     /**
      * @brief Write the QSettings values using the constants from this namespace.
      * @param showDefaults Optionally indicates if the default should be shown with the key.

--- a/src/settings-catalog.json
+++ b/src/settings-catalog.json
@@ -2,7 +2,7 @@
   "$schema": "https://qdomyos-zwift.local/settings-catalog.schema.json",
   "schemaVersion": 1,
   "format": "qdomyos-zwift-settings-catalog",
-  "settingCount": 945,
+  "settingCount": 946,
   "pages": [
     {
       "key": "page_custom_gear_table",
@@ -13451,6 +13451,19 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
+      "options": null
+    },
+    {
+      "key": "horizon_treadmill_omega_z",
+      "name": "Omega Z",
+      "description": null,
+      "parent": "Horizon Treadmill Options",
+      "type": "boolean",
+      "qmlType": "bool",
+      "control": "switch",
+      "visible": true,
+      "defaultValue": false,
+      "defaultExpression": "false",
       "options": null
     }
   ]

--- a/src/settings.qml
+++ b/src/settings.qml
@@ -1656,7 +1656,8 @@ import Qt.labs.platform 1.1
             property string shortcut_preset_powerzone_6: ""
             property string shortcut_preset_powerzone_7: ""
             property string shortcut_lap: ""
-            property string shortcut_start_stop: ""                                         
+            property string shortcut_start_stop: ""
+            property bool horizon_treadmill_omega_z: false
         }
 
 
@@ -10503,6 +10504,20 @@ import Qt.labs.platform 1.1
                                 Layout.alignment: Qt.AlignLeft | Qt.AlignTop
                                 Layout.fillWidth: true
                                 onClicked: { settings.horizon_treadmill_7_8 = checked; window.settings_restart_to_apply = true; }
+                            }
+                            IndicatorOnlySwitch {
+                                id: horizonOmegaZTreadmillDelegate
+                                text: qsTr("Omega Z")
+                                spacing: 0
+                                bottomPadding: 0
+                                topPadding: 0
+                                rightPadding: 0
+                                leftPadding: 0
+                                clip: false
+                                checked: settings.horizon_treadmill_omega_z
+                                Layout.alignment: Qt.AlignLeft | Qt.AlignTop
+                                Layout.fillWidth: true
+                                onClicked: { settings.horizon_treadmill_omega_z = checked; window.settings_restart_to_apply = true; }
                             }
 
                             IndicatorOnlySwitch {


### PR DESCRIPTION
Adds a dedicated 'Omega Z' toggle in the Horizon treadmill settings section
that automatically applies both the 'Paragon X' and 'Horizon 7.8 start issue'
behaviors required for the Omega Z treadmill to work correctly.

https://claude.ai/code/session_012cr2wkFxjAE25ZxYMpSMyF