### PR TITLE
Xiaomi Content Helper without heart changes

### DIFF
--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -2,3 +2,4 @@ when you add a setting remember:
 - you have to add always as the last settings declared in the settings.qml
 - if you have to add a setting also on another qml file, you need also to declare it there always putting as the last one
 - in the qzsettings.cpp there is a allsettingscount that must be updated if you add a setting
+- in settings-catalog.json the "settingCount" field must match the number of entries in the "settings" array (the pre-commit hook updates it automatically, but verify if committing without the hook)

--- a/src/GPXList.qml
+++ b/src/GPXList.qml
@@ -13,20 +13,35 @@ ColumnLayout {
     signal trainprogram_open_clicked(url name)
     signal trainprogram_open_other_folder(url name)
     signal trainprogram_preview(url name)
+    property var selectedFileUrl: ""
+
+    Connections {
+        target: rootItem
+        function onAndroidDocumentPicked(kind, localUrl) {
+            if (kind === "gpx") {
+                trainprogram_open_clicked(localUrl)
+            }
+        }
+    }
+
     Loader {
         id: fileDialogLoader
         active: false
         sourceComponent: Component {
             FileDialog {
+                id: fileDialog
                 title: "Please choose a file"
                 folder: shortcuts.home
+                nameFilters: ["GPX files (*.gpx *.GPX)", "All files (*)"]
                 visible: true
                 onAccepted: {
-                    console.log("You chose: " + fileUrl)
+                    var chosenFile = fileDialog.fileUrl || fileDialog.file || (fileDialog.fileUrls && fileDialog.fileUrls.length > 0 ? fileDialog.fileUrls[0] : "")
+                    console.log("You chose: " + chosenFile)
+                    selectedFileUrl = chosenFile
                     if(OS_VERSION === "Android") {
-                        trainprogram_open_other_folder(fileUrl)
+                        trainprogram_open_other_folder(chosenFile)
                     } else {
-                        trainprogram_open_clicked(fileUrl)
+                        trainprogram_open_clicked(chosenFile)
                     }
                     close()
                     // Destroy and recreate the dialog for next use
@@ -71,7 +86,7 @@ ColumnLayout {
                            filter+= "[%1%2]".arg(text[i].toUpperCase()).arg(text[i].toLowerCase())
                         filter+="*"
                         print(filter)
-                        folderModel.nameFilters = [filter + ".gpx"]
+                        folderModel.nameFilters = [filter + ".gpx", filter + ".GPX"]
                     }
                     id: filterField
                     onTextChanged: updateFilter()
@@ -95,7 +110,7 @@ ColumnLayout {
                 id: list
                 FolderListModel {
                     id: folderModel
-                    nameFilters: ["*.gpx"]
+                    nameFilters: ["*.gpx", "*.GPX"]
                     folder: "file://" + rootItem.getWritableAppDir() + 'gpx'
                     showDotAndDotDot: false
                     showDirs: true
@@ -273,8 +288,11 @@ ColumnLayout {
         Layout.alignment: Qt.AlignCenter | Qt.AlignVCenter
         onClicked: {
             console.log("folder is " + rootItem.getWritableAppDir() + 'gpx')
-            // Create a fresh FileDialog instance
-            fileDialogLoader.active = true
+            if (Qt.platform.os === "android") {
+                rootItem.openAndroidDocumentPicker("gpx")
+            } else {
+                fileDialogLoader.active = true
+            }
         }
         anchors {
             bottom: parent.bottom

--- a/src/SettingsList.qml
+++ b/src/SettingsList.qml
@@ -7,6 +7,16 @@ import QtQuick.Dialogs 1.0
 
 ColumnLayout {
     signal loadSettings(url name)
+
+    Connections {
+        target: rootItem
+        function onAndroidDocumentPicked(kind, localUrl) {
+            if (kind === "settings") {
+                loadSettings(localUrl)
+            }
+        }
+    }
+
     Loader {
         id: fileDialogLoader
         active: false
@@ -116,8 +126,11 @@ ColumnLayout {
         Layout.alignment: Qt.AlignCenter | Qt.AlignVCenter
         onClicked: {
             console.log("folder is " + rootItem.getWritableAppDir() + 'settings')
-            // Create a fresh FileDialog instance
-            fileDialogLoader.active = true
+            if (Qt.platform.os === "android") {
+                rootItem.openAndroidDocumentPicker("settings")
+            } else {
+                fileDialogLoader.active = true
+            }
         }
         anchors {
             bottom: parent.bottom

--- a/src/TrainingProgramsList.qml
+++ b/src/TrainingProgramsList.qml
@@ -15,6 +15,15 @@ ColumnLayout {
     property url selectedWorkoutUrl: ""
     property url initialWorkoutUrl: ""
 
+    Connections {
+        target: rootItem
+        function onAndroidDocumentPicked(kind, localUrl) {
+            if (kind === "training") {
+                trainprogram_open_clicked(localUrl)
+            }
+        }
+    }
+
     function openWorkoutPreview(fileUrl) {
         if (!fileUrl || fileUrl.toString() === "") {
             return
@@ -59,6 +68,7 @@ ColumnLayout {
             FileDialog {
                 title: "Please choose a file"
                 folder: shortcuts.home
+                nameFilters: ["Training programs (*.xml *.zwo)", "All files (*)"]
                 visible: true
                 onAccepted: {
                     console.log("You chose: " + fileUrl)
@@ -371,8 +381,11 @@ ColumnLayout {
             text: "Other folders"
             onClicked: {
                 console.log("folder is " + rootItem.getWritableAppDir() + 'training')
-                // Create a fresh FileDialog instance
-                fileDialogLoader.active = true
+                if (Qt.platform.os === "android") {
+                    rootItem.openAndroidDocumentPicker("training")
+                } else {
+                    fileDialogLoader.active = true
+                }
             }
         }
         anchors {

--- a/src/TrainingProgramsListJS.qml
+++ b/src/TrainingProgramsListJS.qml
@@ -25,6 +25,15 @@ ColumnLayout {
     property var selectedFileUrl: ""
     property bool isSearching: false
 
+    Connections {
+        target: rootItem
+        function onAndroidDocumentPicked(kind, localUrl) {
+            if (kind === "training") {
+                trainprogram_open_clicked(localUrl)
+            }
+        }
+    }
+
     function openWorkoutPreview(fileUrl) {
         if (!fileUrl || fileUrl.toString() === "") {
             return
@@ -73,6 +82,7 @@ ColumnLayout {
                 id: fileDialog
                 title: "Please choose a file"
                 folder: shortcuts.home
+                nameFilters: ["Training programs (*.xml *.zwo)", "All files (*)"]
                 visible: true
                 onAccepted: {
                     var chosenFile = fileDialog.fileUrl || fileDialog.file || (fileDialog.fileUrls && fileDialog.fileUrls.length > 0 ? fileDialog.fileUrls[0] : "")
@@ -276,7 +286,11 @@ ColumnLayout {
                     height: 50
                     text: "Other folders"
                     onClicked: {
-                        fileDialogLoader.active = true
+                        if (Qt.platform.os === "android") {
+                            rootItem.openAndroidDocumentPicker("training")
+                        } else {
+                            fileDialogLoader.active = true
+                        }
                     }
                 }
             }

--- a/src/android/src/ContentHelper.java
+++ b/src/android/src/ContentHelper.java
@@ -4,25 +4,125 @@ import android.content.Context;
 import android.database.Cursor;
 import android.net.Uri;
 import android.provider.OpenableColumns;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
 import org.cagnulen.qdomyoszwift.QLog;
 
 public class ContentHelper {
 
     public static String getFileName(Context context, Uri uri) {
+        if (uri == null) {
+            return null;
+        }
+
         String result = null;
-        if (uri.getScheme().equals("content")) {
+        String scheme = uri.getScheme();
+        if ("content".equals(scheme)) {
             QLog.d("ContentHelper", "content");
-            Cursor cursor = context.getContentResolver().query(uri, null, null, null, null);
-            QLog.d("ContentHelper", "cursor " + cursor);
+            Cursor cursor = null;
             try {
+                cursor = context.getContentResolver().query(uri, new String[] {OpenableColumns.DISPLAY_NAME}, null, null, null);
+                QLog.d("ContentHelper", "cursor " + cursor);
                 if (cursor != null && cursor.moveToFirst()) {
-                    result = cursor.getString(cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME));
-                    QLog.d("ContentHelper", "result " + result);
+                    int nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME);
+                    if (nameIndex >= 0) {
+                        result = cursor.getString(nameIndex);
+                        QLog.d("ContentHelper", "result " + result);
+                    }
                 }
+            } catch (Exception e) {
+                QLog.d("ContentHelper", "getFileName query failed " + e);
             } finally {
-                cursor.close();
+                if (cursor != null) {
+                    cursor.close();
+                }
             }
         }
+        if ((result == null || result.isEmpty()) && uri.getLastPathSegment() != null) {
+            result = uri.getLastPathSegment();
+        }
         return result;
+    }
+
+    public static boolean copyContentToFile(Context context, Uri uri, String destinationPath) {
+        if (context == null || uri == null || destinationPath == null || destinationPath.isEmpty()) {
+            return false;
+        }
+
+        InputStream inputStream = null;
+        FileOutputStream outputStream = null;
+        try {
+            inputStream = context.getContentResolver().openInputStream(uri);
+            if (inputStream == null) {
+                QLog.d("ContentHelper", "copyContentToFile null input stream for " + uri);
+                return false;
+            }
+
+            outputStream = new FileOutputStream(destinationPath, false);
+            byte[] buffer = new byte[8192];
+            int read;
+            while ((read = inputStream.read(buffer)) != -1) {
+                outputStream.write(buffer, 0, read);
+            }
+            outputStream.flush();
+            return true;
+        } catch (Exception e) {
+            QLog.d("ContentHelper", "copyContentToFile failed " + e);
+            return false;
+        } finally {
+            try {
+                if (inputStream != null) {
+                    inputStream.close();
+                }
+            } catch (Exception ignored) {
+            }
+            try {
+                if (outputStream != null) {
+                    outputStream.close();
+                }
+            } catch (Exception ignored) {
+            }
+        }
+    }
+
+    public static String importContentToAppDir(Context context, Uri uri, String destinationDirPath) {
+        if (context == null || uri == null || destinationDirPath == null || destinationDirPath.isEmpty()) {
+            return "";
+        }
+
+        String fileName = sanitizeFileName(getFileName(context, uri));
+        if (fileName.isEmpty()) {
+            fileName = "imported_file";
+        }
+
+        File destinationDir = new File(destinationDirPath);
+        if (!destinationDir.exists() && !destinationDir.mkdirs()) {
+            QLog.d("ContentHelper", "importContentToAppDir could not create " + destinationDirPath);
+            return "";
+        }
+
+        File destinationFile = new File(destinationDir, fileName);
+        if (destinationFile.exists() && !destinationFile.delete()) {
+            QLog.d("ContentHelper", "importContentToAppDir could not replace " + destinationFile.getAbsolutePath());
+            return "";
+        }
+
+        if (!copyContentToFile(context, uri, destinationFile.getAbsolutePath())) {
+            if (destinationFile.exists()) {
+                destinationFile.delete();
+            }
+            return "";
+        }
+
+        return destinationFile.getAbsolutePath();
+    }
+
+    private static String sanitizeFileName(String value) {
+        if (value == null) {
+            return "";
+        }
+
+        return value.replace('\\', '_').replace('/', '_').trim();
     }
 }

--- a/src/android/src/CustomQtActivity.java
+++ b/src/android/src/CustomQtActivity.java
@@ -4,6 +4,7 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.util.SparseArray;
 import android.util.Log;
 import android.view.View;
 import android.view.WindowInsets;
@@ -14,12 +15,18 @@ import org.qtproject.qt5.android.bindings.QtActivity;
 
 public class CustomQtActivity extends QtActivity {
     private static final String TAG = "CustomQtActivity";
+    private static final int DOCUMENT_PICKER_PROFILE_REQUEST_CODE = 4101;
+    private static final int DOCUMENT_PICKER_TRAINING_REQUEST_CODE = 4102;
+    private static final int DOCUMENT_PICKER_GPX_REQUEST_CODE = 4103;
+    private static final int DOCUMENT_PICKER_SETTINGS_REQUEST_CODE = 4104;
+    private final SparseArray<String> pendingImportDirectories = new SparseArray<>();
 
     // Declare the native method that will be implemented in C++
     private static native void onInsetsChanged(int top, int bottom, int left, int right,
                                                int waterfallTop, int waterfallBottom,
                                                int waterfallLeft, int waterfallRight);
     private static native void nativeOnOAuthCallback(String callbackUrl);
+    private static native void nativeOnDocumentPicked(int requestCode, int resultCode, String localPath);
 
     private void dispatchOAuthCallback(Intent intent) {
         if (intent == null) {
@@ -149,8 +156,74 @@ public class CustomQtActivity extends QtActivity {
         dispatchOAuthCallback(intent);
     }
 
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        if (isDocumentPickerRequest(requestCode)) {
+            handleDocumentPickerResult(requestCode, resultCode, data);
+            return;
+        }
+
+        String uriString = "";
+        if (data != null && data.getData() != null) {
+            uriString = data.getData().toString();
+        }
+        Log.d(TAG, "onActivityResult passthrough requestCode=" + requestCode + " resultCode=" + resultCode + " uri=" + uriString);
+        super.onActivityResult(requestCode, resultCode, data);
+    }
+
+    public void openDocumentPicker(String mimeType, int requestCode, String destinationDir) {
+        pendingImportDirectories.put(requestCode, destinationDir == null ? "" : destinationDir);
+        Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
+        intent.addCategory(Intent.CATEGORY_OPENABLE);
+        intent.setType((mimeType == null || mimeType.isEmpty()) ? "*/*" : mimeType);
+        intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        startActivityForResult(Intent.createChooser(intent, "Select file"), requestCode);
+    }
+
     // This method is still needed for the QML check
     public static int getApiLevel() {
         return Build.VERSION.SDK_INT;
+    }
+
+    private boolean isDocumentPickerRequest(int requestCode) {
+        return requestCode == DOCUMENT_PICKER_PROFILE_REQUEST_CODE
+            || requestCode == DOCUMENT_PICKER_TRAINING_REQUEST_CODE
+            || requestCode == DOCUMENT_PICKER_GPX_REQUEST_CODE
+            || requestCode == DOCUMENT_PICKER_SETTINGS_REQUEST_CODE;
+    }
+
+    private void handleDocumentPickerResult(int requestCode, int resultCode, Intent data) {
+        String destinationDir = pendingImportDirectories.get(requestCode, "");
+        pendingImportDirectories.remove(requestCode);
+
+        String action = "";
+        int flags = 0;
+        int clipItemCount = 0;
+        String uriString = "";
+        String localPath = "";
+
+        if (data != null) {
+            action = data.getAction() == null ? "" : data.getAction();
+            flags = data.getFlags();
+            if (data.getClipData() != null) {
+                clipItemCount = data.getClipData().getItemCount();
+            }
+            if (data.getData() != null) {
+                Uri uri = data.getData();
+                uriString = uri.toString();
+                if (resultCode == RESULT_OK) {
+                    localPath = ContentHelper.importContentToAppDir(this, uri, destinationDir);
+                }
+            }
+        }
+
+        Log.d(TAG, "handleDocumentPickerResult requestCode=" + requestCode
+            + " resultCode=" + resultCode
+            + " action=" + action
+            + " flags=0x" + Integer.toHexString(flags)
+            + " clipItems=" + clipItemCount
+            + " uri=" + uriString
+            + " localPath=" + localPath);
+        nativeOnDocumentPicked(requestCode, resultCode, localPath);
     }
 }

--- a/src/homeform.cpp
+++ b/src/homeform.cpp
@@ -191,6 +191,40 @@ QString uploadActivityLabelFromFitFile(const QString &fitFilePath) {
     return uploadActivityLabelFromSport(sport);
 }
 
+#ifdef Q_OS_ANDROID
+bool clearAndroidJniException(const char *context) {
+    QAndroidJniEnvironment env;
+    if (!env->ExceptionCheck()) {
+        return false;
+    }
+
+    env->ExceptionDescribe();
+    env->ExceptionClear();
+    qWarning() << "Android JNI exception cleared during" << context;
+    return true;
+}
+
+QString fallbackFileNameFromUri(const QString &uriString) {
+    QUrl url(uriString);
+    QString fileName = url.fileName();
+    if (!fileName.isEmpty()) {
+        return fileName;
+    }
+
+    const QString lastSegment = url.path().section('/', -1);
+    if (!lastSegment.isEmpty()) {
+        return lastSegment;
+    }
+
+    return QStringLiteral("imported_file");
+}
+
+constexpr int AndroidDocumentPickerProfileRequestCode = 4101;
+constexpr int AndroidDocumentPickerTrainingRequestCode = 4102;
+constexpr int AndroidDocumentPickerGpxRequestCode = 4103;
+constexpr int AndroidDocumentPickerSettingsRequestCode = 4104;
+constexpr jint AndroidActivityResultOk = -1;
+#endif
 double interpolatedHeartZone(double percentHeartRate, double zone1, double zone2, double zone3, double zone4) {
     const double z1 = std::max(1.0, zone1);
     const double z2 = zone2 > z1 ? zone2 : z1 + 10.0;
@@ -1280,6 +1314,31 @@ Java_org_cagnulen_qdomyoszwift_CustomQtActivity_nativeOnOAuthCallback(JNIEnv *en
         QMetaObject::invokeMethod(homeform::singleton(), "handleOAuthCallbackUrl", Qt::QueuedConnection,
                                   Q_ARG(QString, url));
     }
+}
+
+JNIEXPORT void JNICALL
+Java_org_cagnulen_qdomyoszwift_CustomQtActivity_nativeOnDocumentPicked(JNIEnv *env, jclass clazz, jint requestCode,
+                                                                       jint resultCode, jstring localPathString) {
+    Q_UNUSED(clazz)
+    if (resultCode != AndroidActivityResultOk || !homeform::singleton()) {
+        return;
+    }
+
+    QString localPath;
+    if (localPathString) {
+        const char *pathChars = env->GetStringUTFChars(localPathString, nullptr);
+        localPath = QString::fromUtf8(pathChars ? pathChars : "");
+        if (pathChars) {
+            env->ReleaseStringUTFChars(localPathString, pathChars);
+        }
+    }
+
+    if (localPath.isEmpty()) {
+        return;
+    }
+
+    QMetaObject::invokeMethod(homeform::singleton(), "handleAndroidDocumentPicked", Qt::QueuedConnection,
+                              Q_ARG(int, static_cast<int>(requestCode)), Q_ARG(QString, localPath));
 }
 
 JNIEXPORT void JNICALL
@@ -5302,26 +5361,23 @@ void homeform::Plus(const QString &name) {
             if (bluetoothManager->device()->deviceType() == BIKE) {
                 m_overridePower = true;
                 ((bike *)bluetoothManager->device())
-                    ->changePower(((bike *)bluetoothManager->device())->lastRequestedPower().value() + 10);
+                    ->changePower(((bike *)bluetoothManager->device())->lastRequestedPower().value() + powerJog);
                 if (trainProgram) {
-                    trainProgram->overridePowerForCurrentRow(
-                        ((bike *)bluetoothManager->device())->lastRequestedPower().value());
+                    trainProgram->adjustPowerOffsetForTrainingProgram(powerJog);
                 }
             } else if (bluetoothManager->device()->deviceType() == TREADMILL) {
                 m_overridePower = true;
                 ((treadmill *)bluetoothManager->device())
-                    ->changePower(((treadmill *)bluetoothManager->device())->lastRequestedPower().value() + 10);
+                    ->changePower(((treadmill *)bluetoothManager->device())->lastRequestedPower().value() + powerJog);
                 if (trainProgram) {
-                    trainProgram->overridePowerForCurrentRow(
-                        ((treadmill *)bluetoothManager->device())->lastRequestedPower().value());
+                    trainProgram->adjustPowerOffsetForTrainingProgram(powerJog);
                 }
             } else if (bluetoothManager->device()->deviceType() == ROWING) {
                 m_overridePower = true;
                 ((rower *)bluetoothManager->device())
-                    ->changePower(((rower *)bluetoothManager->device())->lastRequestedPower().value() + 10);
+                    ->changePower(((rower *)bluetoothManager->device())->lastRequestedPower().value() + powerJog);
                 if (trainProgram) {
-                    trainProgram->overridePowerForCurrentRow(
-                        ((rower *)bluetoothManager->device())->lastRequestedPower().value());
+                    trainProgram->adjustPowerOffsetForTrainingProgram(powerJog);
                 }
             }
         }
@@ -5605,26 +5661,23 @@ void homeform::Minus(const QString &name) {
             if (bluetoothManager->device()->deviceType() == BIKE) {
                 m_overridePower = true;
                 ((bike *)bluetoothManager->device())
-                    ->changePower(((bike *)bluetoothManager->device())->lastRequestedPower().value() - 10);
+                    ->changePower(((bike *)bluetoothManager->device())->lastRequestedPower().value() - powerJog);
                 if (trainProgram) {
-                    trainProgram->overridePowerForCurrentRow(
-                        ((bike *)bluetoothManager->device())->lastRequestedPower().value());
+                    trainProgram->adjustPowerOffsetForTrainingProgram(-powerJog);
                 }
             } else if (bluetoothManager->device()->deviceType() == TREADMILL) {
                 m_overridePower = true;
                 ((treadmill *)bluetoothManager->device())
-                    ->changePower(((treadmill *)bluetoothManager->device())->lastRequestedPower().value() - 10);
+                    ->changePower(((treadmill *)bluetoothManager->device())->lastRequestedPower().value() - powerJog);
                 if (trainProgram) {
-                    trainProgram->overridePowerForCurrentRow(
-                        ((treadmill *)bluetoothManager->device())->lastRequestedPower().value());
+                    trainProgram->adjustPowerOffsetForTrainingProgram(-powerJog);
                 }
             } else if (bluetoothManager->device()->deviceType() == ROWING) {
                 m_overridePower = true;
                 ((rower *)bluetoothManager->device())
-                    ->changePower(((rower *)bluetoothManager->device())->lastRequestedPower().value() - 10);
+                    ->changePower(((rower *)bluetoothManager->device())->lastRequestedPower().value() - powerJog);
                 if (trainProgram) {
-                    trainProgram->overridePowerForCurrentRow(
-                        ((rower *)bluetoothManager->device())->lastRequestedPower().value());
+                    trainProgram->adjustPowerOffsetForTrainingProgram(-powerJog);
                 }
             }
         }
@@ -6466,6 +6519,15 @@ void homeform::update() {
                                                      QString::number(inclination, 'f', 1) + QStringLiteral("%"));
             this->target_power->setValue(
                 QString::number(((treadmill *)bluetoothManager->device())->lastRequestedPower().value(), 'f', 0));
+            if (trainProgram && trainProgram->isStarted() && trainProgram->powerOffsetForTrainingProgram() != 0) {
+                this->target_power->setSecondLine(
+                    QStringLiteral("%1%2W")
+                        .arg(trainProgram->powerOffsetForTrainingProgram() > 0 ? QStringLiteral("+")
+                                                                              : QStringLiteral(""))
+                        .arg(trainProgram->powerOffsetForTrainingProgram()));
+            } else {
+                this->target_power->setSecondLine(QStringLiteral(""));
+            }
             this->inclination->setValue(QString::number(inclination, 'f', 1));
             this->inclination->setSecondLine(
                 QStringLiteral("AVG: ") +
@@ -6781,6 +6843,15 @@ void homeform::update() {
                 QString::number(((bike *)bluetoothManager->device())->lastRequestedCadence().value(), 'f', 0));
             this->target_power->setValue(
                 QString::number(((bike *)bluetoothManager->device())->lastRequestedPower().value(), 'f', 0));
+            if (trainProgram && trainProgram->isStarted() && trainProgram->powerOffsetForTrainingProgram() != 0) {
+                this->target_power->setSecondLine(
+                    QStringLiteral("%1%2W")
+                        .arg(trainProgram->powerOffsetForTrainingProgram() > 0 ? QStringLiteral("+")
+                                                                              : QStringLiteral(""))
+                        .arg(trainProgram->powerOffsetForTrainingProgram()));
+            } else {
+                this->target_power->setSecondLine(QStringLiteral(""));
+            }
             this->resistance->setValue(QString::number(resistance, 'f', 0));
             updateGearsValue();
 
@@ -6917,6 +6988,15 @@ void homeform::update() {
                 QString::number(((rower *)bluetoothManager->device())->lastRequestedCadence().value(), 'f', 0));
             this->target_power->setValue(
                 QString::number(((rower *)bluetoothManager->device())->lastRequestedPower().value(), 'f', 0));
+            if (trainProgram && trainProgram->isStarted() && trainProgram->powerOffsetForTrainingProgram() != 0) {
+                this->target_power->setSecondLine(
+                    QStringLiteral("%1%2W")
+                        .arg(trainProgram->powerOffsetForTrainingProgram() > 0 ? QStringLiteral("+")
+                                                                              : QStringLiteral(""))
+                        .arg(trainProgram->powerOffsetForTrainingProgram()));
+            } else {
+                this->target_power->setSecondLine(QStringLiteral(""));
+            }
             this->resistance->setValue(QString::number(resistance, 'f', 0));
 
             this->resistance->setSecondLine(
@@ -8528,13 +8608,24 @@ QString homeform::getFileNameFromContentUri(const QString &uriString) {
 
     QAndroidJniObject jUriString = QAndroidJniObject::fromString(uriString);
     QAndroidJniObject jUri = QAndroidJniObject::callStaticObjectMethod("android/net/Uri", "parse", "(Ljava/lang/String;)Landroid/net/Uri;", jUriString.object<jstring>());
+    if (clearAndroidJniException("Uri.parse") || !jUri.isValid()) {
+        return fallbackFileNameFromUri(uriString);
+    }
     QAndroidJniObject result = QAndroidJniObject::callStaticObjectMethod(
         "org/cagnulen/qdomyoszwift/ContentHelper",
         "getFileName",
         "(Landroid/content/Context;Landroid/net/Uri;)Ljava/lang/String;",
         QtAndroid::androidContext().object(),
         jUri.object());
-    return result.toString();
+    if (clearAndroidJniException("ContentHelper.getFileName") || !result.isValid()) {
+        return fallbackFileNameFromUri(uriString);
+    }
+
+    QString fileName = result.toString();
+    if (fileName.isEmpty()) {
+        fileName = fallbackFileNameFromUri(uriString);
+    }
+    return fileName;
 #else
     return uriString;
 #endif
@@ -8542,40 +8633,80 @@ QString homeform::getFileNameFromContentUri(const QString &uriString) {
 
 QString homeform::copyAndroidContentsURI(QUrl file, QString subfolder) {
 #ifdef Q_OS_ANDROID        
-    QString fileNameLocal = "";
     qDebug() << "Android Version:" << QOperatingSystemVersion::current();
-    if (QOperatingSystemVersion::current() >= QOperatingSystemVersion(QOperatingSystemVersion::Android, 13))
-        fileNameLocal = getFileNameFromContentUri(file.toString());
-    if(fileNameLocal.contains(getWritableAppDir() + subfolder + "/")) {
+    const QString sourcePath = QQmlFile::urlToLocalFileOrQrc(file);
+    const QString destinationDir = getWritableAppDir() + subfolder + "/";
+    QDir().mkpath(destinationDir);
+
+    if (!sourcePath.isEmpty() && sourcePath.startsWith(destinationDir)) {
         qDebug() << "no need to copy file, the file is already in QZ subfolder" << file << subfolder;
-        return file.toString();
+        return sourcePath;
     }
-    
-    QString filename = "";
-    QFile fileFile(QQmlFile::urlToLocalFileOrQrc(file));
-    // android <14 fallback
-    if(fileNameLocal.length() == 0) {
-        qDebug() << "android <14 fallback" << fileNameLocal << filename << file.fileName();
-        filename = file.fileName();
-    } else {
-        QFileInfo f(fileNameLocal);
-        filename = f.fileName();        
+
+    QString filename;
+    if (file.toString().startsWith(QStringLiteral("content"))) {
+        filename = getFileNameFromContentUri(file.toString());
     }
-    QString dest = getWritableAppDir() + subfolder + "/" + filename;
-    qDebug() << file.fileName() << fileNameLocal << filename;
+    if (filename.isEmpty() && !sourcePath.isEmpty()) {
+        filename = QFileInfo(sourcePath).fileName();
+    }
+    if (filename.isEmpty()) {
+        filename = QFileInfo(file.fileName()).fileName();
+    }
+    if (filename.isEmpty()) {
+        filename = QStringLiteral("imported_file");
+    }
+
+    const QString dest = destinationDir + filename;
+    qDebug() << file.fileName() << sourcePath << filename;
     QFile::remove(dest);
+
+    if (file.toString().startsWith(QStringLiteral("content"))) {
+        QAndroidJniObject jUriString = QAndroidJniObject::fromString(file.toString());
+        QAndroidJniObject jUri = QAndroidJniObject::callStaticObjectMethod(
+            "android/net/Uri", "parse", "(Ljava/lang/String;)Landroid/net/Uri;", jUriString.object<jstring>());
+        if (clearAndroidJniException("Uri.parse for copy") || !jUri.isValid()) {
+            qWarning() << "Unable to parse content URI for copy" << file;
+            return QString();
+        }
+
+        QAndroidJniObject jDest = QAndroidJniObject::fromString(dest);
+        jboolean copied = QAndroidJniObject::callStaticMethod<jboolean>(
+            "org/cagnulen/qdomyoszwift/ContentHelper",
+            "copyContentToFile",
+            "(Landroid/content/Context;Landroid/net/Uri;Ljava/lang/String;)Z",
+            QtAndroid::androidContext().object(),
+            jUri.object(),
+            jDest.object<jstring>());
+        if (clearAndroidJniException("ContentHelper.copyContentToFile")) {
+            QFile::remove(dest);
+            return QString();
+        }
+
+        qDebug() << "copyContentToFile" << dest << static_cast<bool>(copied);
+        if (!copied || !QFile::exists(dest)) {
+            QFile::remove(dest);
+            return QString();
+        }
+        return dest;
+    }
+
+    QFile fileFile(sourcePath);
     bool copy = fileFile.copy(dest);
     qDebug() << "copy" << dest << copy << fileFile.exists() << fileFile.isReadable();
-    return dest;
+    return copy ? dest : QString();
 #endif
     return file.toString();
 }
 
 void homeform::profile_open_clicked(const QUrl &fileName) {
-    QFile file(QQmlFile::urlToLocalFileOrQrc(fileName));
 #ifdef Q_OS_ANDROID
-    copyAndroidContentsURI(fileName, "profiles");
+    const QString copiedFile = copyAndroidContentsURI(fileName, "profiles");
+    if (!copiedFile.isEmpty()) {
+        loadSettings(QUrl::fromLocalFile(copiedFile));
+    }
 #else
+    QFile file(QQmlFile::urlToLocalFileOrQrc(fileName));
     QFileInfo fileInfo(file);
     bool r = file.copy(getWritableAppDir() + "profiles/" + fileInfo.fileName());
     qDebug() << "profile copy" << r << getWritableAppDir() + "profiles/" + fileInfo.fileName();
@@ -8583,13 +8714,17 @@ void homeform::profile_open_clicked(const QUrl &fileName) {
 }
 
 void homeform::trainprogram_open_other_folder(const QUrl &fileName) {
-    QFile file(QQmlFile::urlToLocalFileOrQrc(fileName));
-    copyAndroidContentsURI(fileName, "training");
+    const QString copiedFile = copyAndroidContentsURI(fileName, "training");
+    if (!copiedFile.isEmpty()) {
+        trainprogram_open_clicked(QUrl::fromLocalFile(copiedFile));
+    }
 }
 
 void homeform::gpx_open_other_folder(const QUrl &fileName) {
-    QFile file(QQmlFile::urlToLocalFileOrQrc(fileName));
-    copyAndroidContentsURI(fileName, "gpx");
+    const QString copiedFile = copyAndroidContentsURI(fileName, "gpx");
+    if (!copiedFile.isEmpty()) {
+        gpx_open_clicked(QUrl::fromLocalFile(copiedFile));
+    }
 }
 
 bool homeform::startTrainingProgramFromFile(const QString &filePath) {
@@ -8606,6 +8741,77 @@ bool homeform::startTrainingProgramFromFile(const QString &filePath) {
     }
     trainprogram_open_clicked(QUrl::fromLocalFile(localPath));
     return true;
+}
+
+void homeform::openAndroidDocumentPicker(const QString &kind) {
+#ifdef Q_OS_ANDROID
+    int requestCode = 0;
+    QString mimeType = QStringLiteral("*/*");
+    QString destinationDir;
+    if (kind == QStringLiteral("profile")) {
+        requestCode = AndroidDocumentPickerProfileRequestCode;
+        destinationDir = getWritableAppDir() + QStringLiteral("profiles/");
+    } else if (kind == QStringLiteral("training")) {
+        requestCode = AndroidDocumentPickerTrainingRequestCode;
+        mimeType = QStringLiteral("*/*");
+        destinationDir = getWritableAppDir() + QStringLiteral("training/");
+    } else if (kind == QStringLiteral("gpx")) {
+        requestCode = AndroidDocumentPickerGpxRequestCode;
+        mimeType = QStringLiteral("*/*");
+        destinationDir = getWritableAppDir() + QStringLiteral("gpx/");
+    } else if (kind == QStringLiteral("settings")) {
+        requestCode = AndroidDocumentPickerSettingsRequestCode;
+        destinationDir = getWritableAppDir() + QStringLiteral("settings/");
+    } else {
+        qWarning() << "Unknown Android document picker kind" << kind;
+        return;
+    }
+
+    QAndroidJniObject javaMimeType = QAndroidJniObject::fromString(mimeType);
+    QAndroidJniObject javaDestinationDir = QAndroidJniObject::fromString(destinationDir);
+    QtAndroid::androidActivity().callMethod<void>("openDocumentPicker", "(Ljava/lang/String;ILjava/lang/String;)V",
+                                                  javaMimeType.object<jstring>(), requestCode,
+                                                  javaDestinationDir.object<jstring>());
+    if (clearAndroidJniException("CustomQtActivity.openDocumentPicker")) {
+        return;
+    }
+#else
+    Q_UNUSED(kind)
+#endif
+}
+
+void homeform::handleAndroidDocumentPicked(int requestCode, const QString &localPath) {
+#ifdef Q_OS_ANDROID
+    if (localPath.isEmpty()) {
+        qWarning() << "Android document picker returned empty local path for request code" << requestCode;
+        return;
+    }
+
+    const QUrl localUrl = QUrl::fromLocalFile(localPath);
+    QString kind;
+    switch (requestCode) {
+    case AndroidDocumentPickerProfileRequestCode:
+        kind = QStringLiteral("profile");
+        break;
+    case AndroidDocumentPickerTrainingRequestCode:
+        kind = QStringLiteral("training");
+        break;
+    case AndroidDocumentPickerGpxRequestCode:
+        kind = QStringLiteral("gpx");
+        break;
+    case AndroidDocumentPickerSettingsRequestCode:
+        kind = QStringLiteral("settings");
+        break;
+    default:
+        qWarning() << "Unknown Android document picker request code" << requestCode << localPath;
+        return;
+    }
+
+    emit androidDocumentPicked(kind, localUrl);
+#else
+    Q_UNUSED(requestCode)
+    Q_UNUSED(localPath)
+#endif
 }
 
 bool homeform::deleteTrainingProgramFile(const QString &fileUrl) {
@@ -10783,12 +10989,18 @@ void homeform::saveSettings(const QUrl &filename) {
 void homeform::loadSettings(const QUrl &filename) {
 
     QFile file(QQmlFile::urlToLocalFileOrQrc(filename));
-    copyAndroidContentsURI(filename, "settings");
+    QString settingsFile = file.fileName();
+#ifdef Q_OS_ANDROID
+    const QString copiedSettingsFile = copyAndroidContentsURI(filename, "settings");
+    if (!copiedSettingsFile.isEmpty()) {
+        settingsFile = copiedSettingsFile;
+    }
+#endif
 
     qDebug() << "homeform::loadSettings" << file.fileName();
 
     QSettings settings;
-    QSettings settings2Load(file.fileName(), QSettings::IniFormat);
+    QSettings settings2Load(settingsFile, QSettings::IniFormat);
     auto settings2LoadAllKeys = settings2Load.allKeys();
     for (const QString &s : qAsConst(settings2LoadAllKeys)) {
         if (!s.contains(QZSettings::cryptoKeySettingsProfiles)) {

--- a/src/homeform.h
+++ b/src/homeform.h
@@ -666,6 +666,7 @@ public:
     Q_INVOKABLE static QString getProfileDir();
     Q_INVOKABLE static void clearFiles();
     Q_INVOKABLE bool startTrainingProgramFromFile(const QString &filePath);
+    Q_INVOKABLE void openAndroidDocumentPicker(const QString &kind);
     Q_INVOKABLE bool deleteTrainingProgramFile(const QString &fileUrl);
 
     double wattMaxChart() {
@@ -1089,6 +1090,7 @@ public:
     static QString getFileNameFromContentUri(const QString &uriString);
 
     int16_t fanOverride = 0;
+    const float powerJog = 5.0;
 
     void update();
     void ten_hz();
@@ -1145,6 +1147,7 @@ public:
     void trainprogram_open_clicked(const QUrl &fileName);
     void trainprogram_autostart_requested();
     void handleOAuthCallbackUrl(const QString &callbackUrl);
+    void handleAndroidDocumentPicked(int requestCode, const QString &uriString);
 
   private slots:
     void Start();
@@ -1240,6 +1243,7 @@ public:
 
     void changeOfdevice();
     void changeOflap();
+    void androidDocumentPicked(QString kind, QUrl localUrl);
     void signalChanged(QString value);
     void startTextChanged(QString value);
     void startIconChanged(QString value);

--- a/src/inner_templates/workouteditor/workout-editor-app.js
+++ b/src/inner_templates/workouteditor/workout-editor-app.js
@@ -521,9 +521,26 @@
             .finally(() => setWorking(false));
     }
 
+    function extractRowLabel(row) {
+        if (row.name && row.name !== 'null') {
+            return row.name;
+        }
+        const textEvents = Array.isArray(row.textEvents) ? row.textEvents : [];
+        for (const event of textEvents) {
+            if (!event || typeof event.message !== 'string') {
+                continue;
+            }
+            const message = event.message.trim();
+            if (message) {
+                return message;
+            }
+        }
+        return '';
+    }
+
     function convertRow(row, idx) {
         const out = {};
-        out.name = row.name || `Interval ${idx + 1}`;
+        out.name = extractRowLabel(row) || `Interval ${idx + 1}`;
         if (!out.name || out.name === 'null') {
             out.name = `Interval ${idx + 1}`;
         }

--- a/src/profiles.qml
+++ b/src/profiles.qml
@@ -14,6 +14,15 @@ ColumnLayout {
 
     signal profile_open_clicked(url name)
 
+    Connections {
+        target: rootItem
+        function onAndroidDocumentPicked(kind, localUrl) {
+            if (kind === "profile") {
+                profile_open_clicked(localUrl)
+            }
+        }
+    }
+
     Settings {
         id: settings
         property string profile_name: "default"
@@ -267,8 +276,11 @@ ColumnLayout {
         Layout.alignment: Qt.AlignCenter | Qt.AlignVCenter
         onClicked: {
             console.log("folder is " + rootItem.getWritableAppDir() + 'training')
-            // Create a fresh FileDialog instance
-            fileDialogLoader.active = true
+            if (Qt.platform.os === "android") {
+                rootItem.openAndroidDocumentPicker("profile")
+            } else {
+                fileDialogLoader.active = true
+            }
         }
         anchors {
             bottom: parent.bottom

--- a/src/templateinfosenderbuilder.cpp
+++ b/src/templateinfosenderbuilder.cpp
@@ -579,6 +579,16 @@ void TemplateInfoSenderBuilder::onGetTrainingProgram(const QJsonValue &msgConten
         for (auto &row : lst) {
             QJsonObject item;
             TRAINPROGRAM_FIELD_TO_STRING();
+            if (!row.textEvents.isEmpty()) {
+                QJsonArray textEvents;
+                for (const auto &evt : row.textEvents) {
+                    QJsonObject textEvent;
+                    textEvent[QStringLiteral("timeoffset")] = static_cast<int>(evt.timeoffset);
+                    textEvent[QStringLiteral("message")] = evt.message;
+                    textEvents.append(textEvent);
+                }
+                item[QStringLiteral("textEvents")] = textEvents;
+            }
             outArr.append(item);
         }
         outObj[QStringLiteral("device")] =

--- a/src/trainprogram.cpp
+++ b/src/trainprogram.cpp
@@ -1322,13 +1322,21 @@ bool trainprogram::overrideZoneHRForCurrentRow(uint8_t zone) {
     return false;
 }
 
-bool trainprogram::overridePowerForCurrentRow(double power) {
-    if (started && currentStep < rows.length() && currentRow().power != -1) {
-        qDebug() << "overriding power from" << rows.at(currentStep).power << "to" << power;
-        rows[currentStep].power = power;
-        return true;
+bool trainprogram::adjustPowerOffsetForTrainingProgram(int32_t delta) {
+    if (!started || currentStep >= rows.length() || currentRow().power == -1 || loadedRows.length() != rows.length()) {
+        return false;
     }
-    return false;
+
+    trainingProgramPowerOffset += delta;
+    qDebug() << "applying training program power offset" << trainingProgramPowerOffset;
+
+    for (int i = 0; i < rows.length(); i++) {
+        if (loadedRows.at(i).power != -1) {
+            rows[i].power = loadedRows.at(i).power + trainingProgramPowerOffset;
+        }
+    }
+
+    return true;
 }
 
 bool trainprogram::currentHeartRateEndConditionSatisfied() const {
@@ -1604,6 +1612,12 @@ int trainprogram::totalLogicalSteps() const {
 void trainprogram::onTapeStarted() { started = true; }
 
 void trainprogram::restart() {
+    trainingProgramPowerOffset = 0;
+    for (int i = 0; i < rows.length() && i < loadedRows.length(); i++) {
+        if (loadedRows.at(i).power != -1) {
+            rows[i].power = loadedRows.at(i).power;
+        }
+    }
 
     if (bluetoothManager && bluetoothManager->device())
         lastOdometer = bluetoothManager->device()->odometer();

--- a/src/trainprogram.h
+++ b/src/trainprogram.h
@@ -117,7 +117,8 @@ class trainprogram : public QObject {
     int TotalGPXSecs();
     double weightedInclination(int step);
     double medianInclination(int step);
-    bool overridePowerForCurrentRow(double power);
+    bool adjustPowerOffsetForTrainingProgram(int32_t delta);
+    int32_t powerOffsetForTrainingProgram() const { return trainingProgramPowerOffset; }
     bool overrideZoneHRForCurrentRow(uint8_t zone);
     bool advanceLapButtonStep();
     static int firstBlockingLapButtonRow(const QList<trainrow> &rows, int currentStep, int candidateStep);
@@ -211,6 +212,7 @@ private slots:
     int lastStepTimestampChanged = 0;
     double lastCurrentStepDistance = 0.0;
     QTime lastCurrentStepTime = QTime(0, 0, 0);
+    int32_t trainingProgramPowerOffset = 0;
     int lastLapButtonToastStep = -1;
     int lastLapButtonToastTick = -30;
     


### PR DESCRIPTION
This is a split-out version of #4494. It keeps the Android Content Helper/document picker work and the related non-heart changes, while intentionally leaving the heart-rate changes in #4494 for separate review. Included here: Android ACTION_GET_CONTENT document picking for profiles, settings, training programs, and GPX files; Android content URI import/copy handling; QML handoff through androidDocumentPicked so the existing page signals and main.qml flow still run; training program target-power offset handling with the +/- power display; GPX/training file filters and uppercase GPX support; workout editor textEvents export and row-label fallback. Excluded here: the heart-rate belt discovery/connection refactor in bluetooth.cpp/h, and the PID HR Pushy zone-limit/recovery-zone settings and behavior changes. Validation: settings-catalog JSON loads as 960/960, and git diff --check passes.