### PR TITLE
Fix Horizon 7.0AT (JFTM) speed scaling with FTMS

### DIFF
--- a/src/devices/horizontreadmill/horizontreadmill.cpp
+++ b/src/devices/horizontreadmill/horizontreadmill.cpp
@@ -1293,7 +1293,7 @@ void horizontreadmill::forceSpeed(double requestSpeed) {
                 horizon_7at_ceil = true;   // treadmill truncates mph→km/h, so ceil avoids landing one tick below
             }
         }
-        uint16_t speed_int = horizon_7at_ceil ? (uint16_t)ceil(requestSpeed * 100) : (uint16_t)round(requestSpeed * 100);
+        uint16_t speed_int = horizon_7at_ceil ? ((uint16_t)ceil(requestSpeed * 100)) + 1 : (uint16_t)round(requestSpeed * 100);
         writeS[1] = speed_int & 0xFF;
         writeS[2] = speed_int >> 8;
 

--- a/src/devices/horizontreadmill/horizontreadmill.cpp
+++ b/src/devices/horizontreadmill/horizontreadmill.cpp
@@ -1285,6 +1285,12 @@ void horizontreadmill::forceSpeed(double requestSpeed) {
                 requestSpeed *= miles_conversion;   // these treadmills want the speed in miles when miles_unit is enabled
             }
         }
+        if(settings.value(QZSettings::horizon_treadmill_7_0_at_24, QZSettings::default_horizon_treadmill_7_0_at_24).toBool()) {
+            bool miles = settings.value(QZSettings::miles_unit, QZSettings::default_miles_unit).toBool();
+            if(!miles) {
+                requestSpeed *= miles_conversion;   // this treadmill interprets FTMS speed commands as mph even in km/h mode
+            }
+        }
         uint16_t speed_int = round(requestSpeed * 100);
         writeS[1] = speed_int & 0xFF;
         writeS[2] = speed_int >> 8;

--- a/src/devices/horizontreadmill/horizontreadmill.cpp
+++ b/src/devices/horizontreadmill/horizontreadmill.cpp
@@ -1285,13 +1285,15 @@ void horizontreadmill::forceSpeed(double requestSpeed) {
                 requestSpeed *= miles_conversion;   // these treadmills want the speed in miles when miles_unit is enabled
             }
         }
+        bool horizon_7at_ceil = false;
         if(settings.value(QZSettings::horizon_treadmill_7_0_at_24, QZSettings::default_horizon_treadmill_7_0_at_24).toBool()) {
             bool miles = settings.value(QZSettings::miles_unit, QZSettings::default_miles_unit).toBool();
             if(!miles) {
                 requestSpeed *= miles_conversion;   // this treadmill interprets FTMS speed commands as mph even in km/h mode
+                horizon_7at_ceil = true;   // treadmill truncates mph→km/h, so ceil avoids landing one tick below
             }
         }
-        uint16_t speed_int = round(requestSpeed * 100);
+        uint16_t speed_int = horizon_7at_ceil ? (uint16_t)ceil(requestSpeed * 100) : (uint16_t)round(requestSpeed * 100);
         writeS[1] = speed_int & 0xFF;
         writeS[2] = speed_int >> 8;
 

--- a/src/settings.qml
+++ b/src/settings.qml
@@ -1449,7 +1449,7 @@ import Qt.labs.platform 1.1
             property bool ios_btdevice_native: false            
             property string inclinationResistancePoints: ""
             property int floatingwindow_type: 0
-            property bool horizon_treadmill_7_0_at_24: false  // not used
+            property bool horizon_treadmill_7_0_at_24: false
 
             property bool nordictrack_treadmill_ultra_le: false            
 
@@ -10661,6 +10661,20 @@ import Qt.labs.platform 1.1
                                 Layout.alignment: Qt.AlignLeft | Qt.AlignTop
                                 Layout.fillWidth: true
                                 onClicked: { settings.horizon_treadmill_force_ftms = checked; window.settings_restart_to_apply = true; }
+                            }
+                            IndicatorOnlySwitch {
+                                id: horizon7_0ATTreadmillDelegate
+                                text: qsTr("Horizon 7.0AT speed fix (FTMS)")
+                                spacing: 0
+                                bottomPadding: 0
+                                topPadding: 0
+                                rightPadding: 0
+                                leftPadding: 0
+                                clip: false
+                                checked: settings.horizon_treadmill_7_0_at_24
+                                Layout.alignment: Qt.AlignLeft | Qt.AlignTop
+                                Layout.fillWidth: true
+                                onClicked: { settings.horizon_treadmill_7_0_at_24 = checked; window.settings_restart_to_apply = true; }
                             }
                             IndicatorOnlySwitch {
                                 id: horizon78TreadmillDelegate


### PR DESCRIPTION
## Summary

Fixes #4716 — Horizon 7.0AT / JFTM 7.0AT treadmill speed control bug when using FTMS.

**Root cause:** The JFTM 7.0AT interprets FTMS Control Point speed commands (opcode `0x02`) as mph even when the treadmill is in km/h mode. QZ was sending km/h values which the device treated as mph, causing the belt to run at ~1.609× the commanded speed. The minus button also appeared to increase speed because `(X - 0.1) mph > X km/h` for any `X > 0.26`.

**Fix:** Adds an opt-in setting `horizon_treadmill_7_0_at_24` (already declared in `qzsettings.h`/`.cpp` since #3466, but previously unused) that applies a km/h → mph conversion before the FTMS Set Target Speed command. Only active when `miles_unit` is `false`, since users already in miles mode send compatible values.

This setting must be used alongside `horizon_treadmill_force_ftms = true` for the JFTM 7.0AT device.

## Changes

- **`horizontreadmill.cpp`** — `forceSpeed()` FTMS branch: multiply `requestSpeed` by `miles_conversion` (0.621371) when the setting is enabled and the app is in km/h mode
- **`settings.qml`** — activate the existing `horizon_treadmill_7_0_at_24` property (remove `// not used`), add new "Horizon 7.0AT speed fix (FTMS)" toggle under Horizon Treadmill Options

## Test plan

- [ ] Enable both "Force Using FTMS" and "Horizon 7.0AT speed fix (FTMS)" in Horizon Treadmill Options, restart app
- [ ] Verify that pressing + increases speed correctly (~0.1 km/h increments, not ×1.609)
- [ ] Verify that pressing - decreases speed correctly
- [ ] Verify that users with `miles_unit = true` are unaffected (no double conversion)
- [ ] Verify unrelated Horizon models (7.8, Paragon X, etc.) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)