### PR TITLE
Fix Garmin login for passwords/usernames with special characters (^, +, etc.)

### DIFF
--- a/src/garminconnect.cpp
+++ b/src/garminconnect.cpp
@@ -413,23 +413,14 @@ bool GarminConnect::performLogin(const QString &email, const QString &password, 
     query.addQueryItem("redirectAfterAccountCreationUrl", ssoEmbedUrl);
     url.setQuery(query);
 
-    // Prepare POST data
-    QUrlQuery postData;
-    postData.addQueryItem("username", email);
-    postData.addQueryItem("password", password);
-    postData.addQueryItem("embed", "true");
-    postData.addQueryItem("_csrf", m_csrfToken);
-
-    QString queryString = postData.query(QUrl::FullyEncoded);
-
-    // CRITICAL: Fix '+' character encoding for usernames like "user+tag@example.com"
-    // QUrlQuery doesn't percent-encode '+' in form data (treats it as space character)
-    // but Garmin authentication requires literal '+' to be encoded as '%2B'
-    // This is safe because in URL-encoded form data, '+' always means space,
-    // so any literal '+' must be encoded as '%2B'
-    queryString.replace("+", "%2B");
-
-    QByteArray data = queryString.toUtf8();
+    // Prepare POST data using QUrl::toPercentEncoding() for each value so that ALL
+    // special characters (^, +, &, =, %, spaces, …) are correctly encoded.
+    // QUrlQuery::query(FullyEncoded) only encodes a subset of special chars and required
+    // a manual '+' → '%2B' patch (see #4121/#4137); this approach supersedes that workaround.
+    QByteArray data = "username=" + QUrl::toPercentEncoding(email) +
+                      "&password=" + QUrl::toPercentEncoding(password) +
+                      "&embed=true" +
+                      "&_csrf=" + QUrl::toPercentEncoding(m_csrfToken);
 
     QNetworkRequest request(url);
     request.setRawHeader("User-Agent", USER_AGENT);


### PR DESCRIPTION
## Summary

- Replaces `QUrlQuery` + manual `+`→`%2B` patch with `QUrl::toPercentEncoding()` for each POST field value in `performLogin()`
- This correctly encodes **all** special characters (`^`, `+`, `&`, `=`, `%`, spaces, …) required by `application/x-www-form-urlencoded`
- Supersedes the partial fix from #4121 / #4137 which only handled `+` in usernames

## Root cause

`QUrlQuery::query(QUrl::FullyEncoded)` does not percent-encode characters like `^` because Qt considers them "unreserved" in URL context. For form-encoded POST bodies, these characters still need to be encoded. A previous workaround (PR #4137) patched only `+`, leaving all other special characters broken.

## Fix

```cpp
// Before (partial fix, only handled '+'):
QUrlQuery postData;
postData.addQueryItem("username", email);
postData.addQueryItem("password", password);
...
QString queryString = postData.query(QUrl::FullyEncoded);
queryString.replace("+", "%2B");
QByteArray data = queryString.toUtf8();

// After (handles all special characters):
QByteArray data = "username=" + QUrl::toPercentEncoding(email) +
                  "&password=" + QUrl::toPercentEncoding(password) +
                  "&embed=true" +
                  "&_csrf=" + QUrl::toPercentEncoding(m_csrfToken);
```

## Test plan

- [ ] Login with password containing `^` succeeds
- [ ] Login with password containing `+` still succeeds (previously fixed in #4137)
- [ ] Login with password containing other special chars (`&`, `=`, `%`, space) succeeds
- [ ] Normal login (no special chars) unaffected

Fixes #4718. Supersedes #4121 / #4137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)