### PR TITLE
fix(apple-watch): Apple Health shows inflated distance for treadmill workouts (km written as miles)

### DIFF
--- a/build-qdomyos-zwift-Qt_5_15_2_for_iOS-Debug/watchkit Extension/MainController.swift
+++ b/build-qdomyos-zwift-Qt_5_15_2_for_iOS-Debug/watchkit Extension/MainController.swift
@@ -110,11 +110,11 @@ extension MainController: WorkoutTrackingDelegate {
         WorkoutTracking.cadence = WatchKitConnection.cadence
         WorkoutTracking.steps = WatchKitConnection.steps
                 
-		if Locale.current.measurementSystem != "Metric" {
-			self.distanceLabel.setText("Distance \(String(format:"%.2f", WorkoutTracking.distance))")
-		} else {
-			self.distanceLabel.setText("Distance \(String(format:"%.2f", WorkoutTracking.distance * 1.60934))")
-		}
+        if Locale.current.measurementSystem != "Metric" {
+            self.distanceLabel.setText("Distance \(String(format:"%.2f", WorkoutTracking.distance * 0.621371)) mi")
+        } else {
+            self.distanceLabel.setText("Distance \(String(format:"%.2f", WorkoutTracking.distance)) km")
+        }
         self.caloriesLabel.setText("KCal \(Int(WorkoutTracking.kcal))")
         //WorkoutTracking.cadenceSteps = pedometer.
     }

--- a/build-qdomyos-zwift-Qt_5_15_2_for_iOS-Debug/watchkit Extension/WatchWorkoutTracking.swift
+++ b/build-qdomyos-zwift-Qt_5_15_2_for_iOS-Debug/watchkit Extension/WatchWorkoutTracking.swift
@@ -302,7 +302,7 @@ extension WorkoutTracking: WorkoutTrackingProtocol {
         }
                     
         let unitDistance = HKUnit.mile()
-        let miles = WorkoutTracking.distance
+        let miles = WorkoutTracking.distance * 0.621371
         let quantityMiles = HKQuantity(unit: unitDistance,
                                   doubleValue: miles)
         

--- a/src/ios/lockscreen.mm
+++ b/src/ios/lockscreen.mm
@@ -153,7 +153,7 @@ void lockscreen::setTotalKcal(double totalKcal)
 
 void lockscreen::setDistance(double distance)
 {
-    [h setDistanceWithDistance:distance * 0.621371];
+    [h setDistanceWithDistance:distance];
 }
 
 void lockscreen::setSteps(double steps)


### PR DESCRIPTION
## Root cause

When a workout ends, the Apple Watch writes the total distance to HealthKit via `WatchWorkoutTracking.stopWorkOut()`. The value it writes comes from `WorkoutTracking.distance`, which is populated from `WatchKitConnection.distance` (Watch side) on every heart-rate tick. `WatchKitConnection.distance` (Watch side) is set from the WatchConnectivity reply that the iPhone sends back whenever the Watch pings it.

The bug is a **unit mismatch** in that reply value. Depending on which device is the QZ primary:

| Scenario | How `WatchKitConnection.distance` (iPhone) is set | Unit sent to Watch |
|---|---|---|
| iPhone is primary (BLE to treadmill) | `lockscreen::setDistance(km)` → `km * 0.621371` → stored | **miles** ✓ |
| Another QZ device is primary (e.g. iPad, `SENDER=PAD`) | `Connection.swift` reads raw `ODO=` from local-network message | **km** ✗ |

The Watch always wrote the received value with `HKUnit.mile()`, so in the iPad-primary scenario it was writing km as if they were miles. A 4.47 km run showed up as 4.47 mi in Apple Health instead of 2.78 mi.

### Evidence from the debug log

The log for the reported session (`iFIT_Xenon1`, 30 min run) shows two interleaved local-network message streams:

```
SENDER=PHONE  ODO=0.000621371   (first sample: 1 m in miles, correctly converted by lockscreen)
...
SENDER=PAD    ODO=0.000173898   (Watch/iPad km stream starts ~9 s later)
SENDER=PAD    ODO=0.000620490
...
SENDER=PAD    ODO=4.478690      ← 4.47 km = 2.78 mi
SENDER=PHONE  ODO=4.478690      ← PHONE ODO overwritten to km after Connection.swift clobbers WatchKitConnection.distance
```

At workout end the Watch received `4.47` via WatchConnectivity and wrote `HKQuantity(unit: .mile(), doubleValue: 4.47)` → Apple Health displayed **4.4 mi** instead of **2.78 mi**.

### Why `SENDER=PAD` must be kept

`Connection.swift` reading `ODO` from `SENDER=PAD` is intentional and correct: it is how a secondary device (phone/Watch) receives live distance from a primary QZ instance (iPad or another phone). Removing that line would break multi-device setups.

## Fix

Standardise the iPhone→Watch WatchConnectivity channel to **always carry km**. The Watch does the single km→miles conversion at write time.

**`src/ios/lockscreen.mm`** — stop pre-converting in the iPhone; pass raw km:
```objc
// before
[h setDistanceWithDistance:distance * 0.621371];
// after
[h setDistanceWithDistance:distance];
```

**`watchkit Extension/WatchWorkoutTracking.swift`** — convert at the HealthKit write site:
```swift
// before
let miles = WorkoutTracking.distance
// after
let miles = WorkoutTracking.distance * 0.621371
```

With both changes every distance source (iPhone primary via `lockscreen`, iPad/multi-device primary via `Connection.swift`) arrives at the Watch in km, and the conversion to miles happens once, in the right place.

## Test plan

- [ ] Solo iPhone + treadmill (iPhone primary): verify Apple Health distance matches QZ display
- [ ] iPad primary + iPhone companion + Apple Watch: verify Apple Health distance matches QZ display on iPad
- [ ] Cycling workout: verify distance is correct (same code path, `distanceCycling` quantity type)
- [ ] Walking/elliptical/rowing: verify distance is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)