### PR TITLE
Gate Sole bike detection when FTMS bike is disabled

### DIFF
--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -2777,7 +2777,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
             } else if ((b.name().toUpper().startsWith(QStringLiteral("LCB")) ||
                         b.name().toUpper().startsWith("LCR") ||
                         b.name().toUpper().startsWith(QStringLiteral("R92"))) &&
-                       !soleBike && filter) {
+                       ftms_bike.contains(QZSettings::default_ftms_bike) && !soleBike && filter) {
                 this->setLastBluetoothDevice(b);
                 this->stopDiscovery();
                 soleBike = new solebike(noWriteResistance, noHeartService, bikeResistanceOffset, bikeResistanceGain);

--- a/tst/Devices/devicetestdataindex.cpp
+++ b/tst/Devices/devicetestdataindex.cpp
@@ -1115,7 +1115,8 @@ void DeviceTestDataIndex::Initialize() {
     // Sole Bike
     RegisterNewDeviceTestData(DeviceIndex::SoleBike)
         ->expectDevice<solebike>()
-        ->acceptDeviceNames({"LCB", "R92"}, DeviceNameComparison::StartsWithIgnoreCase);
+        ->acceptDeviceNames({"LCB", "LCR", "R92"}, DeviceNameComparison::StartsWithIgnoreCase)
+        ->configureSettingsWith(QZSettings::ftms_bike, QZSettings::default_ftms_bike, "XX");
 
     // Sole Elliptical
     RegisterNewDeviceTestData(DeviceIndex::SoleElliptical)


### PR DESCRIPTION
### Motivation
- Ensure Sole bike devices (`LCB`/`LCR`/`R92`) are only matched when the FTMS bike setting is left at its default (i.e. FTMS bike is disabled) to avoid conflicting detection with generic FTMS bikes.

### Description
- Add a gating condition to the Sole bike discovery branch in `src/devices/bluetooth.cpp` so the branch requires `ftms_bike.contains(QZSettings::default_ftms_bike)` before instantiating `solebike`.
- Update the Sole bike test data in `tst/Devices/devicetestdataindex.cpp` to include the `LCR` prefix and to use `->configureSettingsWith(QZSettings::ftms_bike, QZSettings::default_ftms_bike, "XX")` so the test verifies the FTMS bike setting gates Sole bike detection.

### Testing
- Ran `git diff --check` and local repository checks which returned clean results.
- Attempted to run the build/test (`qmake -v`) but `qmake` was not available in the environment so full build and unit tests could not be executed; no test failures were observed from the static checks performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4010075ba083259caff6e399602d6e)