### PR TITLE
[codex] Add Adidas horizon treadmill incline limits

### DIFF
--- a/src/devices/horizontreadmill/horizontreadmill.cpp
+++ b/src/devices/horizontreadmill/horizontreadmill.cpp
@@ -2689,6 +2689,10 @@ void horizontreadmill::deviceDiscovered(const QBluetoothDeviceInfo &device) {
             sole_tt8_treadmill = true;
             minInclination = -6.0;
             qDebug() << QStringLiteral("SOLE TT8 TREADMILL workaround ON!");
+        } else if (device.name().toUpper().startsWith(QStringLiteral("ADIDAS"))) {
+            minInclination = -6.0;
+            maxInclination = 40.0;
+            qDebug() << QStringLiteral("ADIDAS TREADMILL workaround ON!");
         } else if (device.name().toUpper().startsWith(QStringLiteral("S77"))) {
             sole_s77_treadmill = true;
             qDebug() << QStringLiteral("SOLE S77 TREADMILL workaround ON!");


### PR DESCRIPTION
## Summary

Adds a Horizon treadmill special case for ADIDAS devices.

## Details

- Detects ADIDAS names inside `horizontreadmill::deviceDiscovered()`.
- Sets ADIDAS inclination limits to `-6.0` minimum and `40.0` maximum.
- Leaves Bluetooth routing unchanged to avoid conflicts with the existing ADIDAS patterns.

## Validation

- Ran `git diff --check`.
- Did not run a full Qt build for this small device-limit change.
