### PR TITLE
Avoid Qt private QObject in vendored MQTT

### DIFF
--- a/src/mqtt/qmqttclient.cpp
+++ b/src/mqtt/qmqttclient.cpp
@@ -340,11 +340,15 @@ Q_LOGGING_CATEGORY(lcMqttClient, "qt.mqtt.client")
 /*
     Creates a new MQTT client instance with the specified \a parent.
  */
-QMqttClient::QMqttClient(QObject *parent) : QObject(*(new QMqttClientPrivate(this)), parent)
+QMqttClient::QMqttClient(QObject *parent)
+    : QObject(parent)
+    , d_ptr(new QMqttClientPrivate(this))
 {
     Q_D(QMqttClient);
     d->m_connection.setClientPrivate(d);
 }
+
+QMqttClient::~QMqttClient() = default;
 
 /*!
     Sets the transport to \a device. A transport can be either a socket type
@@ -1044,7 +1048,7 @@ void QMqttClient::setError(ClientError e)
 }
 
 QMqttClientPrivate::QMqttClientPrivate(QMqttClient *c)
-    : QObjectPrivate()
+    : q_ptr(c)
 {
     m_client = c;
     m_clientId = QUuid::createUuid().toString();

--- a/src/mqtt/qmqttclient.h
+++ b/src/mqtt/qmqttclient.h
@@ -41,6 +41,7 @@
 #include <QtCore/QIODevice>
 #include <QtCore/QObject>
 #include <QtCore/QSharedPointer>
+#include <QtCore/QScopedPointer>
 #include <QtNetwork/QTcpSocket>
 #ifndef QT_NO_SSL
 #include <QtNetwork/QSslConfiguration>
@@ -111,6 +112,7 @@ private:
     Q_PROPERTY(bool autoKeepAlive READ autoKeepAlive WRITE setAutoKeepAlive NOTIFY autoKeepAliveChanged)
 public:
     explicit QMqttClient(QObject *parent = nullptr);
+    ~QMqttClient() override;
 
     void setTransport(QIODevice *device, TransportType transport);
     QIODevice *transport() const;
@@ -217,6 +219,7 @@ private:
     void connectToHost(bool encrypted, const QString &sslPeerName);
     Q_DISABLE_COPY(QMqttClient)
     Q_DECLARE_PRIVATE(QMqttClient)
+    QScopedPointer<QMqttClientPrivate> d_ptr;
 };
 
 Q_DECLARE_TYPEINFO(QMqttClient::TransportType, Q_PRIMITIVE_TYPE);

--- a/src/mqtt/qmqttclient_p.h
+++ b/src/mqtt/qmqttclient_p.h
@@ -46,18 +46,17 @@
 
 #include <QtNetwork/QAbstractSocket>
 
-#include <private/qobject_p.h>
-
 QT_BEGIN_NAMESPACE
 
-class QMqttClientPrivate : public QObjectPrivate
+class QMqttClientPrivate
 {
     Q_DECLARE_PUBLIC(QMqttClient)
 public:
     QMqttClientPrivate(QMqttClient *c);
-    ~QMqttClientPrivate() override;
+    ~QMqttClientPrivate();
     void setStateAndError(QMqttClient::ClientState s, QMqttClient::ClientError e = QMqttClient::NoError);
     void setClientId(const QString &id);
+    QMqttClient *q_ptr{nullptr};
     QMqttClient *m_client{nullptr};
     QString m_hostname;
     quint16 m_port{0};

--- a/src/mqtt/qmqttconnection.cpp
+++ b/src/mqtt/qmqttconnection.cpp
@@ -36,6 +36,7 @@
 #include "qmqttclient_p.h"
 
 #include <QtCore/QLoggingCategory>
+#include <QtCore/QTimerEvent>
 #include <QtNetwork/QSslSocket>
 #include <QtNetwork/QTcpSocket>
 

--- a/src/mqtt/qmqttsubscription.cpp
+++ b/src/mqtt/qmqttsubscription.cpp
@@ -116,7 +116,9 @@ QT_BEGIN_NAMESPACE
     \brief This property holds the name of the shared subscription.
 */
 
-QMqttSubscription::QMqttSubscription(QObject *parent) : QObject(*(new QMqttSubscriptionPrivate), parent)
+QMqttSubscription::QMqttSubscription(QObject *parent)
+    : QObject(parent)
+    , d_ptr(new QMqttSubscriptionPrivate(this))
 {
 
 }
@@ -241,8 +243,8 @@ void QMqttSubscription::setSharedSubscriptionName(const QString &name)
     d->m_sharedSubscriptionName = name;
 }
 
-QMqttSubscriptionPrivate::QMqttSubscriptionPrivate()
-    : QObjectPrivate()
+QMqttSubscriptionPrivate::QMqttSubscriptionPrivate(QMqttSubscription *q)
+    : q_ptr(q)
 {
 
 }

--- a/src/mqtt/qmqttsubscription.h
+++ b/src/mqtt/qmqttsubscription.h
@@ -35,6 +35,7 @@
 #include "qmqtttopicfilter.h"
 
 #include <QtCore/QObject>
+#include <QtCore/QScopedPointer>
 
 QT_BEGIN_NAMESPACE
 
@@ -92,6 +93,7 @@ private:
     friend class QMqttConnection;
     friend class QMqttClient;
     explicit QMqttSubscription(QObject *parent = nullptr);
+    QScopedPointer<QMqttSubscriptionPrivate> d_ptr;
 };
 
 QT_END_NAMESPACE

--- a/src/mqtt/qmqttsubscription_p.h
+++ b/src/mqtt/qmqttsubscription_p.h
@@ -42,16 +42,16 @@
 //
 
 #include "qmqttsubscription.h"
-#include <QtCore/private/qobject_p.h>
 
 QT_BEGIN_NAMESPACE
 
-class QMqttSubscriptionPrivate : public QObjectPrivate
+class QMqttSubscriptionPrivate
 {
     Q_DECLARE_PUBLIC(QMqttSubscription)
 public:
-    QMqttSubscriptionPrivate();
-    ~QMqttSubscriptionPrivate() override = default;
+    QMqttSubscriptionPrivate(QMqttSubscription *q);
+    ~QMqttSubscriptionPrivate() = default;
+    QMqttSubscription *q_ptr{nullptr};
     QMqttClient *m_client{nullptr};
     QMqttTopicFilter m_topic;
     QString m_reasonString;


### PR DESCRIPTION
## Summary
- replace the vendored MQTT QObjectPrivate inheritance with regular QObject ownership plus QScopedPointer d-pointers
- remove direct qobject_p.h usage from QMqttClient and QMqttSubscription
- avoid Qt private-header runtime version aborts on Raspberry builds using MQTT

## Context
The Raspberry no-GUI MQTT run in issue #4711 aborts through QMessageLogger::fatal -> QObjectPrivate::QObjectPrivate(int). That maps to Qt's private-header runtime check: Cannot mix incompatible Qt library (...) with this library (...). The vendored MQTT client/subscription were constructing QObject with custom QObjectPrivate subclasses, making them sensitive to Qt private-header version mismatches.

## Verification
- qmake qdomyos-zwift.pro
- make qmqttclient.o qmqttsubscription.o

Full make was also attempted, but this worktree stops on missing smtpclient/src/SmtpMime, unrelated to this MQTT change.