### PR TITLE
[codex] Add FTMS treadmill inclination for virtual bikes

### DIFF
--- a/src/characteristics/characteristicnotifier2acd.cpp
+++ b/src/characteristics/characteristicnotifier2acd.cpp
@@ -8,7 +8,7 @@ CharacteristicNotifier2ACD::CharacteristicNotifier2ACD(bluetoothdevice *Bike, QO
 
 int CharacteristicNotifier2ACD::notify(QByteArray &value) {
     BLUETOOTH_TYPE dt = Bike->deviceType();
-    if (dt == TREADMILL || dt == ELLIPTICAL) {
+    if (dt == TREADMILL || dt == ELLIPTICAL || dt == BIKE) {
         QSettings settings;
         bool bike_cadence_sensor = settings.value(QZSettings::bike_cadence_sensor, QZSettings::default_bike_cadence_sensor).toBool();
 
@@ -68,7 +68,7 @@ int CharacteristicNotifier2ACD::notify(QByteArray &value) {
         uint16_t normalizeIncline = 0;
 
         bool real_inclination_to_virtual_treamill_bridge = settings.value(QZSettings::real_inclination_to_virtual_treamill_bridge, QZSettings::default_real_inclination_to_virtual_treamill_bridge).toBool();
-        double inclination = ((treadmill *)Bike)->currentInclination().value();
+        double inclination = Bike->currentInclination().value();
         if(real_inclination_to_virtual_treamill_bridge) {
             double offset = settings.value(QZSettings::zwift_inclination_offset,
                                            QZSettings::default_zwift_inclination_offset).toDouble();
@@ -78,7 +78,7 @@ int CharacteristicNotifier2ACD::notify(QByteArray &value) {
             inclination /= gain;
         }
 
-        if (dt == TREADMILL)
+        if (dt == TREADMILL || dt == BIKE)
             normalizeIncline = (uint32_t)qRound(inclination * 10);
         a = (normalizeIncline >> 8) & 0XFF;
         b = normalizeIncline & 0XFF;
@@ -86,7 +86,7 @@ int CharacteristicNotifier2ACD::notify(QByteArray &value) {
         inclineBytes.append(b);
         inclineBytes.append(a);
         double ramp = 0;
-        if (dt == TREADMILL)
+        if (dt == TREADMILL || dt == BIKE)
             ramp = qRadiansToDegrees(qAtan(inclination / 100));
         int16_t normalizeRamp = (int16_t)qRound(ramp * 10);
         a = (normalizeRamp >> 8) & 0XFF;

--- a/src/devices/ftmsbike/ftmsbike.cpp
+++ b/src/devices/ftmsbike/ftmsbike.cpp
@@ -781,7 +781,196 @@ void ftmsbike::characteristicChanged(const QLowEnergyCharacteristic &characteris
         setGears(gear);
     }
 
-    if (characteristic.uuid() == QBluetoothUuid((quint16)0x2AD2)) {
+    if (characteristic.uuid() == QBluetoothUuid((quint16)0x2ACD)) {
+        union flags {
+            struct {
+                uint16_t moreData : 1;
+                uint16_t avgSpeed : 1;
+                uint16_t totDistance : 1;
+                uint16_t inclinationAndRampAngle : 1;
+                uint16_t positiveElevationGain : 1;
+                uint16_t instantPace : 1;
+                uint16_t avgPace : 1;
+                uint16_t expEnergy : 1;
+                uint16_t heartRate : 1;
+                uint16_t metabolicEq : 1;
+                uint16_t elapsedTime : 1;
+                uint16_t remainingTime : 1;
+                uint16_t forceOnBeltAndPowerOutput : 1;
+                uint16_t spare : 3;
+            };
+
+            uint16_t word_flags;
+        };
+
+        if (newValue.length() < 2) {
+            qDebug() << "Invalid FTMS 0x2ACD packet length" << newValue.length();
+            return;
+        }
+
+        flags Flags;
+        int index = 0;
+        Flags.word_flags = (((uint16_t)((uint8_t)newValue.at(1))) << 8) |
+                           ((uint16_t)((uint8_t)newValue.at(0)));
+        index += 2;
+
+        auto ensureTreadmillBytesAvailable = [&](int bytesNeeded, const QString &fieldName) {
+            if (newValue.length() < index + bytesNeeded) {
+                qDebug() << "Invalid FTMS 0x2ACD packet: missing" << fieldName
+                         << "need" << bytesNeeded << "bytes at index" << index
+                         << "length" << newValue.length() << newValue.toHex(' ');
+                return false;
+            }
+            return true;
+        };
+
+        if (!Flags.moreData) {
+            if (!ensureTreadmillBytesAvailable(2, QStringLiteral("speed")))
+                return;
+            double treadmillSpeed = ((double)(((uint16_t)((uint8_t)newValue.at(index + 1)) << 8) |
+                                      (uint16_t)((uint8_t)newValue.at(index)))) /
+                                    100.0;
+            index += 2;
+            emit debug(QStringLiteral("FTMS Treadmill Data Speed: ") + QString::number(treadmillSpeed));
+        }
+
+        if (Flags.avgSpeed) {
+            if (!ensureTreadmillBytesAvailable(2, QStringLiteral("average speed")))
+                return;
+
+            double treadmillAverageSpeed = ((double)(((uint16_t)((uint8_t)newValue.at(index + 1)) << 8) |
+                                             (uint16_t)((uint8_t)newValue.at(index)))) /
+                                           100.0;
+            index += 2;
+            emit debug(QStringLiteral("FTMS Treadmill Data Average Speed: ") +
+                       QString::number(treadmillAverageSpeed));
+        }
+
+        if (Flags.totDistance) {
+            if (!ensureTreadmillBytesAvailable(3, QStringLiteral("total distance")))
+                return;
+
+            double treadmillDistance = ((double)((((uint32_t)((uint8_t)newValue.at(index + 2)) << 16) |
+                                                  (uint32_t)((uint8_t)newValue.at(index + 1)) << 8) |
+                                                 (uint32_t)((uint8_t)newValue.at(index)))) /
+                                       1000.0;
+            index += 3;
+            emit debug(QStringLiteral("FTMS Treadmill Data Distance: ") + QString::number(treadmillDistance));
+        }
+
+        if (Flags.inclinationAndRampAngle) {
+            if (!ensureTreadmillBytesAvailable(4, QStringLiteral("inclination and ramp angle")))
+                return;
+
+            int16_t inclination = ((int16_t)(((uint16_t)((uint8_t)newValue.at(index + 1)) << 8) |
+                                   (uint16_t)((uint8_t)newValue.at(index))));
+            Inclination = ((double)inclination) / 10.0;
+            index += 2;
+            int16_t rampAngle = ((int16_t)(((uint16_t)((uint8_t)newValue.at(index + 1)) << 8) |
+                                 (uint16_t)((uint8_t)newValue.at(index))));
+            double treadmillRampAngle = ((double)rampAngle) / 10.0;
+            index += 2;
+            emit debug(QStringLiteral("Current Inclination: ") + QString::number(Inclination.value()));
+            emit debug(QStringLiteral("FTMS Treadmill Data Ramp Angle: ") + QString::number(treadmillRampAngle));
+        }
+
+        if (Flags.positiveElevationGain) {
+            if (!ensureTreadmillBytesAvailable(4, QStringLiteral("elevation gain")))
+                return;
+            uint16_t positiveElevationGain = (((uint16_t)((uint8_t)newValue.at(index + 1)) << 8) |
+                                              (uint16_t)((uint8_t)newValue.at(index)));
+            uint16_t negativeElevationGain = (((uint16_t)((uint8_t)newValue.at(index + 3)) << 8) |
+                                              (uint16_t)((uint8_t)newValue.at(index + 2)));
+            index += 4;
+            emit debug(QStringLiteral("FTMS Treadmill Data Positive Elevation Gain: ") +
+                       QString::number(positiveElevationGain));
+            emit debug(QStringLiteral("FTMS Treadmill Data Negative Elevation Gain: ") +
+                       QString::number(negativeElevationGain));
+        }
+
+        if (Flags.instantPace) {
+            if (!ensureTreadmillBytesAvailable(2, QStringLiteral("instant pace")))
+                return;
+            uint16_t instantPace = (((uint16_t)((uint8_t)newValue.at(index + 1)) << 8) |
+                                    (uint16_t)((uint8_t)newValue.at(index)));
+            index += 2;
+            emit debug(QStringLiteral("FTMS Treadmill Data Instant Pace: ") + QString::number(instantPace));
+        }
+
+        if (Flags.avgPace) {
+            if (!ensureTreadmillBytesAvailable(2, QStringLiteral("average pace")))
+                return;
+            uint16_t averagePace = (((uint16_t)((uint8_t)newValue.at(index + 1)) << 8) |
+                                    (uint16_t)((uint8_t)newValue.at(index)));
+            index += 2;
+            emit debug(QStringLiteral("FTMS Treadmill Data Average Pace: ") + QString::number(averagePace));
+        }
+
+        if (Flags.expEnergy) {
+            if (!ensureTreadmillBytesAvailable(5, QStringLiteral("expended energy")))
+                return;
+            uint16_t expendedEnergy = (((uint16_t)((uint8_t)newValue.at(index + 1)) << 8) |
+                                       (uint16_t)((uint8_t)newValue.at(index)));
+            uint16_t energyPerHour = (((uint16_t)((uint8_t)newValue.at(index + 3)) << 8) |
+                                      (uint16_t)((uint8_t)newValue.at(index + 2)));
+            uint8_t energyPerMinute = (uint8_t)newValue.at(index + 4);
+            index += 5;
+            emit debug(QStringLiteral("FTMS Treadmill Data Expended Energy: ") +
+                       QString::number(expendedEnergy));
+            emit debug(QStringLiteral("FTMS Treadmill Data Energy Per Hour: ") +
+                       QString::number(energyPerHour));
+            emit debug(QStringLiteral("FTMS Treadmill Data Energy Per Minute: ") +
+                       QString::number(energyPerMinute));
+        }
+
+        if (Flags.heartRate) {
+            if (!ensureTreadmillBytesAvailable(1, QStringLiteral("heart rate")))
+                return;
+
+            uint8_t treadmillHeartRate = (uint8_t)newValue.at(index);
+            index += 1;
+            emit debug(QStringLiteral("FTMS Treadmill Data Heart Rate: ") + QString::number(treadmillHeartRate));
+        }
+
+        if (Flags.metabolicEq) {
+            if (!ensureTreadmillBytesAvailable(1, QStringLiteral("metabolic equivalent")))
+                return;
+            double metabolicEquivalent = ((double)((uint8_t)newValue.at(index))) / 10.0;
+            index += 1;
+            emit debug(QStringLiteral("FTMS Treadmill Data Metabolic Equivalent: ") +
+                       QString::number(metabolicEquivalent));
+        }
+
+        if (Flags.elapsedTime) {
+            if (!ensureTreadmillBytesAvailable(2, QStringLiteral("elapsed time")))
+                return;
+            uint16_t elapsedTime = (((uint16_t)((uint8_t)newValue.at(index + 1)) << 8) |
+                                    (uint16_t)((uint8_t)newValue.at(index)));
+            index += 2;
+            emit debug(QStringLiteral("FTMS Treadmill Data Elapsed Time: ") + QString::number(elapsedTime));
+        }
+
+        if (Flags.remainingTime) {
+            if (!ensureTreadmillBytesAvailable(2, QStringLiteral("remaining time")))
+                return;
+            uint16_t remainingTime = (((uint16_t)((uint8_t)newValue.at(index + 1)) << 8) |
+                                      (uint16_t)((uint8_t)newValue.at(index)));
+            index += 2;
+            emit debug(QStringLiteral("FTMS Treadmill Data Remaining Time: ") + QString::number(remainingTime));
+        }
+
+        if (Flags.forceOnBeltAndPowerOutput) {
+            if (!ensureTreadmillBytesAvailable(4, QStringLiteral("force on belt and power output")))
+                return;
+            int16_t forceOnBelt = ((int16_t)(((uint16_t)((uint8_t)newValue.at(index + 1)) << 8) |
+                                  (uint16_t)((uint8_t)newValue.at(index))));
+            int16_t powerOutput = ((int16_t)(((uint16_t)((uint8_t)newValue.at(index + 3)) << 8) |
+                                  (uint16_t)((uint8_t)newValue.at(index + 2))));
+            index += 4;
+            emit debug(QStringLiteral("FTMS Treadmill Data Force On Belt: ") + QString::number(forceOnBelt));
+            emit debug(QStringLiteral("FTMS Treadmill Data Power Output: ") + QString::number(powerOutput));
+        }
+    } else if (characteristic.uuid() == QBluetoothUuid((quint16)0x2AD2)) {
         union flags {
             struct {
                 uint16_t moreData : 1;

--- a/src/qfit.cpp
+++ b/src/qfit.cpp
@@ -872,6 +872,9 @@ void qfit::save(const QString &filename, QList<SessionLine> session, BLUETOOTH_T
         newRecord.SetPower(sl.watt);
         newRecord.SetResistance(sl.resistance);
         newRecord.SetCalories(sl.calories);
+        if (type == BIKE || type == TREADMILL || type == ELLIPTICAL) {
+            newRecord.SetGrade(sl.inclination);
+        }
         if (type == TREADMILL) {
             newRecord.SetStepLength(sl.instantaneousStrideLengthCM * 10);
             newRecord.SetVerticalOscillation(sl.verticalOscillationMM);

--- a/src/qfit.cpp
+++ b/src/qfit.cpp
@@ -1277,6 +1277,9 @@ class Listener : public fit::FileIdMesgListener,
             s.watt = record.GetPower();
             s.resistance = record.GetResistance();
             s.calories = record.GetCalories();
+            if (record.IsGradeValid()) {
+                s.inclination = record.GetGrade();
+            }
             if (record.IsCoreTemperatureValid()) {
                 s.coreTemp = record.GetCoreTemperature();
             }

--- a/src/virtualdevices/virtualbike.cpp
+++ b/src/virtualdevices/virtualbike.cpp
@@ -49,6 +49,7 @@ virtualbike::virtualbike(bluetoothdevice *t, bool noWriteResistance, bool noHear
     }
     if (!settings.value(QZSettings::virtual_device_bluetooth, QZSettings::default_virtual_device_bluetooth).toBool())
         return;
+    notif2ACD = new CharacteristicNotifier2ACD(Bike, this);
     notif2AD2 = new CharacteristicNotifier2AD2(Bike, this);
     notif2AD9 = new CharacteristicNotifier2AD9(Bike, this);
     notif2A63 = new CharacteristicNotifier2A63(Bike, this);
@@ -180,6 +181,11 @@ virtualbike::virtualbike(bluetoothdevice *t, bool noWriteResistance, bool noHear
                                                                  descriptor);
                     charDataFIT4.addDescriptor(clientConfig4);
 
+                    QLowEnergyCharacteristicData charDataFIT4Treadmill;
+                    charDataFIT4Treadmill.setUuid((QBluetoothUuid::CharacteristicType)0x2ACD); // treadmill data
+                    charDataFIT4Treadmill.setProperties(QLowEnergyCharacteristic::Notify | QLowEnergyCharacteristic::Read);
+                    charDataFIT4Treadmill.addDescriptor(clientConfig4);
+
                     QLowEnergyCharacteristicData charDataFIT5;
                     charDataFIT5.setUuid((QBluetoothUuid::CharacteristicType)0x2ADA); // Fitness Machine status
                     charDataFIT5.setProperties(QLowEnergyCharacteristic::Notify);
@@ -210,6 +216,7 @@ virtualbike::virtualbike(bluetoothdevice *t, bool noWriteResistance, bool noHear
                     serviceDataFIT.addCharacteristic(charDataFIT2);
                     serviceDataFIT.addCharacteristic(charDataFIT3);
                     serviceDataFIT.addCharacteristic(charDataFIT4);
+                    serviceDataFIT.addCharacteristic(charDataFIT4Treadmill);
                     serviceDataFIT.addCharacteristic(charDataFIT5);
                     serviceDataFIT.addCharacteristic(charDataFIT6);
 
@@ -1550,6 +1557,14 @@ void virtualbike::bikeProvider() {
                         return;
                     }
                     writeCharacteristic(serviceFIT, characteristic, value);
+
+                    value.clear();
+                    if (notif2ACD->notify(value) == CN_OK) {
+                        QLowEnergyCharacteristic treadmillCharacteristic =
+                            serviceFIT->characteristic((QBluetoothUuid::CharacteristicType)0x2ACD);
+                        Q_ASSERT(treadmillCharacteristic.isValid());
+                        writeCharacteristic(serviceFIT, treadmillCharacteristic, value);
+                    }
 
                     if(zwift_play_emulator) {
                         QLowEnergyCharacteristic characteristic1 =

--- a/src/virtualdevices/virtualbike.h
+++ b/src/virtualdevices/virtualbike.h
@@ -75,6 +75,7 @@ class virtualbike : public virtualdevice {
     bluetoothdevice *Bike;
     CharacteristicWriteProcessor2AD9 *writeP2AD9 = 0;
     CharacteristicWriteProcessor0003 *writeP0003 = 0;
+    CharacteristicNotifier2ACD *notif2ACD = 0;
     CharacteristicNotifier2AD2 *notif2AD2 = 0;
     CharacteristicNotifier2AD9 *notif2AD9 = 0;
     CharacteristicNotifier2A63 *notif2A63 = 0;


### PR DESCRIPTION
## Summary
- advertise FTMS Treadmill Data (0x2ACD) from virtual bike alongside Indoor Bike Data (0x2AD2)
- allow the 0x2ACD notifier to publish bike currentInclination() as treadmill inclination/ramp angle
- parse FTMS Treadmill Data in ftmsbike only to consume inclination, while skipping other fields without using them as bike metrics

## Validation
- qmake
- git diff --check
- make -f src/Makefile.qdomyos-zwift-lib characteristicnotifier2acd.o ftmsbike.o virtualbike.o
- make -f src/Makefile.qdomyos-zwift-lib ftmsbike.o after parser adjustment

Note: full make was started after submodule init and reached unrelated project-wide compilation, then was interrupted after the requested ftmsbike parser adjustment.