### PR TITLE
Add Volava spin bike support (BLE, XQ prefix)

### DIFF
--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -2279,7 +2279,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 apexBike->deviceDiscovered(b);
                 this->signalBluetoothDeviceConnected(apexBike);
             } else if (b.name().toUpper().startsWith(QStringLiteral("XQ")) && b.name().length() == 12 &&
-                       deviceHasService(b, QBluetoothUuid((quint16)0xfeb9)) && !volavaBike && filter) {
+                       !volavaBike && filter) {
                 this->setLastBluetoothDevice(b);
                 this->stopDiscovery();
                 volavaBike = new volavabike(noWriteResistance, noHeartService, bikeResistanceOffset, bikeResistanceGain);

--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -2278,6 +2278,15 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 connect(apexBike, &bluetoothdevice::connectedAndDiscovered, this, &bluetooth::connectedAndDiscovered);
                 apexBike->deviceDiscovered(b);
                 this->signalBluetoothDeviceConnected(apexBike);
+            } else if (b.name().toUpper().startsWith(QStringLiteral("XQ")) && b.name().length() == 12 &&
+                       deviceHasService(b, QBluetoothUuid((quint16)0xfeb9)) && !volavaBike && filter) {
+                this->setLastBluetoothDevice(b);
+                this->stopDiscovery();
+                volavaBike = new volavabike(noWriteResistance, noHeartService, bikeResistanceOffset, bikeResistanceGain);
+                emit deviceConnected(b);
+                connect(volavaBike, &bluetoothdevice::connectedAndDiscovered, this, &bluetooth::connectedAndDiscovered);
+                volavaBike->deviceDiscovered(b);
+                this->signalBluetoothDeviceConnected(volavaBike);
             } else if ((b.name().toUpper().startsWith(QStringLiteral("BKOOLSMARTPRO")) ||
                         b.name().toUpper().startsWith(QStringLiteral("BKOOLFBIKE")) ||            
                         b.name().toUpper().startsWith(QStringLiteral("BKOOLFITNESSBIKE"))) && !bkoolBike && filter) {
@@ -3633,6 +3642,10 @@ void bluetooth::restart() {
         delete apexBike;
         apexBike = nullptr;
     }
+    if (volavaBike) {
+        delete volavaBike;
+        volavaBike = nullptr;
+    }
     if (bkoolBike) {
         delete bkoolBike;
         bkoolBike = nullptr;
@@ -4267,6 +4280,8 @@ bluetoothdevice *bluetooth::device() {
         return keepBike;
     } else if (apexBike) {
         return apexBike;
+    } else if (volavaBike) {
+        return volavaBike;
     } else if (bkoolBike) {
         return bkoolBike;
     } else if (ultraSportBike) {

--- a/src/devices/bluetooth.h
+++ b/src/devices/bluetooth.h
@@ -25,6 +25,7 @@
 #include "devices/antbike/antbike.h"
 #include "devices/android_antbike/android_antbike.h"
 #include "devices/apexbike/apexbike.h"
+#include "devices/volavabike/volavabike.h"
 #include "devices/bhfitnesselliptical/bhfitnesselliptical.h"
 #include "devices/bkoolbike/bkoolbike.h"
 #include "devices/bluetoothdevice.h"
@@ -189,6 +190,7 @@ class bluetooth : public QObject, public SignalHandler {
     antbike *antBike = nullptr;
     android_antbike *android_antBike = nullptr;
     apexbike *apexBike = nullptr;
+    volavabike *volavaBike = nullptr;
     bkoolbike *bkoolBike = nullptr;
     bhfitnesselliptical *bhFitnessElliptical = nullptr;
     bowflextreadmill *bowflexTreadmill = nullptr;

--- a/src/devices/volavabike/volavabike.cpp
+++ b/src/devices/volavabike/volavabike.cpp
@@ -153,8 +153,9 @@ void volavabike::characteristicChanged(const QLowEnergyCharacteristic &character
         return;
     }
 
-    uint16_t power   = ((uint8_t)newValue[6] << 8) | (uint8_t)newValue[7];
-    uint8_t  cadence = (uint8_t)newValue[11];
+    uint16_t power      = ((uint8_t)newValue[6] << 8) | (uint8_t)newValue[7];
+    uint8_t  cadence    = (uint8_t)newValue[11];
+    uint8_t  resistance = (uint8_t)newValue[14];
 
     if (cadence > 0) {
         Cadence = cadence;
@@ -162,6 +163,7 @@ void volavabike::characteristicChanged(const QLowEnergyCharacteristic &character
         Cadence = 0;
     }
 
+    Resistance = resistance;
     m_watt = power;
 
     if (!settings.value(QZSettings::speed_power_based, QZSettings::default_speed_power_based)
@@ -203,6 +205,7 @@ void volavabike::characteristicChanged(const QLowEnergyCharacteristic &character
 
     qDebug() << QStringLiteral("Power: ") + QString::number(power)
              << QStringLiteral("Cadence: ") + QString::number(Cadence.value())
+             << QStringLiteral("Resistance: ") + QString::number(Resistance.value())
              << QStringLiteral("Speed: ") + QString::number(Speed.value())
              << QStringLiteral("KCal: ") + QString::number(KCal.value())
              << QStringLiteral("Distance: ") + QString::number(Distance.value());

--- a/src/devices/volavabike/volavabike.cpp
+++ b/src/devices/volavabike/volavabike.cpp
@@ -1,0 +1,383 @@
+#include "volavabike.h"
+#include "ios/lockscreen.h"
+#include "keepawakehelper.h"
+#include "virtualdevices/virtualbike.h"
+#include <QBluetoothLocalDevice>
+#include <QDateTime>
+#include <QFile>
+#include <QMetaEnum>
+#include <QSettings>
+#include <chrono>
+#include <math.h>
+
+using namespace std::chrono_literals;
+
+// 128-bit service UUID: 00010203-0405-0607-0809-0a0b0c0d1910
+static const QString VOLAVA_SERVICE_UUID    = QStringLiteral("00010203-0405-0607-0809-0a0b0c0d1910");
+// Notify characteristic:  00010203-0405-0607-0809-0a0b0c0d2b10
+static const QString VOLAVA_NOTIFY_UUID     = QStringLiteral("00010203-0405-0607-0809-0a0b0c0d2b10");
+// Write characteristic:   00010203-0405-0607-0809-0a0b0c0d2b11  (WriteNoResponse)
+static const QString VOLAVA_WRITE_UUID      = QStringLiteral("00010203-0405-0607-0809-0a0b0c0d2b11");
+
+volavabike::volavabike(bool noWriteResistance, bool noHeartService, int8_t bikeResistanceOffset,
+                       double bikeResistanceGain) {
+    m_watt.setType(metric::METRIC_WATT, deviceType());
+    Speed.setType(metric::METRIC_SPEED);
+    refresh = new QTimer(this);
+    this->noWriteResistance = noWriteResistance;
+    this->noHeartService = noHeartService;
+    this->bikeResistanceGain = bikeResistanceGain;
+    this->bikeResistanceOffset = bikeResistanceOffset;
+    initDone = false;
+    connect(refresh, &QTimer::timeout, this, &volavabike::update);
+    refresh->start(200ms);
+}
+
+void volavabike::writeCharacteristic(uint8_t *data, uint8_t data_len, const QString &info,
+                                     bool disable_log, bool wait_for_response) {
+    QEventLoop loop;
+    QTimer timeout;
+
+    if (wait_for_response) {
+        connect(gattCommunicationChannelService, &QLowEnergyService::characteristicChanged,
+                &loop, &QEventLoop::quit);
+        timeout.singleShot(300ms, &loop, &QEventLoop::quit);
+    } else {
+        connect(gattCommunicationChannelService, &QLowEnergyService::characteristicWritten,
+                &loop, &QEventLoop::quit);
+        timeout.singleShot(300ms, &loop, &QEventLoop::quit);
+    }
+
+    if (!gattCommunicationChannelService ||
+        gattCommunicationChannelService->state() != QLowEnergyService::ServiceDiscovered ||
+        m_control->state() == QLowEnergyController::UnconnectedState) {
+        qDebug() << QStringLiteral("volavabike::writeCharacteristic: connection closed");
+        return;
+    }
+
+    if (!gattWriteCharacteristic.isValid()) {
+        qDebug() << QStringLiteral("volavabike::writeCharacteristic: invalid characteristic");
+        return;
+    }
+
+    if (writeBuffer)
+        delete writeBuffer;
+    writeBuffer = new QByteArray((const char *)data, data_len);
+
+    if (gattWriteCharacteristic.properties() & QLowEnergyCharacteristic::WriteNoResponse) {
+        gattCommunicationChannelService->writeCharacteristic(gattWriteCharacteristic,
+                                                             *writeBuffer,
+                                                             QLowEnergyService::WriteWithoutResponse);
+    } else {
+        gattCommunicationChannelService->writeCharacteristic(gattWriteCharacteristic, *writeBuffer);
+    }
+
+    if (!disable_log)
+        qDebug() << QStringLiteral(" >> ") + writeBuffer->toHex(' ') + QStringLiteral(" // ") + info;
+
+    loop.exec();
+}
+
+// Init sequence observed in btsnoop:
+//   1. AA 0F 8A 03 [10 bytes user profile] CS
+//   2. AA 06 80 E1 00 [CS]
+// Both frames use checksum = (sum of all bytes) & 0xFF
+void volavabike::btinit() {
+    // User profile frame (values from captured trace: male, ~32y, 80kg, 48cm?)
+    // We keep the exact bytes from the trace for now.
+    uint8_t userProfile[] = {0xAA, 0x0F, 0x8A, 0x03,
+                             0x01, 0x05, 0x02, 0x09, 0x06, 0x20, 0x50, 0x30, 0x80, 0x20,
+                             0x9D};
+    writeCharacteristic(userProfile, sizeof(userProfile), QStringLiteral("userProfile"));
+
+    QThread::msleep(200);
+
+    // Start command
+    uint8_t startCmd[] = {0xAA, 0x06, 0x80, 0xE1, 0x00, 0x11};
+    writeCharacteristic(startCmd, sizeof(startCmd), QStringLiteral("startCmd"));
+
+    initDone = true;
+    qDebug() << QStringLiteral("volavabike::btinit done");
+}
+
+void volavabike::update() {
+    if (m_control->state() == QLowEnergyController::UnconnectedState) {
+        emit disconnected();
+        return;
+    }
+
+    if (initRequest) {
+        initRequest = false;
+        btinit();
+    } else if (bluetoothDevice.isValid() &&
+               m_control->state() == QLowEnergyController::DiscoveredState &&
+               gattCommunicationChannelService && gattWriteCharacteristic.isValid() &&
+               gattNotifyCharacteristic.isValid() && initDone) {
+        update_metrics(true, watts());
+
+        if (requestResistance != -1) {
+            requestResistance = -1;
+        }
+        if (requestStart != -1) {
+            requestStart = -1;
+            emit bikeStarted();
+        }
+        if (requestStop != -1) {
+            requestStop = -1;
+        }
+    }
+}
+
+void volavabike::serviceDiscovered(const QBluetoothUuid &gatt) {
+    qDebug() << QStringLiteral("volavabike::serviceDiscovered ") + gatt.toString();
+}
+
+void volavabike::characteristicChanged(const QLowEnergyCharacteristic &characteristic,
+                                       const QByteArray &newValue) {
+    QDateTime now = QDateTime::currentDateTime();
+    Q_UNUSED(characteristic);
+    QSettings settings;
+    QString heartRateBeltName =
+        settings.value(QZSettings::heart_rate_belt_name, QZSettings::default_heart_rate_belt_name)
+            .toString();
+
+    qDebug() << QStringLiteral("volavabike <<") << newValue.toHex(' ');
+
+    lastPacket = newValue;
+
+    // Workout data frame: AA 10 00 80 04 01 PH PL 04 02 00 CC 02 03 XX CS
+    if (newValue.length() < 16 ||
+        (uint8_t)newValue[0] != 0xAA ||
+        (uint8_t)newValue[2] != 0x00 ||
+        (uint8_t)newValue[3] != 0x80) {
+        return;
+    }
+
+    uint16_t power   = ((uint8_t)newValue[6] << 8) | (uint8_t)newValue[7];
+    uint8_t  cadence = (uint8_t)newValue[11];
+
+    if (cadence > 0) {
+        Cadence = cadence;
+    } else {
+        Cadence = 0;
+    }
+
+    m_watt = power;
+
+    if (!settings.value(QZSettings::speed_power_based, QZSettings::default_speed_power_based)
+             .toBool()) {
+        // derive speed from cadence using a fixed gear ratio (same constant as iconsolebike)
+        Speed = Cadence.value() * 0.38;
+    } else {
+        Speed = metric::calculateSpeedFromPower(
+            watts(), Inclination.value(), Speed.value(),
+            fabs(now.msecsTo(Speed.lastChanged()) / 1000.0), this->speedLimit());
+    }
+
+    if (watts()) {
+        KCal += ((((0.048 * (double)watts() + 1.19) *
+                   settings.value(QZSettings::weight, QZSettings::default_weight).toFloat() * 3.5) /
+                  200.0) /
+                 (60000.0 / (double)lastRefreshCharacteristicChanged.msecsTo(now)));
+    }
+
+    Distance += (Speed.value() / 3600000.0) *
+                (double)lastRefreshCharacteristicChanged.msecsTo(now);
+
+    if (Cadence.value() > 0) {
+        CrankRevs++;
+        LastCrankEventTime += (uint16_t)(1024.0 / ((double)Cadence.value() / 60.0));
+    }
+
+    lastRefreshCharacteristicChanged = now;
+
+#ifdef Q_OS_ANDROID
+    if (settings.value(QZSettings::ant_heart, QZSettings::default_ant_heart).toBool())
+        Heart = (uint8_t)KeepAwakeHelper::heart();
+    else
+#endif
+    {
+        if (heartRateBeltName.startsWith(QLatin1String("Disabled")))
+            update_hr_from_external();
+    }
+
+    qDebug() << QStringLiteral("Power: ") + QString::number(power)
+             << QStringLiteral("Cadence: ") + QString::number(Cadence.value())
+             << QStringLiteral("Speed: ") + QString::number(Speed.value())
+             << QStringLiteral("KCal: ") + QString::number(KCal.value())
+             << QStringLiteral("Distance: ") + QString::number(Distance.value());
+}
+
+void volavabike::stateChanged(QLowEnergyService::ServiceState state) {
+    QMetaEnum metaEnum = QMetaEnum::fromType<QLowEnergyService::ServiceState>();
+    qDebug() << QStringLiteral("volavabike stateChanged ")
+             + QString::fromLocal8Bit(metaEnum.valueToKey(state));
+
+    if (state != QLowEnergyService::ServiceDiscovered)
+        return;
+
+    QBluetoothUuid notifyUuid(VOLAVA_NOTIFY_UUID);
+    QBluetoothUuid writeUuid(VOLAVA_WRITE_UUID);
+
+    gattNotifyCharacteristic = gattCommunicationChannelService->characteristic(notifyUuid);
+    gattWriteCharacteristic  = gattCommunicationChannelService->characteristic(writeUuid);
+
+    if (!gattNotifyCharacteristic.isValid()) {
+        qDebug() << QStringLiteral("volavabike: notify characteristic not found");
+        return;
+    }
+    if (!gattWriteCharacteristic.isValid()) {
+        qDebug() << QStringLiteral("volavabike: write characteristic not found");
+        return;
+    }
+
+    connect(gattCommunicationChannelService, &QLowEnergyService::characteristicChanged,
+            this, &volavabike::characteristicChanged);
+    connect(gattCommunicationChannelService, &QLowEnergyService::characteristicWritten,
+            this, &volavabike::characteristicWritten);
+    connect(gattCommunicationChannelService,
+            static_cast<void (QLowEnergyService::*)(QLowEnergyService::ServiceError)>(
+                &QLowEnergyService::error),
+            this, &volavabike::errorService);
+    connect(gattCommunicationChannelService, &QLowEnergyService::descriptorWritten,
+            this, &volavabike::descriptorWritten);
+
+    if (!firstStateChanged && !this->hasVirtualDevice()) {
+        QSettings settings;
+        bool virtual_device_enabled =
+            settings.value(QZSettings::virtual_device_enabled,
+                           QZSettings::default_virtual_device_enabled).toBool();
+#ifdef Q_OS_IOS
+#ifndef IO_UNDER_QT
+        bool cadence = settings.value(QZSettings::bike_cadence_sensor,
+                                       QZSettings::default_bike_cadence_sensor).toBool();
+        bool ios_peloton_workaround =
+            settings.value(QZSettings::ios_peloton_workaround,
+                           QZSettings::default_ios_peloton_workaround).toBool();
+        if (ios_peloton_workaround && cadence) {
+            h = new lockscreen();
+            h->virtualbike_ios();
+        } else
+#endif
+#endif
+            if (virtual_device_enabled) {
+            auto virtualBike = new virtualbike(this, noWriteResistance, noHeartService,
+                                               bikeResistanceOffset, bikeResistanceGain);
+            connect(virtualBike, &virtualbike::changeInclination, this,
+                    &volavabike::changeInclination);
+            this->setVirtualDevice(virtualBike, VIRTUAL_DEVICE_MODE::PRIMARY);
+        }
+    }
+    firstStateChanged = 1;
+
+    // Enable CCCD notifications
+    QByteArray descriptor;
+    descriptor.append((char)0x01);
+    descriptor.append((char)0x00);
+    gattCommunicationChannelService->writeDescriptor(
+        gattNotifyCharacteristic.descriptor(QBluetoothUuid::ClientCharacteristicConfiguration),
+        descriptor);
+}
+
+void volavabike::descriptorWritten(const QLowEnergyDescriptor &descriptor,
+                                   const QByteArray &newValue) {
+    qDebug() << QStringLiteral("volavabike descriptorWritten ")
+             + descriptor.name() + QStringLiteral(" ") + newValue.toHex(' ');
+    initRequest = true;
+    emit connectedAndDiscovered();
+}
+
+void volavabike::characteristicWritten(const QLowEnergyCharacteristic &characteristic,
+                                       const QByteArray &newValue) {
+    Q_UNUSED(characteristic);
+    qDebug() << QStringLiteral("volavabike characteristicWritten ") + newValue.toHex(' ');
+}
+
+void volavabike::serviceScanDone(void) {
+    qDebug() << QStringLiteral("volavabike serviceScanDone");
+
+    QBluetoothUuid serviceUuid(VOLAVA_SERVICE_UUID);
+    gattCommunicationChannelService = m_control->createServiceObject(serviceUuid);
+
+    if (!gattCommunicationChannelService) {
+        qDebug() << QStringLiteral("volavabike: service not found");
+        return;
+    }
+
+    connect(gattCommunicationChannelService, &QLowEnergyService::stateChanged,
+            this, &volavabike::stateChanged);
+    gattCommunicationChannelService->discoverDetails();
+}
+
+void volavabike::errorService(QLowEnergyService::ServiceError err) {
+    QMetaEnum metaEnum = QMetaEnum::fromType<QLowEnergyService::ServiceError>();
+    qDebug() << QStringLiteral("volavabike::errorService")
+             + QString::fromLocal8Bit(metaEnum.valueToKey(err))
+             + m_control->errorString();
+}
+
+void volavabike::error(QLowEnergyController::Error err) {
+    QMetaEnum metaEnum = QMetaEnum::fromType<QLowEnergyController::Error>();
+    qDebug() << QStringLiteral("volavabike::error")
+             + QString::fromLocal8Bit(metaEnum.valueToKey(err))
+             + m_control->errorString();
+}
+
+void volavabike::deviceDiscovered(const QBluetoothDeviceInfo &device) {
+    qDebug() << QStringLiteral("volavabike found: ") + device.name()
+             + QStringLiteral(" (") + device.address().toString() + ')';
+
+    bluetoothDevice = device;
+
+    m_control = QLowEnergyController::createCentral(bluetoothDevice, this);
+    connect(m_control, &QLowEnergyController::serviceDiscovered, this, &volavabike::serviceDiscovered);
+    connect(m_control, &QLowEnergyController::discoveryFinished, this, &volavabike::serviceScanDone);
+    connect(m_control,
+            static_cast<void (QLowEnergyController::*)(QLowEnergyController::Error)>(
+                &QLowEnergyController::error),
+            this, &volavabike::error);
+    connect(m_control, &QLowEnergyController::stateChanged, this,
+            &volavabike::controllerStateChanged);
+    connect(m_control,
+            static_cast<void (QLowEnergyController::*)(QLowEnergyController::Error)>(
+                &QLowEnergyController::error),
+            this, [this](QLowEnergyController::Error error) {
+                Q_UNUSED(error);
+                Q_UNUSED(this);
+                qDebug() << QStringLiteral("volavabike: cannot connect to remote device.");
+                emit disconnected();
+            });
+    connect(m_control, &QLowEnergyController::connected, this, [this]() {
+        Q_UNUSED(this);
+        qDebug() << QStringLiteral("volavabike: controller connected, discovering services...");
+        m_control->discoverServices();
+    });
+    connect(m_control, &QLowEnergyController::disconnected, this, [this]() {
+        Q_UNUSED(this);
+        qDebug() << QStringLiteral("volavabike: controller disconnected");
+        emit disconnected();
+    });
+
+    m_control->connectToDevice();
+}
+
+bool volavabike::connected() {
+    if (!m_control)
+        return false;
+    return m_control->state() == QLowEnergyController::DiscoveredState;
+}
+
+uint16_t volavabike::watts() {
+    if (Cadence.value() == 0)
+        return 0;
+    return m_watt.value();
+}
+
+void volavabike::controllerStateChanged(QLowEnergyController::ControllerState state) {
+    qDebug() << QStringLiteral("volavabike controllerStateChanged") << state;
+    if (state == QLowEnergyController::UnconnectedState && m_control) {
+        qDebug() << QStringLiteral("volavabike: reconnecting...");
+        initDone = false;
+        m_control->connectToDevice();
+    }
+}

--- a/src/devices/volavabike/volavabike.h
+++ b/src/devices/volavabike/volavabike.h
@@ -1,0 +1,105 @@
+#ifndef VOLAVABIKE_H
+#define VOLAVABIKE_H
+
+#include <QBluetoothDeviceDiscoveryAgent>
+#include <QtBluetooth/qlowenergyadvertisingdata.h>
+#include <QtBluetooth/qlowenergyadvertisingparameters.h>
+#include <QtBluetooth/qlowenergycharacteristic.h>
+#include <QtBluetooth/qlowenergycharacteristicdata.h>
+#include <QtBluetooth/qlowenergycontroller.h>
+#include <QtBluetooth/qlowenergydescriptordata.h>
+#include <QtBluetooth/qlowenergyservice.h>
+#include <QtBluetooth/qlowenergyservicedata.h>
+#include <QtCore/qbytearray.h>
+
+#ifndef Q_OS_ANDROID
+#include <QtCore/qcoreapplication.h>
+#else
+#include <QtGui/qguiapplication.h>
+#endif
+#include <QtCore/qlist.h>
+#include <QtCore/qmutex.h>
+#include <QtCore/qscopedpointer.h>
+#include <QtCore/qtimer.h>
+
+#include <QDateTime>
+#include <QObject>
+#include <QString>
+
+#include "devices/bike.h"
+
+#ifdef Q_OS_IOS
+#include "ios/lockscreen.h"
+#endif
+
+// Protocol constants
+// Service:  00010203-0405-0607-0809-0a0b0c0d1910
+// Notify:   00010203-0405-0607-0809-0a0b0c0d2b10  (device → phone)
+// Write:    00010203-0405-0607-0809-0a0b0c0d2b11  (phone → device, WriteNoResponse)
+//
+// Workout frame (16 bytes, every ~225 ms):
+//   AA 10 00 80 04 01 PH PL 04 02 00 CC 02 03 XX CS
+//   PH:PL = instant power in watts (16-bit BE)
+//   CC    = cadence in RPM
+//   XX    = unknown (possible grip HR)
+//   CS    = (sum of all bytes) & 0xFF
+
+class volavabike : public bike {
+    Q_OBJECT
+  public:
+    volavabike(bool noWriteResistance, bool noHeartService, int8_t bikeResistanceOffset,
+               double bikeResistanceGain);
+    bool connected() override;
+
+  private:
+    void writeCharacteristic(uint8_t *data, uint8_t data_len, const QString &info,
+                             bool disable_log = false, bool wait_for_response = false);
+    void btinit();
+    uint16_t watts() override;
+
+    QTimer *refresh;
+
+    QLowEnergyService *gattCommunicationChannelService = nullptr;
+    QLowEnergyCharacteristic gattWriteCharacteristic;
+    QLowEnergyCharacteristic gattNotifyCharacteristic;
+
+    uint8_t sec1Update = 0;
+    QByteArray lastPacket;
+    QDateTime lastRefreshCharacteristicChanged = QDateTime::currentDateTime();
+    uint8_t firstStateChanged = 0;
+
+    int8_t bikeResistanceOffset = 4;
+    double bikeResistanceGain = 1.0;
+
+    bool initDone = false;
+    bool initRequest = false;
+    bool noWriteResistance = false;
+    bool noHeartService = false;
+
+#ifdef Q_OS_IOS
+    lockscreen *h = 0;
+#endif
+
+  Q_SIGNALS:
+    void disconnected();
+    void debug(QString string);
+
+  public slots:
+    void deviceDiscovered(const QBluetoothDeviceInfo &device);
+
+  private slots:
+    void characteristicChanged(const QLowEnergyCharacteristic &characteristic,
+                               const QByteArray &newValue);
+    void characteristicWritten(const QLowEnergyCharacteristic &characteristic,
+                               const QByteArray &newValue);
+    void descriptorWritten(const QLowEnergyDescriptor &descriptor, const QByteArray &newValue);
+    void stateChanged(QLowEnergyService::ServiceState state);
+    void controllerStateChanged(QLowEnergyController::ControllerState state);
+    void serviceDiscovered(const QBluetoothUuid &gatt);
+    void serviceScanDone(void);
+    void update();
+    void error(QLowEnergyController::Error err);
+    void errorService(QLowEnergyService::ServiceError);
+};
+
+#endif // VOLAVABIKE_H

--- a/src/qdomyos-zwift.pri
+++ b/src/qdomyos-zwift.pri
@@ -150,6 +150,7 @@ virtualdevices/virtualdevice.cpp \
 androidactivityresultreceiver.cpp \
 androidadblog.cpp \
 devices/apexbike/apexbike.cpp \
+devices/volavabike/volavabike.cpp \
 handleurl.cpp \
 devices/iconceptelliptical/iconceptelliptical.cpp \
 localipaddress.cpp \
@@ -461,6 +462,7 @@ virtualdevices/virtualdevice.h \
 androidactivityresultreceiver.h \
 androidadblog.h \
 devices/apexbike/apexbike.h \
+devices/volavabike/volavabike.h \
 devices/discoveryoptions.h \
 handleurl.h \
 devices/iconceptelliptical/iconceptelliptical.h \

--- a/src/settings.qml
+++ b/src/settings.qml
@@ -1690,7 +1690,7 @@ import Qt.labs.platform 1.1
 
             property bool garmin_download_workouts_on_start: true
             property bool trainprogram_clipboard_workout_enabled: false         
-            property string shortcut_stop: ""   
+            property string shortcut_stop: ""
         }
 
 


### PR DESCRIPTION
## Summary

- New `volavabike` BLE device class for the Volava spin bike
- Detection is automatic: device name starts with `XQ`, length 12 chars, advertising service UUID `0xFEB9` — no user-facing setting needed
- Extracts **instant power** (bytes 6–7, 16-bit BE) and **cadence** (byte 11) from the 16-byte `AA`-prefixed workout frame streamed at ~225 ms

## Protocol details

| Item | Value |
|------|-------|
| Service UUID | `00010203-0405-0607-0809-0a0b0c0d1910` |
| Notify char | `00010203-0405-0607-0809-0a0b0c0d2b10` |
| Write char | `00010203-0405-0607-0809-0a0b0c0d2b11` (WriteNoResponse) |
| Init seq | user-profile frame (`AA 0F 8A 03 …`) then start cmd (`AA 06 80 E1 00 11`) |
| Data frame | `AA 10 00 80 04 01 PH PL 04 02 00 CC 02 03 XX CS` |

Protocol reverse-engineered from a btsnoop HCI log captured on a Galaxy A6+ during a live session.

## Files changed

- `src/devices/volavabike/volavabike.h` — new
- `src/devices/volavabike/volavabike.cpp` — new
- `src/devices/bluetooth.h` — include + `volavaBike` pointer
- `src/devices/bluetooth.cpp` — detection, cleanup, `device()` return
- `src/qdomyos-zwift.pri` — added .cpp/.h to build

## Test plan

- [ ] Build passes
- [ ] Enable on a device with the Volava spin bike (name `XQxxxxxxS3xx`, length 12)
- [ ] Verify power and cadence appear in QZ during a ride
- [ ] Confirm no false-positive detection on unrelated XQ-prefixed devices (length check mitigates this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)