### PR TITLE
[codex] Skip invalid Health Connect HRV samples

### DIFF
--- a/src/android/src/HealthConnectHelper.kt
+++ b/src/android/src/HealthConnectHelper.kt
@@ -37,6 +37,7 @@ class HealthConnectHelper {
         private const val HEALTH_CONNECT_PROVIDER = "com.google.android.apps.healthdata"
         private const val PREFS_NAME = "qz_health_connect"
         private const val PREF_PERMISSION_PROMPT_PENDING = "permission_prompt_pending_v2"
+        private const val MIN_HRV_RMSSD_MILLIS = 1.0
 
         private var initialized = false
 
@@ -310,7 +311,7 @@ class HealthConnectHelper {
                         stepsCadenceSamples += StepsCadenceRecord.Sample(time = time, rate = cadence)
                     }
                 }
-                if (hasHrv && hrv > 0.0) {
+                if (hasHrv && hrv >= MIN_HRV_RMSSD_MILLIS) {
                     hrvRecords += HeartRateVariabilityRmssdRecord(
                         time = time,
                         zoneOffset = zoneOffset,

--- a/src/android/tests/org/cagnulen/qdomyoszwift/HealthConnectHelperTest.kt
+++ b/src/android/tests/org/cagnulen/qdomyoszwift/HealthConnectHelperTest.kt
@@ -328,6 +328,18 @@ class HealthConnectHelperTest {
     }
 
     @Test
+    fun `buildRecords omits HeartRateVariabilityRmssdRecord when hrv is below health connect minimum`() {
+        val samples = JSONArray().apply {
+            put(makeSample(1_000L, hrv = 0.9067155184426361))
+            put(makeSample(2_000L, hrv = 1.0))
+        }
+        val records = HealthConnectHelper.buildRecords(samples, "t", BIKE, null)
+        val hrvRecords = records.filterIsInstance<HeartRateVariabilityRmssdRecord>()
+        assertEquals(1, hrvRecords.size)
+        assertEquals(1.0, hrvRecords[0].heartRateVariabilityMillis, 0.001)
+    }
+
+    @Test
     fun `buildRecords omits HeartRateVariabilityRmssdRecord when hrv is 0`() {
         val samples = JSONArray().apply { put(makeSample(1_000L)) }
         val records = HealthConnectHelper.buildRecords(samples, "t", BIKE, null)


### PR DESCRIPTION
## What changed

- Skip Health Connect HRV RMSSD samples below 1.0 ms before creating `HeartRateVariabilityRmssdRecord`.
- Added a unit test covering the failing value seen in the user log (`0.9067155184426361`) while keeping `1.0` accepted.

## Why

Health Connect rejects `HeartRateVariabilityRmssdRecord` values below 1.0 ms. The log from the Gmail thread showed the workout write failing during record construction with:

```text
heartRateVariabilityMillis must not be less than 1.0, currently 0.9067155184426361
```

Because the exception is thrown before `insertRecords`, the whole Health Connect workout upload fails. Filtering invalid HRV samples lets the rest of the workout records be written.

## Validation

- `git diff --check`
- Android unit tests were not run per request (`Non compilare`).