### PR TITLE
[codex] Add Yesoul C1EV Peloton resistance mapping

### DIFF
--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -1859,6 +1859,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                         (b.name().toUpper().startsWith("DHZ-")) ||                         // JK fitness 577
                         (b.name().toUpper().startsWith("MKSM")) ||                         // MKSM3600036
                         (b.name().toUpper().startsWith("YS_C1_")) ||                       // Yesoul C1H
+                        (b.name().toUpper().startsWith("YS_C1EV_")) ||                     // Yesoul C1EV
                         (b.name().toUpper().startsWith("YS_G1_")) ||                       // Yesoul S3
 						(b.name().toUpper().startsWith("YS_M1P_")) ||                      // Yesoul M1
                         (b.name().toUpper().startsWith("YS_G1MPLUS")) ||                   // Yesoul G1M Plus

--- a/src/devices/ftmsbike/ftmsbike.cpp
+++ b/src/devices/ftmsbike/ftmsbike.cpp
@@ -907,6 +907,14 @@ void ftmsbike::characteristicChanged(const QLowEnergyCharacteristic &characteris
                     Resistance = d;
                     native_resistance_received = true;
                     calculatedResistanceFallbackSince = QDateTime();
+                    if (YS_C1EV) {
+                        m_pelotonResistance =
+                            (Resistance.value() *
+                             settings.value(QZSettings::peloton_gain, QZSettings::default_peloton_gain).toDouble()) +
+                            settings.value(QZSettings::peloton_offset, QZSettings::default_peloton_offset).toDouble();
+                        emit debug(QStringLiteral("Current Peloton Resistance: ") +
+                                   QString::number(m_pelotonResistance.value()));
+                    }
                 }
                 if (SMARTBIKE_3DIGIT) {
                     emit debug(QStringLiteral("Ignoring native resistance for SmartBike manual resistance mode: ") +
@@ -926,7 +934,7 @@ void ftmsbike::characteristicChanged(const QLowEnergyCharacteristic &characteris
             double br = -5.841344538;
             double cr = 97.62165482;
 
-            if (Cadence.value() && m_watt.value()) {
+            if (!(YS_C1EV && native_resistance_received) && Cadence.value() && m_watt.value()) {
                 double res =
                     (((sqrt(pow(br, 2.0) - 4.0 * ar *
                                                 (cr - (m_watt.value() * 132.0 /
@@ -2101,6 +2109,10 @@ void ftmsbike::deviceDiscovered(const QBluetoothDeviceInfo &device) {
         } else if (((bluetoothDevice.name().toUpper().startsWith("YS_G1MPLUS")))) {
             qDebug() << QStringLiteral("YS_G1MPLUS found");
             YS_G1MPLUS = true;
+            max_resistance = 100;
+        } else if ((bluetoothDevice.name().toUpper().startsWith(QStringLiteral("YS_C1EV_")))) {
+            qDebug() << QStringLiteral("YS_C1EV found");
+            YS_C1EV = true;
             max_resistance = 100;
         } else if (bluetoothDevice.name().toUpper().startsWith(QStringLiteral("PM5"))) {
             PM5 = true;

--- a/src/devices/ftmsbike/ftmsbike.h
+++ b/src/devices/ftmsbike/ftmsbike.h
@@ -190,6 +190,7 @@ class ftmsbike : public bike {
     bool TITAN_7000 = false;
     bool T2 = false;
     bool FIT_BK = false;
+    bool YS_C1EV = false;
     bool YS_G1MPLUS = false;
     bool EXPERT_SX9 = false;
     bool PM5 = false;


### PR DESCRIPTION
## Summary
- Detect `YS_C1EV_` devices as FTMS bikes.
- Mark the C1EV model in `ftmsbike` and keep its max resistance at 100.
- Use the bike's native FTMS resistance as a linear Peloton resistance source, still honoring `peloton_gain` and `peloton_offset`.

## Root Cause
The Yesoul C1EV advertises as `YS_C1EV_...`, which was not covered by the existing Yesoul/FTMS detection patterns. When manually configured as FTMS, QZ parsed native resistance but calculated Peloton resistance from cadence/watts instead of the bike's 1-100 resistance scale.

## Validation
- `git diff --check`
- Verified `YS_C1EV_00928` does not match the existing `YS_C1_` pattern and does match the new `YS_C1EV_` pattern.