### PR TITLE
[codex] Increase WLT8828 resistance range

### DIFF
--- a/src/devices/ftmsbike/ftmsbike.cpp
+++ b/src/devices/ftmsbike/ftmsbike.cpp
@@ -2081,7 +2081,7 @@ void ftmsbike::deviceDiscovered(const QBluetoothDeviceInfo &device) {
         } else if(device.name().toUpper().startsWith(QStringLiteral("WLT8828"))) {
             qDebug() << QStringLiteral("WLT8828 found");
             WLT8828 = true;
-            max_resistance = 32;
+            max_resistance = 100;
             resistance_lvl_mode = true;
             ergModeSupported = false; // this bike doesn't have ERG mode natively
         } else if(device.name().toUpper().startsWith("VANRYSEL-HT")) {


### PR DESCRIPTION
## Summary
- Increase the hardcoded WLT8828/Ascend S2 max resistance from 32 to 100.
- Keeps the existing resistance-level ERG emulation path unchanged.

## Root Cause
WLT8828 was configured with `max_resistance = 32`, so ERG watt-to-resistance conversion could never request levels above the low 30s. This matches the reported cap around resistance 31.

Fixes #4766

## Validation
- `git diff --check`