### PR TITLE
Add post-workout RPE/Feel popup, saved into the FIT file

### DIFF
--- a/src/Home.qml
+++ b/src/Home.qml
@@ -103,6 +103,94 @@ HomeForm {
         onNoClicked: close()
     }
 
+    // Optional post-workout popup (settings.rpe_feel_popup_enabled) asking for perceived exertion
+    // and how the user felt. Saving the FIT file (rootItem.finalizeFitSave) is suspended until this
+    // popup is answered, so the values can be embedded in the FIT file before it's written/uploaded.
+    Popup {
+        id: rpeFeelPopup
+        parent: Overlay.overlay
+
+        x: Math.round((parent.width - width) / 2)
+        y: Math.round((parent.height - height) / 2)
+        width: 420
+        height: 340
+        modal: true
+        focus: true
+        palette.text: "white"
+        closePolicy: Popup.NoAutoClose
+
+        property int selectedRpe: 5
+        property int selectedFeel: 50
+
+        Column {
+            anchors.fill: parent
+            anchors.margins: 16
+            spacing: 14
+
+            Label {
+                text: qsTr("How was this workout?")
+                font.bold: true
+                font.pixelSize: 18
+                width: parent.width
+                wrapMode: Text.WordWrap
+            }
+
+            Label {
+                text: qsTr("Perceived Exertion (RPE): ") + rpeFeelPopup.selectedRpe
+                width: parent.width
+                wrapMode: Text.WordWrap
+            }
+
+            Slider {
+                id: rpeSlider
+                width: parent.width
+                from: 0
+                to: 10
+                stepSize: 1
+                value: rpeFeelPopup.selectedRpe
+                onValueChanged: rpeFeelPopup.selectedRpe = value
+            }
+
+            Label {
+                text: qsTr("How did you feel?")
+                width: parent.width
+                wrapMode: Text.WordWrap
+            }
+
+            ComboBox {
+                id: feelCombo
+                width: parent.width
+                model: [qsTr("Very Bad"), qsTr("Bad"), qsTr("OK"), qsTr("Good"), qsTr("Very Good")]
+                currentIndex: 2
+                onCurrentIndexChanged: rpeFeelPopup.selectedFeel = currentIndex * 25
+            }
+
+            Row {
+                spacing: 12
+                anchors.horizontalCenter: parent.horizontalCenter
+
+                Button {
+                    text: qsTr("Skip")
+                    onClicked: {
+                        rpeFeelPopup.close();
+                        rootItem.finalizeFitSave(-1, -1);
+                        finish_stop();
+                    }
+                }
+
+                Button {
+                    text: qsTr("Save")
+                    highlighted: true
+                    onClicked: {
+                        rpeFeelPopup.close();
+                        rootItem.finalizeFitSave(rpeFeelPopup.selectedRpe, rpeFeelPopup.selectedFeel);
+                        finish_stop();
+                    }
+                }
+            }
+        }
+    }
+
     Timer {
         id: popupLapAutoClose
         interval: 2000; running: false; repeat: false
@@ -160,6 +248,16 @@ HomeForm {
 
     function inner_stop() {
         stop_clicked();
+        if (rootItem.rpeFeelPopupEnabled()) {
+            rpeFeelPopup.selectedRpe = 5;
+            rpeFeelPopup.selectedFeel = 50;
+            rpeFeelPopup.open();
+        } else {
+            finish_stop();
+        }
+    }
+
+    function finish_stop() {
         rootItem.save_screenshot();
         if(CHARTJS)
             stackView.push("ChartJsTest.qml")

--- a/src/Home.qml
+++ b/src/Home.qml
@@ -121,6 +121,11 @@ HomeForm {
 
         property int selectedRpe: 5
         property int selectedFeel: 50
+        readonly property var rpeLabels: [
+            qsTr("Rest"), qsTr("Very Light"), qsTr("Light"), qsTr("Moderate"),
+            qsTr("Somewhat Hard"), qsTr("Hard"), qsTr("Harder"), qsTr("Very Hard"),
+            qsTr("Very Very Hard"), qsTr("Extremely Hard"), qsTr("Maximum Effort")
+        ]
 
         Column {
             anchors.fill: parent
@@ -136,7 +141,7 @@ HomeForm {
             }
 
             Label {
-                text: qsTr("Perceived Exertion (RPE): ") + rpeFeelPopup.selectedRpe
+                text: qsTr("Perceived Exertion (RPE): ") + rpeFeelPopup.selectedRpe + " - " + rpeFeelPopup.rpeLabels[rpeFeelPopup.selectedRpe]
                 width: parent.width
                 wrapMode: Text.WordWrap
             }

--- a/src/homeform.cpp
+++ b/src/homeform.cpp
@@ -5913,7 +5913,15 @@ void homeform::Stop() {
     if (!(pelotonHandler && !pelotonHandler->current_ride_id.isEmpty())) {
         saveSessionAsTrainingProgram();
     }
-    fit_save_clicked();
+
+    m_workoutRpe = -1;
+    m_workoutFeel = -1;
+    if (!settings.value(QZSettings::rpe_feel_popup_enabled, QZSettings::default_rpe_feel_popup_enabled).toBool()) {
+        // Popup disabled: save (and upload) the FIT file right away, as before.
+        fit_save_clicked();
+    }
+    // else: QML shows the RPE/feel popup and calls finalizeFitSave() once the user answers,
+    // which writes the FIT file (with RPE/feel embedded) and triggers the uploads.
 
     if (bluetoothManager->device()) {
         bluetoothManager->device()->setPaused(paused | stopped);
@@ -9302,7 +9310,8 @@ void homeform::fit_save_clicked() {
         qfit::save(filename, Session, dev->deviceType(),
                    qobject_cast<m3ibike *>(dev) ? QFIT_PROCESS_DISTANCENOISE : QFIT_PROCESS_NONE,
                    stravaPelotonWorkoutType, workoutName, dev->bluetoothDevice.name(),
-                   workoutSource, pelotonWorkoutId, pelotonUrl, trainingProgramFile);
+                   workoutSource, pelotonWorkoutId, pelotonUrl, trainingProgramFile,
+                   m_workoutRpe, m_workoutFeel);
         lastFitFileSaved = filename;
 
         // Process the newly saved file immediately and refresh workout model

--- a/src/homeform.h
+++ b/src/homeform.h
@@ -437,6 +437,19 @@ class homeform : public QObject {
         return settings.value(QZSettings::confirm_stop_workout, QZSettings::default_confirm_stop_workout).toBool();
     }
 
+    Q_INVOKABLE bool rpeFeelPopupEnabled() {
+        QSettings settings;
+        return settings.value(QZSettings::rpe_feel_popup_enabled, QZSettings::default_rpe_feel_popup_enabled).toBool();
+    }
+
+    // Called from QML once the post-workout RPE/feel popup is dismissed (Save or Skip, rpe/feel -1 if skipped).
+    // Stop() defers fit_save_clicked() until this is called when the popup is enabled.
+    Q_INVOKABLE void finalizeFitSave(int rpe, int feel) {
+        m_workoutRpe = rpe;
+        m_workoutFeel = feel;
+        fit_save_clicked();
+    }
+
     Q_INVOKABLE bool locationServices() {
         return m_locationServices;
     }
@@ -1043,6 +1056,10 @@ public:
 
     QString lastFitFileSaved = QLatin1String("");
     QString lastTrainProgramFileSaved = QLatin1String("");
+
+    // Perceived exertion (RPE, 0-10) and feel (0-100) entered in the post-workout popup; -1 means not set
+    int m_workoutRpe = -1;
+    int m_workoutFeel = -1;
 
     QList<QString> chartImagesFilenames;
     bool mailSent = false;

--- a/src/qfit.cpp
+++ b/src/qfit.cpp
@@ -31,7 +31,8 @@ qfit::qfit(QObject *parent) : QObject(parent) {}
 
 void qfit::save(const QString &filename, QList<SessionLine> session, BLUETOOTH_TYPE type,
                 uint32_t processFlag, FIT_SPORT overrideSport, QString workoutName, QString bluetooth_device_name,
-                QString workoutSource, QString pelotonWorkoutId, QString pelotonUrl, QString trainingProgramFile) {
+                QString workoutSource, QString pelotonWorkoutId, QString pelotonUrl, QString trainingProgramFile,
+                int workoutRpe, int workoutFeel) {
     QSettings settings;
     bool strava_virtual_activity =
         settings.value(QZSettings::strava_virtual_activity, QZSettings::default_strava_virtual_activity).toBool();
@@ -423,6 +424,12 @@ void qfit::save(const QString &filename, QList<SessionLine> session, BLUETOOTH_T
     sessionMesg.SetFirstLapIndex(0);
     sessionMesg.SetTrigger(FIT_SESSION_TRIGGER_ACTIVITY_END);
     sessionMesg.SetMessageIndex(FIT_MESSAGE_INDEX_RESERVED);
+
+    // Perceived exertion (Borg CR10, 0-10 scale multiplied 10x) and how the user felt (0-100 scale)
+    if (workoutRpe >= 0)
+        sessionMesg.SetWorkoutRpe(static_cast<FIT_UINT8>(workoutRpe * 10));
+    if (workoutFeel >= 0)
+        sessionMesg.SetWorkoutFeel(static_cast<FIT_UINT8>(workoutFeel));
 
     // Set training load in FIT file
     // Always set training_load_peak (Garmin uses this for acute training load)

--- a/src/qfit.h
+++ b/src/qfit.h
@@ -18,7 +18,8 @@ class qfit : public QObject {
     explicit qfit(QObject *parent = nullptr);
     static void save(const QString &filename, QList<SessionLine> session, BLUETOOTH_TYPE type,
                      uint32_t processFlag = QFIT_PROCESS_NONE, FIT_SPORT overrideSport = FIT_SPORT_INVALID, QString workoutName = "", QString bluetooth_device_name = "",
-                     QString workoutSource = "", QString pelotonWorkoutId = "", QString pelotonUrl = "", QString trainingProgramFile = "");
+                     QString workoutSource = "", QString pelotonWorkoutId = "", QString pelotonUrl = "", QString trainingProgramFile = "",
+                     int workoutRpe = -1, int workoutFeel = -1);
     static void open(const QString &filename, QList<SessionLine>* output, FIT_SPORT *sport);
     static void open(const QString &filename, QList<SessionLine>* output, FIT_SPORT *sport, QString *workoutName);
     static void open(const QString &filename, QList<SessionLine>* output, FIT_SPORT *sport, QString *workoutName, 

--- a/src/qzsettings.cpp
+++ b/src/qzsettings.cpp
@@ -45,6 +45,7 @@ const QString QZSettings::default_garmin_email = QStringLiteral("");
 const QString QZSettings::garmin_password = QStringLiteral("garmin_password");
 const QString QZSettings::default_garmin_password = QStringLiteral("");
 const QString QZSettings::garmin_upload_enabled = QStringLiteral("garmin_upload_enabled");
+const QString QZSettings::rpe_feel_popup_enabled = QStringLiteral("rpe_feel_popup_enabled");
 const QString QZSettings::garmin_download_workouts_on_start = QStringLiteral("garmin_download_workouts_on_start");
 const QString QZSettings::garmin_access_token = QStringLiteral("garmin_access_token");
 const QString QZSettings::default_garmin_access_token = QStringLiteral("");
@@ -1247,7 +1248,7 @@ const QString QZSettings::default_shortcut_start_stop = QStringLiteral("");
 const QString QZSettings::shortcut_stop = QStringLiteral("shortcut_stop");
 const QString QZSettings::default_shortcut_stop = QStringLiteral("");
 
-const uint32_t allSettingsCount = 974;
+const uint32_t allSettingsCount = 975;
 
 QVariant allSettings[allSettingsCount][2] = {
     {QZSettings::cryptoKeySettingsProfiles, QZSettings::default_cryptoKeySettingsProfiles},
@@ -1274,6 +1275,7 @@ QVariant allSettings[allSettingsCount][2] = {
     {QZSettings::garmin_email, QZSettings::default_garmin_email},
     {QZSettings::garmin_password, QZSettings::default_garmin_password},
     {QZSettings::garmin_upload_enabled, QZSettings::default_garmin_upload_enabled},
+    {QZSettings::rpe_feel_popup_enabled, QZSettings::default_rpe_feel_popup_enabled},
     {QZSettings::garmin_download_workouts_on_start, QZSettings::default_garmin_download_workouts_on_start},
     {QZSettings::garmin_access_token, QZSettings::default_garmin_access_token},
     {QZSettings::garmin_refresh_token, QZSettings::default_garmin_refresh_token},

--- a/src/qzsettings.h
+++ b/src/qzsettings.h
@@ -91,6 +91,9 @@ class QZSettings {
     static const QString garmin_upload_enabled;
     static constexpr bool default_garmin_upload_enabled = false;
 
+    static const QString rpe_feel_popup_enabled;
+    static constexpr bool default_rpe_feel_popup_enabled = false;
+
     static const QString garmin_download_workouts_on_start;
     static constexpr bool default_garmin_download_workouts_on_start = true;
 

--- a/src/settings-catalog.json
+++ b/src/settings-catalog.json
@@ -2,7 +2,7 @@
   "$schema": "https://qdomyos-zwift.local/settings-catalog.schema.json",
   "schemaVersion": 1,
   "format": "qdomyos-zwift-settings-catalog",
-  "settingCount": 962,
+  "settingCount": 963,
   "pages": [
     {
       "key": "page_custom_gear_table",
@@ -11825,6 +11825,19 @@
       "key": "garmin_upload_enabled",
       "name": "Enable Garmin Upload",
       "description": "Enable automatic upload of FIT files to Garmin Connect after workouts.",
+      "parent": "Garmin Options",
+      "type": "boolean",
+      "qmlType": "bool",
+      "control": "switch",
+      "visible": true,
+      "defaultValue": false,
+      "defaultExpression": "false",
+      "options": null
+    },
+    {
+      "key": "rpe_feel_popup_enabled",
+      "name": "Ask RPE / Feeling after workout",
+      "description": "Show a popup after Stop to rate perceived exertion (RPE) and how you felt; the values are saved into the FIT file and shown in Garmin Connect.",
       "parent": "Garmin Options",
       "type": "boolean",
       "qmlType": "bool",

--- a/src/settings.qml
+++ b/src/settings.qml
@@ -1708,6 +1708,7 @@ import AndroidStatusBar 1.0
             property bool proform_treadmill_105_cst: false
             property real trainprogram_pid_hr_pushy_zone_limit: 0.8
             property real trainprogram_pid_hr_recovery_zone_limit: 60.0
+            property bool rpe_feel_popup_enabled: false
         }
 
 
@@ -7630,6 +7631,33 @@ import AndroidStatusBar 1.0
 
                     Label {
                         text: qsTr("Enable automatic upload of FIT files to Garmin Connect after workouts.")
+                        font.bold: true
+                        font.italic: true
+                        font.pixelSize: Qt.application.font.pixelSize - 2
+                        textFormat: Text.PlainText
+                        wrapMode: Text.WordWrap
+                        verticalAlignment: Text.AlignVCenter
+                        Layout.alignment: Qt.AlignLeft | Qt.AlignTop
+                        Layout.fillWidth: true
+                        color: Material.color(Material.Lime)
+                    }
+
+                    IndicatorOnlySwitch {
+                        text: qsTr("Ask RPE / Feeling after workout")
+                        spacing: 0
+                        bottomPadding: 0
+                        topPadding: 0
+                        rightPadding: 0
+                        leftPadding: 0
+                        clip: false
+                        checked: settings.rpe_feel_popup_enabled
+                        Layout.alignment: Qt.AlignLeft | Qt.AlignTop
+                        Layout.fillWidth: true
+                        onClicked: { settings.rpe_feel_popup_enabled = checked; }
+                    }
+
+                    Label {
+                        text: qsTr("Show a popup after Stop to rate perceived exertion (RPE) and how you felt; the values are saved into the FIT file and shown in Garmin Connect.")
                         font.bold: true
                         font.italic: true
                         font.pixelSize: Qt.application.font.pixelSize - 2


### PR DESCRIPTION
## Summary
- Adds an optional popup shown after Stop that asks for perceived exertion (RPE, 0-10 slider) and how the workout felt (5-option dropdown)
- Values are embedded into the FIT session message (`workout_rpe`/`workout_feel` fields) so they show up in Garmin Connect
- Off by default; toggled via the new "Ask RPE / Feeling after workout" setting under Garmin Options
- FIT save (and any uploads) is deferred until the popup is answered (Save or Skip) so the values can be written before the file is finalized

## Test plan
Tested live on a WayDroid Android device using the built-in Fake Device (bike) simulator:
- [x] Enabled "Ask RPE / Feeling after workout" in Settings (found via in-app settings search)
- [x] Enabled "Fake Device" to simulate a connected bike
- [x] Started a workout, tapped Stop → popup appeared with RPE slider (default 5) and Feel dropdown (default OK)
- [x] Adjusted RPE to 8 and Feel to "Very Good", tapped Save → workout summary screen appeared as expected
- [x] Pulled the resulting `.fit` file and parsed it with `fitparse`: session message contains field 193 (`workout_rpe`) = 80 (8×10) and field 192 (`workout_feel`) = 100 (Very Good), confirming correct encoding
- [x] Verified Skip path calls `finalizeFitSave(-1, -1)` so no RPE/feel fields are written when skipped

Screenshots of each step are attached as PR comments.