### PR TITLE
[codex] Recognize CARE SportsPlus rower

### DIFF
--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -2411,7 +2411,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 // SLOT(inclinationChanged(double)));
                 sportsPlusBike->deviceDiscovered(b);
                 this->signalBluetoothDeviceConnected(sportsPlusBike);
-            } else if (((b.name().toUpper().contains(QStringLiteral("CARE")) && b.name().length() >= 13) ||  // CARE968300122
+            } else if (((b.name().toUpper().contains(QStringLiteral("CARE")) && b.name().length() >= 12) ||  // CARE968300122, CARE10692135
                        (b.name().toUpper().startsWith(QStringLiteral("VMAX"))))
                        && !sportsPlusRower && filter) {
                 this->setLastBluetoothDevice(b);

--- a/tst/Devices/deviceindex.cpp
+++ b/tst/Devices/deviceindex.cpp
@@ -135,6 +135,7 @@ DEFINE_DEVICE(SoleF80Treadmill2, "Sole F80 Treadmill 2");
 DEFINE_DEVICE(SoleF85Treadmill, "Sole F85 Treadmill");
 DEFINE_DEVICE(SpiritTreadmill, "Spirit Treadmill");
 DEFINE_DEVICE(SportsPlusBike, "Sports Plus Bike");
+DEFINE_DEVICE(SportsPlusRower, "Sports Plus Rower");
 DEFINE_DEVICE(SportsTechBike, "Sports Tech Bike");
 DEFINE_DEVICE(StagesBike_Assioma_PowerSensorDisabled, "Stages Bike (Assioma / Power Sensor disabled)");
 DEFINE_DEVICE(StagesBike, "Stages Bike");

--- a/tst/Devices/deviceindex.h
+++ b/tst/Devices/deviceindex.h
@@ -140,6 +140,7 @@ public:
     DEFINE_DEVICE(SoleF85Treadmill, "Sole F85 Treadmill");
     DEFINE_DEVICE(SpiritTreadmill, "Spirit Treadmill");
     DEFINE_DEVICE(SportsPlusBike, "Sports Plus Bike");
+    DEFINE_DEVICE(SportsPlusRower, "Sports Plus Rower");
     DEFINE_DEVICE(SportsTechBike, "Sports Tech Bike");
     DEFINE_DEVICE(StagesBike_Assioma_PowerSensorDisabled, "Stages Bike (Assioma / Power Sensor disabled)");
     DEFINE_DEVICE(StagesBike, "Stages Bike");

--- a/tst/Devices/devicetestdataindex.cpp
+++ b/tst/Devices/devicetestdataindex.cpp
@@ -1156,6 +1156,11 @@ void DeviceTestDataIndex::Initialize() {
         ->expectDevice<sportsplusbike>()        
         ->acceptDeviceName("CARDIOFIT", DeviceNameComparison::StartsWithIgnoreCase);
 
+    // Sports Plus Rower
+    RegisterNewDeviceTestData(DeviceIndex::SportsPlusRower)
+        ->expectDevice<sportsplusrower>()
+        ->acceptDeviceName("CARE10692135", DeviceNameComparison::IgnoreCase);
+
     // Sports Tech Bike
     RegisterNewDeviceTestData(DeviceIndex::SportsTechBike)
         ->expectDevice<sportstechbike>()        


### PR DESCRIPTION
## Summary
- Recognize `CARE10692135` as a SportsPlus rower by allowing 12-character `CARE` rower names.
- Add device detection test metadata for the CARE SportsPlus rower case.

## Protocol check
The attached HCI snoop advertises `CARE10692135` and uses the existing SportsPlus rower protocol: GATT service `fff0`, write characteristic `fff2`, notify characteristic `fff1`, 5-byte `40 ...` init, periodic `20 01 ...` poll frames, and 12-byte notifications. No new device class is needed.

## Name conflict check
`CARE9040177` remains matched by the existing SportsPlus bike condition because it is exactly 11 characters. `CARE10692135` is 12 characters and now falls through to the SportsPlus rower condition. No broader earlier `CARE` pattern was found in `bluetooth.cpp`.

## Validation
- `git diff --check`
- Could not run the Qt test suite here because `qmake` is not available in PATH.