### PR TITLE
Fix FTMS elliptical (Feier-EM-1784) not sending data to Zwift

### DIFF
--- a/src/devices/ypooelliptical/ypooelliptical.cpp
+++ b/src/devices/ypooelliptical/ypooelliptical.cpp
@@ -217,10 +217,9 @@ void ypooelliptical::update() {
         }
         if (requestStart != -1) {
             emit debug(QStringLiteral("starting..."));
-            if(E35 || SCH_590E || SCH_411_510E || KETTLER || CARDIOPOWER_EEGO || MYELLIPTICAL || SKANDIKA || DOMYOS || FEIER || MX_AS || FTMS || SOLE_E25 || TRUE_ELLIPTICAL) {
-                uint8_t write[] = {FTMS_START_RESUME};
-                writeCharacteristic(&gattFTMSWriteCharControlPointId, gattFTMSService, write, sizeof(write), "startResume", false, true);
-            }
+
+            // btinit();
+
             requestStart = -1;
             emit bikeStarted();
         }

--- a/src/devices/ypooelliptical/ypooelliptical.cpp
+++ b/src/devices/ypooelliptical/ypooelliptical.cpp
@@ -217,9 +217,10 @@ void ypooelliptical::update() {
         }
         if (requestStart != -1) {
             emit debug(QStringLiteral("starting..."));
-
-            // btinit();
-
+            if(E35 || SCH_590E || SCH_411_510E || KETTLER || CARDIOPOWER_EEGO || MYELLIPTICAL || SKANDIKA || DOMYOS || FEIER || MX_AS || FTMS || SOLE_E25 || TRUE_ELLIPTICAL) {
+                uint8_t write[] = {FTMS_START_RESUME};
+                writeCharacteristic(&gattFTMSWriteCharControlPointId, gattFTMSService, write, sizeof(write), "startResume", false, true);
+            }
             requestStart = -1;
             emit bikeStarted();
         }
@@ -1045,7 +1046,7 @@ void ypooelliptical::descriptorWritten(const QLowEnergyDescriptor &descriptor, c
         if(!iconsole_elliptical)
             initRequest = true;
         emit connectedAndDiscovered();
-    } else if(E35) {
+    } else if(gattFTMSService != nullptr) {
         initRequest = true;
         emit connectedAndDiscovered();
     }

--- a/src/devices/ypooelliptical/ypooelliptical.cpp
+++ b/src/devices/ypooelliptical/ypooelliptical.cpp
@@ -133,6 +133,10 @@ void ypooelliptical::update() {
         if(E35 || SCH_590E || SCH_411_510E || KETTLER || CARDIOPOWER_EEGO || MYELLIPTICAL || SKANDIKA || DOMYOS || FEIER || MX_AS || FTMS || SOLE_E25 || TRUE_ELLIPTICAL) {
             uint8_t write[] = {FTMS_REQUEST_CONTROL};
             writeCharacteristic(&gattFTMSWriteCharControlPointId, gattFTMSService, write, sizeof(write), "requestControl", false, true);
+            if(FEIER || FTMS) {
+                write[0] = FTMS_START_RESUME;
+                writeCharacteristic(&gattFTMSWriteCharControlPointId, gattFTMSService, write, sizeof(write), "startResume", false, true);
+            }
         } else {
             uint8_t init1[] = {0x02, 0x42, 0x42, 0x03};
             uint8_t init2[] = {0x02, 0x41, 0x02, 0x43, 0x03};


### PR DESCRIPTION
Two bugs in ypooelliptical for FTMS-based devices (FEIER, E35, SCH_590E, etc.):

1. descriptorWritten: the `else if(E35)` fallback for FTMS-only devices did not
   cover FEIER and other FTMS devices that lack a gattCustomService. Changed to
   `else if(gattFTMSService != nullptr)` so all FTMS devices trigger initRequest
   and connectedAndDiscovered correctly.

2. requestStart: no FTMS_START_RESUME command (opcode 0x07) was sent to the
   device when a workout started. FTMS machines require this opcode before they
   begin reporting non-zero speed/cadence, causing the Zwift avatar to not move.

Fixes #4730

https://claude.ai/code/session_016pzRLE7jGiyWi9hH8vcQBw