### PR TITLE
[codex] Add NordicTrack Airglide LE support

### DIFF
--- a/src/devices/proformelliptical/proformelliptical.cpp
+++ b/src/devices/proformelliptical/proformelliptical.cpp
@@ -21,6 +21,9 @@ proformelliptical::proformelliptical(bool noWriteResistance, bool noHeartService
     refresh = new QTimer(this);
     this->noWriteResistance = noWriteResistance;
     this->noHeartService = noHeartService;
+    QSettings settings;
+    nordictrack_airglide_le =
+        settings.value(QZSettings::nordictrack_airglide_le, QZSettings::default_nordictrack_airglide_le).toBool();
     initDone = false;
     connect(refresh, &QTimer::timeout, this, &proformelliptical::update);
     refresh->start(200ms);
@@ -67,7 +70,62 @@ void proformelliptical::update() {
         QSettings settings;
         update_metrics(true, watts());
 
-        {
+        if (nordictrack_airglide_le) {
+            uint8_t noOpData1[] = {0xfe, 0x02, 0x17, 0x03};
+            uint8_t noOpData2[] = {0x00, 0x12, 0x02, 0x04, 0x02, 0x13, 0x06, 0x13, 0x02, 0x00,
+                                   0x0d, 0x3e, 0x94, 0x33, 0x00, 0x10, 0x40, 0x50, 0x00, 0x80};
+            uint8_t noOpData3[] = {0xff, 0x05, 0x00, 0x00, 0x00, 0x05, 0x52, 0x00, 0x00, 0x00,
+                                   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+            uint8_t noOpData4[] = {0xfe, 0x02, 0x19, 0x03};
+            uint8_t noOpData5[] = {0x00, 0x12, 0x02, 0x04, 0x02, 0x15, 0x06, 0x15, 0x02, 0x00,
+                                   0x0f, 0x80, 0x02, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+            uint8_t noOpData6[] = {0xff, 0x07, 0x00, 0x00, 0x00, 0x90, 0x00, 0x10, 0x8e, 0x00,
+                                   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+
+            switch (counterPoll) {
+            case 0:
+                writeCharacteristic(noOpData1, sizeof(noOpData1), QStringLiteral("noOp"));
+                break;
+            case 1:
+                writeCharacteristic(noOpData2, sizeof(noOpData2), QStringLiteral("noOp"));
+                break;
+            case 2:
+                writeCharacteristic(noOpData3, sizeof(noOpData3), QStringLiteral("noOp"));
+                if (requestResistance != -1) {
+                    if (requestResistance < 0)
+                        requestResistance = 0;
+                    if (requestResistance != currentResistance().value() && requestResistance >= 0 &&
+                        requestResistance <= 22) {
+                        emit debug(QStringLiteral("writing resistance ") + QString::number(requestResistance));
+                        forceResistance(requestResistance);
+                    }
+                    requestResistance = -1;
+                }
+                break;
+            case 3:
+                writeCharacteristic(noOpData4, sizeof(noOpData4), QStringLiteral("noOp"));
+                break;
+            case 4:
+                writeCharacteristic(noOpData5, sizeof(noOpData5), QStringLiteral("noOp"));
+                break;
+            case 5:
+                writeCharacteristic(noOpData6, sizeof(noOpData6), QStringLiteral("noOp"));
+                if (requestInclination != -100) {
+                    const double minInclination = -5.0;
+                    if (requestInclination != currentInclination().value() && requestInclination >= minInclination &&
+                        requestInclination <= 15) {
+                        emit debug(QStringLiteral("writing incline ") + QString::number(requestInclination));
+                        forceIncline(requestInclination);
+                    }
+                    requestInclination = -100;
+                }
+                break;
+            }
+            counterPoll++;
+            if (counterPoll > 5) {
+                counterPoll = 0;
+            }
+        } else {
             uint8_t noOpData1[] = {0xfe, 0x02, 0x17, 0x03};
             uint8_t noOpData2[] = {0x00, 0x12, 0x02, 0x04, 0x02, 0x13, 0x13, 0x13, 0x02, 0x00,
                                    0x0d, 0x3c, 0x9e, 0x31, 0x00, 0x00, 0x40, 0x40, 0x00, 0x80};
@@ -95,7 +153,6 @@ void proformelliptical::update() {
                     if (requestInclination != currentInclination().value() && requestInclination >= 0 &&
                         requestInclination <= 15) {
                         emit debug(QStringLiteral("writing incline ") + QString::number(requestInclination));
-                        // forceIncline(requestInclination);
                     }
                     requestInclination = -100;
                 }
@@ -140,8 +197,32 @@ void proformelliptical::update() {
     }
 }
 
+void proformelliptical::forceIncline(double requestIncline) {
+    const uint8_t res[] = {0xfe, 0x02, 0x0d, 0x02};
+    writeCharacteristic((uint8_t *)res, sizeof(res), QStringLiteral("incline"), false, false);
+
+    int16_t incValue = (int16_t)qRound(requestIncline * 100.0);
+    uint8_t low = (uint8_t)(incValue & 0xFF);
+    uint8_t high = (uint8_t)(((uint16_t)incValue >> 8) & 0xFF);
+    uint8_t incCmd[] = {0xff, 0x0d, 0x02, 0x04, 0x02, 0x09, 0x06, 0x09, 0x02, 0x01,
+                        0x02, low, high, 0x00, (uint8_t)(low + high + 0x14), 0x00, 0x00, 0x00, 0x00, 0x00};
+    writeCharacteristic(incCmd, sizeof(incCmd), QStringLiteral("incline_airglide"), false, true);
+}
+
+void proformelliptical::forceResistance(resistance_t requestResistance) {
+    const uint8_t res[] = {0xfe, 0x02, 0x0d, 0x02};
+    writeCharacteristic((uint8_t *)res, sizeof(res), QStringLiteral("resistance"), false, false);
+
+    uint16_t resValue = (uint16_t)((requestResistance * 454) - 1);
+    uint8_t low = (uint8_t)(resValue & 0xFF);
+    uint8_t high = (uint8_t)((resValue >> 8) & 0xFF);
+    uint8_t resCmd[] = {0xff, 0x0d, 0x02, 0x04, 0x02, 0x09, 0x06, 0x09, 0x02, 0x01,
+                        0x04, low, high, 0x00, (uint8_t)(low + high + 0x16), 0x00, 0x00, 0x00, 0x00, 0x00};
+    writeCharacteristic(resCmd, sizeof(resCmd), QStringLiteral("resistance_airglide"), false, true);
+}
+
 void proformelliptical::changeInclinationRequested(double grade, double percentage) {
-    if (percentage < 0)
+    if (!nordictrack_airglide_le && percentage < 0)
         percentage = 0;
     changeInclination(grade, percentage);
 }
@@ -276,6 +357,69 @@ void proformelliptical::characteristicChanged(const QLowEnergyCharacteristic &ch
 }
 
 void proformelliptical::btinit() {
+
+    if (nordictrack_airglide_le) {
+        uint8_t initData1[] = {0xfe, 0x02, 0x08, 0x02};
+        uint8_t initData2[] = {0xff, 0x08, 0x02, 0x04, 0x02, 0x04, 0x02, 0x04, 0x81, 0x87,
+                               0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+        uint8_t initData3[] = {0xff, 0x08, 0x02, 0x04, 0x02, 0x04, 0x06, 0x04, 0x80, 0x8a,
+                               0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+        uint8_t initData4[] = {0xff, 0x08, 0x02, 0x04, 0x02, 0x04, 0x06, 0x04, 0x88, 0x92,
+                               0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+        uint8_t initData5[] = {0xfe, 0x02, 0x0b, 0x02};
+        uint8_t initData6[] = {0xff, 0x0b, 0x02, 0x04, 0x02, 0x07, 0x02, 0x07, 0x82, 0x00,
+                               0x00, 0x8b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+        uint8_t initData7[] = {0xfe, 0x02, 0x0a, 0x02};
+        uint8_t initData8[] = {0xff, 0x0a, 0x02, 0x04, 0x02, 0x06, 0x02, 0x06, 0x84, 0x00,
+                               0x00, 0x8c, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+        uint8_t initData9[] = {0xff, 0x08, 0x02, 0x04, 0x02, 0x04, 0x02, 0x04, 0x95, 0x9b,
+                               0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+        uint8_t initData10[] = {0xfe, 0x02, 0x2c, 0x04};
+        uint8_t initData11[] = {0x00, 0x12, 0x02, 0x04, 0x02, 0x28, 0x06, 0x28, 0x90, 0x07,
+                                0x01, 0xa5, 0x88, 0x71, 0x58, 0x4d, 0x30, 0x21, 0x10, 0x05};
+        uint8_t initData12[] = {0x01, 0x12, 0x08, 0xf1, 0xf8, 0xfd, 0xe0, 0xe1, 0xe0, 0xe5,
+                                0xe8, 0x11, 0x18, 0x0d, 0x30, 0x21, 0x50, 0x45, 0x68, 0x91};
+        uint8_t initData13[] = {0xff, 0x08, 0xb8, 0xdd, 0xc0, 0xa0, 0x02, 0x00, 0x00, 0xd7,
+                                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+        uint8_t initData14[] = {0xfe, 0x02, 0x19, 0x03};
+        uint8_t initData15[] = {0x00, 0x12, 0x02, 0x04, 0x02, 0x15, 0x06, 0x15, 0x02, 0x0e,
+                                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+        uint8_t initData16[] = {0xff, 0x07, 0x00, 0x00, 0x00, 0x10, 0x01, 0x00, 0x3c, 0x00,
+                                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+        uint8_t initData17[] = {0xfe, 0x02, 0x17, 0x03};
+        uint8_t initData18[] = {0x00, 0x12, 0x02, 0x04, 0x02, 0x13, 0x06, 0x13, 0x02, 0x0c,
+                                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+        uint8_t initData19[] = {0xff, 0x05, 0x00, 0x80, 0x01, 0x00, 0xa8, 0x00, 0x00, 0x00,
+                                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+        uint8_t initData20[] = {0x00, 0x12, 0x02, 0x04, 0x02, 0x15, 0x06, 0x15, 0x02, 0x00,
+                                0x0f, 0x00, 0x10, 0x00, 0xd8, 0x1c, 0x4c, 0x00, 0x00, 0xe0};
+        uint8_t initData21[] = {0xff, 0x07, 0x00, 0x00, 0x00, 0x10, 0x00, 0x08, 0x74, 0x00,
+                                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+        uint8_t initData22[] = {0xfe, 0x02, 0x10, 0x02};
+        uint8_t initData23[] = {0xff, 0x10, 0x02, 0x04, 0x02, 0x0c, 0x06, 0x0c, 0x02, 0x04,
+                                0x00, 0x00, 0x00, 0x02, 0xe8, 0x1c, 0x00, 0x1e, 0x00, 0x00};
+
+        uint8_t *initFrames[] = {initData1,  initData2,  initData1,  initData3,  initData1,  initData4,
+                                 initData5,  initData6,  initData7,  initData8,  initData1,  initData9,
+                                 initData10, initData11, initData12, initData13, initData14, initData15,
+                                 initData16, initData17, initData18, initData19, initData14, initData20,
+                                 initData21, initData22, initData23, initData14, initData15, initData16};
+        uint8_t initFrameSizes[] = {sizeof(initData1),  sizeof(initData2),  sizeof(initData1),  sizeof(initData3),
+                                    sizeof(initData1),  sizeof(initData4),  sizeof(initData5),  sizeof(initData6),
+                                    sizeof(initData7),  sizeof(initData8),  sizeof(initData1),  sizeof(initData9),
+                                    sizeof(initData10), sizeof(initData11), sizeof(initData12), sizeof(initData13),
+                                    sizeof(initData14), sizeof(initData15), sizeof(initData16), sizeof(initData17),
+                                    sizeof(initData18), sizeof(initData19), sizeof(initData14), sizeof(initData20),
+                                    sizeof(initData21), sizeof(initData22), sizeof(initData23), sizeof(initData14),
+                                    sizeof(initData15), sizeof(initData16)};
+
+        for (uint8_t i = 0; i < sizeof(initFrameSizes); i++) {
+            writeCharacteristic(initFrames[i], initFrameSizes[i], QStringLiteral("init"), false, false);
+            QThread::msleep(400);
+        }
+        initDone = true;
+        return;
+    }
 
     {
         uint8_t initData1[] = {0xfe, 0x02, 0x08, 0x02};

--- a/src/devices/proformelliptical/proformelliptical.h
+++ b/src/devices/proformelliptical/proformelliptical.h
@@ -45,6 +45,7 @@ class proformelliptical : public elliptical {
     void btinit();
     void writeCharacteristic(uint8_t *data, uint8_t data_len, const QString &info, bool disable_log = false,
                              bool wait_for_response = false);
+    void forceResistance(resistance_t requestResistance);
     void startDiscover();
     void sendPoll();
     void forceIncline(double incline);
@@ -69,6 +70,7 @@ class proformelliptical : public elliptical {
 
     bool noWriteResistance = false;
     bool noHeartService = false;
+    bool nordictrack_airglide_le = false;
 
 #ifdef Q_OS_IOS
     lockscreen *h = 0;

--- a/src/qzsettings.cpp
+++ b/src/qzsettings.cpp
@@ -1112,6 +1112,7 @@ const QString QZSettings::proform_treadmill_cst_505_pftl59420_0 = QStringLiteral
 const QString QZSettings::proform_treadmill_105_cst = QStringLiteral("proform_treadmill_105_cst");
 const QString QZSettings::applewatch_as_treadmill_speed = QStringLiteral("applewatch_as_treadmill_speed");
 const QString QZSettings::horizon_treadmill_omega_z = QStringLiteral("horizon_treadmill_omega_z");
+const QString QZSettings::nordictrack_airglide_le = QStringLiteral("nordictrack_airglide_le");
 
 const QString QZSettings::shortcuts_enabled = QStringLiteral("shortcuts_enabled");
 const QString QZSettings::shortcut_speed_plus = QStringLiteral("shortcut_speed_plus");
@@ -1245,7 +1246,7 @@ const QString QZSettings::default_shortcut_start_stop = QStringLiteral("");
 const QString QZSettings::shortcut_stop = QStringLiteral("shortcut_stop");
 const QString QZSettings::default_shortcut_stop = QStringLiteral("");
 
-const uint32_t allSettingsCount = 972;
+const uint32_t allSettingsCount = 973;
 
 QVariant allSettings[allSettingsCount][2] = {
     {QZSettings::cryptoKeySettingsProfiles, QZSettings::default_cryptoKeySettingsProfiles},
@@ -2242,6 +2243,7 @@ QVariant allSettings[allSettingsCount][2] = {
     {QZSettings::proform_treadmill_105_cst, QZSettings::default_proform_treadmill_105_cst},
     {QZSettings::applewatch_as_treadmill_speed, QZSettings::default_applewatch_as_treadmill_speed},
     {QZSettings::horizon_treadmill_omega_z, QZSettings::default_horizon_treadmill_omega_z},
+    {QZSettings::nordictrack_airglide_le, QZSettings::default_nordictrack_airglide_le},
 };
 
 void QZSettings::qDebugAllSettings(bool showDefaults) {

--- a/src/qzsettings.h
+++ b/src/qzsettings.h
@@ -3214,6 +3214,9 @@ class QZSettings {
     static const QString horizon_treadmill_omega_z;
     static constexpr bool default_horizon_treadmill_omega_z = false;
 
+    static const QString nordictrack_airglide_le;
+    static constexpr bool default_nordictrack_airglide_le = false;
+
     /**
      * @brief Write the QSettings values using the constants from this namespace.
      * @param showDefaults Optionally indicates if the default should be shown with the key.

--- a/src/settings-catalog.json
+++ b/src/settings-catalog.json
@@ -2,7 +2,7 @@
   "$schema": "https://qdomyos-zwift.local/settings-catalog.schema.json",
   "schemaVersion": 1,
   "format": "qdomyos-zwift-settings-catalog",
-  "settingCount": 960,
+  "settingCount": 961,
   "pages": [
     {
       "key": "page_custom_gear_table",
@@ -13648,6 +13648,19 @@
       "name": "Sound on Segment Change",
       "description": "Play a short sound when a training program starts a new row. Default: disabled.",
       "parent": "Training Program Options",
+      "type": "boolean",
+      "qmlType": "bool",
+      "control": "switch",
+      "visible": true,
+      "defaultValue": false,
+      "defaultExpression": "false",
+      "options": null
+    },
+    {
+      "key": "nordictrack_airglide_le",
+      "name": "NordicTrack Airglide LE",
+      "description": "Use NordicTrack Airglide LE elliptical resistance and incline control frames. Default: disabled.",
+      "parent": "Proform/Nordictrack Elliptical Options",
       "type": "boolean",
       "qmlType": "bool",
       "control": "switch",

--- a/src/settings.qml
+++ b/src/settings.qml
@@ -1706,6 +1706,7 @@ import AndroidStatusBar 1.0
             property bool tile_pace_color_enabled: true                        
             property bool treadmill_force_running_activity: false
             property bool proform_treadmill_105_cst: false
+            property bool nordictrack_airglide_le: false
         }
 
 
@@ -11749,6 +11750,19 @@ import AndroidStatusBar 1.0
                                 Layout.alignment: Qt.AlignLeft | Qt.AlignTop
                                 Layout.fillWidth: true
                                 onClicked: { settings.nordictrack_se7i = checked; window.settings_restart_to_apply = true; }
+                            }
+                            IndicatorOnlySwitch {
+                                text: qsTr("NordicTrack Airglide LE")
+                                spacing: 0
+                                bottomPadding: 0
+                                topPadding: 0
+                                rightPadding: 0
+                                leftPadding: 0
+                                clip: false
+                                checked: settings.nordictrack_airglide_le
+                                Layout.alignment: Qt.AlignLeft | Qt.AlignTop
+                                Layout.fillWidth: true
+                                onClicked: { settings.nordictrack_airglide_le = checked; window.settings_restart_to_apply = true; }
                             }
                             RowLayout {
                                 spacing: 10


### PR DESCRIPTION
## Summary
- add a NordicTrack Airglide LE elliptical setting
- use Airglide LE init and no-op frames captured from the btsnoop log
- add Airglide LE resistance and incline control frames, including negative incline support

## Issue
Refs #4771

## Validation
- inspected issue #4771 btsnoop_hci.log with tshark
- verified control frame formulas against captured resistance and incline packets
- ran git diff --check
- compiled proformelliptical.o with qmake-generated Makefile

Note: full make still stops on the existing missing smtpclient/src/SmtpMime dependency in this worktree.