### PR TITLE
Fix: deleted workouts reappear in history after app restart

### DIFF
--- a/src/workoutmodel.cpp
+++ b/src/workoutmodel.cpp
@@ -138,10 +138,11 @@ bool WorkoutModel::deleteWorkout(int workoutId) {
         return false;
     }
 
-    // Optionally, you could also delete the FIT file here if desired
-    // if (!filePath.isEmpty()) {
-    //     QFile::remove(filePath);
-    // }
+    // Delete the underlying FIT file too, otherwise FitDatabaseProcessor::processDirectory()
+    // will find it unindexed on the next app start and re-insert it into the workouts table.
+    if (!filePath.isEmpty()) {
+        QFile::remove(filePath);
+    }
 
     // Refresh the model
     refresh();


### PR DESCRIPTION
## Summary
- `WorkoutModel::deleteWorkout()` removed the row from the SQLite `workouts` table but left the underlying `.fit` file on disk.
- `FitDatabaseProcessor::processDirectory()` runs on every app start (`homeform.cpp`) and re-imports any `.fit` file whose hash isn't already present in the DB — so a deleted workout silently came back after restarting the app.
- Fix: actually delete the `.fit` file when the workout is deleted, so it's no longer picked up by the rescan.

## Test plan
- [x] Ran 3 workouts on-device (WayDroid, Fake Device enabled), all appeared in Workout History
- [x] Swipe-deleted one workout — disappeared from the list
- [x] Force-stopped and relaunched the app — before this fix the deleted workout reappeared; after this fix it stays deleted
- [x] Confirmed the two remaining workouts are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)