### PR TITLE
[codex] Fix Adidas treadmill incline override mapping

### DIFF
--- a/src/devices/horizontreadmill/horizontreadmill.cpp
+++ b/src/devices/horizontreadmill/horizontreadmill.cpp
@@ -987,7 +987,7 @@ void horizontreadmill::update() {
             requestSpeed = -1;
         }
         if (requestInclination != -100) {
-            if (!FS_TREADMILL || !areInclinationSettingsDefault()) {
+            if (!adidas_treadmill && (!FS_TREADMILL || !areInclinationSettingsDefault())) {
                 requestInclination = treadmillInclinationOverrideReverse(requestInclination);
             }
 
@@ -2690,6 +2690,7 @@ void horizontreadmill::deviceDiscovered(const QBluetoothDeviceInfo &device) {
             minInclination = -6.0;
             qDebug() << QStringLiteral("SOLE TT8 TREADMILL workaround ON!");
         } else if (device.name().toUpper().startsWith(QStringLiteral("ADIDAS"))) {
+            adidas_treadmill = true;
             minInclination = -6.0;
             maxInclination = 40.0;
             qDebug() << QStringLiteral("ADIDAS TREADMILL workaround ON!");

--- a/src/devices/horizontreadmill/horizontreadmill.cpp
+++ b/src/devices/horizontreadmill/horizontreadmill.cpp
@@ -2689,6 +2689,10 @@ void horizontreadmill::deviceDiscovered(const QBluetoothDeviceInfo &device) {
             sole_tt8_treadmill = true;
             minInclination = -6.0;
             qDebug() << QStringLiteral("SOLE TT8 TREADMILL workaround ON!");
+        } else if (device.name().toUpper().startsWith(QStringLiteral("ADIDAS"))) {
+            minInclination = -6.0;
+            maxInclination = 40.0;
+            qDebug() << QStringLiteral("ADIDAS TREADMILL workaround ON!");
         } else if (device.name().toUpper().startsWith(QStringLiteral("S77"))) {
             sole_s77_treadmill = true;
             qDebug() << QStringLiteral("SOLE S77 TREADMILL workaround ON!");

--- a/src/devices/horizontreadmill/horizontreadmill.h
+++ b/src/devices/horizontreadmill/horizontreadmill.h
@@ -103,6 +103,7 @@ class horizontreadmill : public treadmill {
     bool trx3500_treadmill = false;
     bool sole_f85_treadmill = false;
     bool sole_f89_treadmill = false;
+    bool adidas_treadmill = false;
     bool schwinn_810_treadmill = false;
     bool yesoul_treadmill = false;
     bool technogymrun = false;


### PR DESCRIPTION
## Summary

Fixes ADIDAS Horizon treadmill inclination requests above 15%.

## Root Cause

The ADIDAS special case was detected and set `maxInclination = 40.0`, but `horizontreadmill::update()` still passed requests through `treadmillInclinationOverrideReverse()`. That helper only maps the 0..15 inclination override table, so a 40% request was converted back to 15% before sending.

## Details

- Adds an `adidas_treadmill` flag.
- Skips `treadmillInclinationOverrideReverse()` for ADIDAS treadmills so requests up to 40 remain unchanged.
- Keeps the Bluetooth routing unchanged.

## Validation

- Inspected the provided debug log:
  - `ADIDAS TREADMILL workaround ON!` confirms the special case was active.
  - `changeInclination 40` followed by `requestInclination= 15` showed the reverse override mapping was the failing step.
- Ran `git diff --check`.
