### PR TITLE
Handle Domyos invalid resistance response

### DIFF
--- a/src/devices/ftmsbike/ftmsbike.cpp
+++ b/src/devices/ftmsbike/ftmsbike.cpp
@@ -700,10 +700,11 @@ void ftmsbike::characteristicChanged(const QLowEnergyCharacteristic &characteris
         const uint8_t resultCode = (uint8_t)newValue.at(2);
 
         if (DOMYOS && responseCode == FTMS_RESPONSE_CODE && requestCode == FTMS_SET_TARGET_RESISTANCE_LEVEL) {
-            if (resultCode == FTMS_CONTROL_NOT_PERMITTED) {
+            if (resultCode == FTMS_CONTROL_NOT_PERMITTED || resultCode == FTMS_INVALID_PARAMETER) {
                 domyosResistanceRetryAfter = now.addMSecs(3000);
                 initDone = false;
-                qDebug() << "DOMYOS resistance command rejected with CONTROL_NOT_PERMITTED"
+                qDebug() << "DOMYOS resistance command rejected with retryable result"
+                         << "resultCode:" << resultCode
                          << "lastRequestedResistance:" << lastDomyosRequestedResistance
                          << "backoffUntil:" << domyosResistanceRetryAfter;
             } else if (resultCode == FTMS_SUCCESS) {


### PR DESCRIPTION
## Summary
- Treat Domyos FTMS `INVALID_PARAMETER` responses to Set Target Resistance Level like the retryable resistance rejection handled in #4421.
- Keep the existing Domyos backoff path active when the bike returns `80 04 03`, as seen in the debug log.

## Testing
- `git diff --check`

Refs #4421
Refs #4403