### PR TITLE
feat: power ramp intervals in workout editor (W and % FTP)

### DIFF
--- a/src/inner_templates/workouteditor/workout-editor-app.js
+++ b/src/inner_templates/workouteditor/workout-editor-app.js
@@ -55,14 +55,14 @@
         bike: [
             { key: 'resistance', label: () => t('workoutEditor.resistance', 'Resistance'), color: '#ab47bc', unit: () => 'lvl', axis: 'resistanceAxis', axisLabel: () => t('workoutEditor.resistance', 'Resistance'), axisPosition: 'left' },
             { key: 'cadence', label: () => t('workoutEditor.cadence', 'Cadence'), color: '#29b6f6', unit: () => 'rpm', axis: 'cadenceAxis', axisLabel: () => t('workoutEditor.cadenceRpm', 'Cadence (rpm)'), axisPosition: 'right' },
-            { key: 'power', label: () => t('workoutEditor.power', 'Power'), color: '#ef6c00', unit: () => 'W', axis: 'powerAxis', axisLabel: () => t('workoutEditor.powerW', 'Power (W)'), axisPosition: 'left' }
+            { key: 'power', label: () => t('workoutEditor.power', 'Power'), color: '#ef6c00', unit: () => 'W', axis: 'powerAxis', axisLabel: () => t('workoutEditor.powerW', 'Power (W)'), axisPosition: 'left', stepped: false }
         ],
         elliptical: [
             { key: 'resistance', label: () => t('workoutEditor.resistance', 'Resistance'), color: '#7e57c2', unit: () => 'lvl', axis: 'resistanceAxis', axisLabel: () => t('workoutEditor.resistance', 'Resistance'), axisPosition: 'left' },
             { key: 'inclination', label: () => t('workoutEditor.ramp', 'Ramp'), color: '#66bb6a', unit: () => '%', axis: 'inclineAxis', axisLabel: () => t('workoutEditor.rampPercent', 'Ramp (%)'), axisPosition: 'right' }
         ],
         rower: [
-            { key: 'power', label: () => t('workoutEditor.power', 'Power'), color: '#fb8c00', unit: () => 'W', axis: 'powerAxis', axisLabel: () => t('workoutEditor.powerW', 'Power (W)'), axisPosition: 'left' },
+            { key: 'power', label: () => t('workoutEditor.power', 'Power'), color: '#fb8c00', unit: () => 'W', axis: 'powerAxis', axisLabel: () => t('workoutEditor.powerW', 'Power (W)'), axisPosition: 'left', stepped: false },
             { key: 'cadence', label: () => t('workoutEditor.strokeRate', 'Stroke Rate'), color: '#26a69a', unit: () => 'spm', axis: 'cadenceAxis', axisLabel: () => t('workoutEditor.strokesPerMinute', 'Strokes/min'), axisPosition: 'right' }
         ],
         jumprope: [],
@@ -1445,6 +1445,7 @@
             axis: def.axis,
             axisLabel: typeof def.axisLabel === 'function' ? def.axisLabel() : def.axisLabel,
             axisPosition: def.axisPosition,
+            stepped: def.stepped !== false,
             points: []
         }));
 

--- a/src/inner_templates/workouteditor/workout-editor-app.js
+++ b/src/inner_templates/workouteditor/workout-editor-app.js
@@ -31,7 +31,7 @@
         { key: 'resistance', labelKey: 'workoutEditor.resistance', label: 'Resistance', type: 'number', step: 1, min: 0, max: 100, group: 'basic', devices: ['bike', 'elliptical'], defaultValue: 20 },
         { key: 'cadence', labelKey: 'workoutEditor.cadence', label: 'Cadence', type: 'number', unitSuffix: 'rpm', min: 0, max: 240, group: 'basic', devices: ['bike', 'elliptical', 'rower'], defaultValue: 80 },
         { key: 'power', labelKey: 'workoutEditor.power', label: 'Power', type: 'number', unitSuffix: 'W', min: 0, max: 2000, group: 'basic', devices: ['bike', 'rower'], defaultValue: 150 },
-        { key: 'powerrampunit', labelKey: 'workoutEditor.powerRampUnit', label: 'Ramp Unit', type: 'select', options: ['W', '% FTP'], group: 'advanced', devices: ['bike', 'rower'], defaultValue: 'W' },
+        { key: 'powerrampunit', labelKey: 'workoutEditor.powerRampUnit', label: 'Ramp Unit', type: 'select', options: ['W', '% FTP'], group: 'advanced', devices: ['bike', 'rower'], defaultValue: 'W', noToggle: true },
         { key: 'powerfrom', labelKey: 'workoutEditor.powerRampFrom', label: 'Ramp From', type: 'number', min: 0, max: 2000, group: 'advanced', devices: ['bike', 'rower'], defaultValue: 100 },
         { key: 'powerto', labelKey: 'workoutEditor.powerRampTo', label: 'Ramp To', type: 'number', min: 0, max: 2000, group: 'advanced', devices: ['bike', 'rower'], defaultValue: 200 },
         { key: 'forcespeed', labelKey: 'workoutEditor.forceSpeed', label: 'Force Speed', type: 'bool', group: 'basic', devices: ['treadmill'], linkedTo: 'speed' },
@@ -821,8 +821,8 @@
                     return;
                 }
                 const value = row[field.key];
-                // For pace field, use speed's enabled state
-                const isEnabled = field.syncWith ? (row['__enabled_' + field.syncWith] !== false) : (row['__enabled_' + field.key] !== false);
+                // For pace field, use speed's enabled state; fields without a toggle are always enabled
+                const isEnabled = field.noToggle ? true : (field.syncWith ? (row['__enabled_' + field.syncWith] !== false) : (row['__enabled_' + field.key] !== false));
                 const fieldWrap = document.createElement('div');
                 fieldWrap.className = 'field';
                 if (!isEnabled) {
@@ -834,7 +834,7 @@
                 const labelWrap = document.createElement('label');
                 labelWrap.className = 'field-label';
 
-                const allowToggle = field.key !== 'name' && !field.linkedTo && !field.syncWith;
+                const allowToggle = field.key !== 'name' && !field.linkedTo && !field.syncWith && !field.noToggle;
                 if (allowToggle) {
                     const enableCheckbox = document.createElement('input');
                     enableCheckbox.type = 'checkbox';

--- a/src/inner_templates/workouteditor/workout-editor-app.js
+++ b/src/inner_templates/workouteditor/workout-editor-app.js
@@ -31,6 +31,9 @@
         { key: 'resistance', labelKey: 'workoutEditor.resistance', label: 'Resistance', type: 'number', step: 1, min: 0, max: 100, group: 'basic', devices: ['bike', 'elliptical'], defaultValue: 20 },
         { key: 'cadence', labelKey: 'workoutEditor.cadence', label: 'Cadence', type: 'number', unitSuffix: 'rpm', min: 0, max: 240, group: 'basic', devices: ['bike', 'elliptical', 'rower'], defaultValue: 80 },
         { key: 'power', labelKey: 'workoutEditor.power', label: 'Power', type: 'number', unitSuffix: 'W', min: 0, max: 2000, group: 'basic', devices: ['bike', 'rower'], defaultValue: 150 },
+        { key: 'powerrampunit', labelKey: 'workoutEditor.powerRampUnit', label: 'Ramp Unit', type: 'select', options: ['W', '% FTP'], group: 'advanced', devices: ['bike', 'rower'], defaultValue: 'W' },
+        { key: 'powerfrom', labelKey: 'workoutEditor.powerRampFrom', label: 'Ramp From', type: 'number', min: 0, max: 2000, group: 'advanced', devices: ['bike', 'rower'], defaultValue: 100 },
+        { key: 'powerto', labelKey: 'workoutEditor.powerRampTo', label: 'Ramp To', type: 'number', min: 0, max: 2000, group: 'advanced', devices: ['bike', 'rower'], defaultValue: 200 },
         { key: 'forcespeed', labelKey: 'workoutEditor.forceSpeed', label: 'Force Speed', type: 'bool', group: 'basic', devices: ['treadmill'], linkedTo: 'speed' },
         { key: 'fanspeed', labelKey: 'workoutEditor.fan', label: 'Fan', type: 'number', min: 0, max: 8, group: 'advanced', devices: 'all', defaultValue: 0 },
         { key: 'requested_peloton_resistance', labelKey: 'workoutEditor.pelotonResistance', label: 'Peloton Res.', type: 'number', min: -1, max: 100, group: 'advanced', devices: ['bike'] },
@@ -340,6 +343,9 @@
                 return;
             }
             state.miles = !!content.miles;
+            if (content.ftp !== undefined) {
+                state.ftp = Number(content.ftp);
+            }
             state.translations = content.translations || {};
             if (window.qzSetTranslations) {
                 window.qzSetTranslations(state.translations);
@@ -611,6 +617,21 @@
                 out['__enabled_' + def.key] = false;
             }
         });
+        // FTP% ramp (from backend that collapsed the rows)
+        if (row.powerzonefrom !== undefined && row.powerzonefrom !== null && Number(row.powerzonefrom) >= 0) {
+            out.powerrampunit = '% FTP';
+            out['__enabled_powerrampunit'] = true;
+            out.powerfrom = Math.round(Number(row.powerzonefrom) * 100);
+            out['__enabled_powerfrom'] = true;
+            out.powerto = Math.round(Number(row.powerzoneto) * 100);
+            out['__enabled_powerto'] = true;
+        }
+        // Watts ramp
+        else if (row.powerfrom !== undefined && row.powerfrom !== null && Number(row.powerfrom) >= 0) {
+            out.powerrampunit = 'W';
+            out['__enabled_powerrampunit'] = true;
+            // powerfrom/powerto already read by the FIELD_DEFS loop above
+        }
         out.__enabled_duration = out.__enabled_distance === true ? false : true;
         out.__selected = false;
         return out;
@@ -859,7 +880,7 @@
                 }
 
                 const labelText = document.createElement('span');
-                labelText.textContent = resolveFieldLabel(field);
+                labelText.textContent = resolveFieldLabel(field, row);
                 labelWrap.appendChild(labelText);
                 fieldWrap.appendChild(labelWrap);
 
@@ -872,6 +893,24 @@
                     checkbox.dataset.type = field.type;
                     checkbox.addEventListener('change', handleFieldChange);
                     fieldWrap.appendChild(checkbox);
+                } else if (field.type === 'select') {
+                    const sel = document.createElement('select');
+                    sel.className = 'field-input field-select';
+                    (field.options || []).forEach(opt => {
+                        const option = document.createElement('option');
+                        option.value = opt;
+                        option.textContent = opt;
+                        const currentVal = String(row[field.key] !== undefined ? row[field.key] : (field.defaultValue !== undefined ? field.defaultValue : ''));
+                        if (currentVal === opt) {
+                            option.selected = true;
+                        }
+                        sel.appendChild(option);
+                    });
+                    sel.addEventListener('change', () => {
+                        row[field.key] = sel.value;
+                        renderIntervals();
+                    });
+                    fieldWrap.appendChild(sel);
                 } else {
                     const inputWrapper = document.createElement('div');
                     inputWrapper.className = 'field-with-buttons';
@@ -946,7 +985,7 @@
         return Array.isArray(field.devices) && field.devices.indexOf(state.device) >= 0;
     }
 
-    function resolveFieldLabel(field) {
+    function resolveFieldLabel(field, interval) {
         if (typeof field.label === 'function') {
             return field.label();
         }
@@ -959,6 +998,10 @@
         }
         if (field.unitKey === 'pace') {
             return `${label} (${state.miles ? 'min/mi' : 'min/km'})`;
+        }
+        if ((field.key === 'powerfrom' || field.key === 'powerto') && interval) {
+            const unit = interval.powerrampunit || 'W';
+            return `${label} (${unit})`;
         }
         if (field.unitSuffix) {
             return `${label} (${field.unitSuffix})`;
@@ -1284,6 +1327,11 @@
                     return;
                 }
 
+                // Power ramp fields are handled separately after this loop
+                if (['powerrampunit', 'powerfrom', 'powerto'].includes(field.key)) {
+                    return;
+                }
+
                 // Check if field is valid for current device type
                 if (!isFieldValidForDevice(field, state.device)) {
                     return;
@@ -1324,6 +1372,22 @@
                     row[field.key] = finalValue;
                 }
             });
+
+            // Power ramp
+            const rampFromEnabled = interval['__enabled_powerfrom'] !== false;
+            const rampToEnabled = interval['__enabled_powerto'] !== false;
+            if (rampFromEnabled && rampToEnabled &&
+                isFieldValidForDevice({ devices: ['bike', 'rower'] }, state.device) &&
+                interval.powerfrom !== undefined && interval.powerto !== undefined) {
+                const unit = interval.powerrampunit || 'W';
+                if (unit === '% FTP') {
+                    row.powerzonefrom = Number(interval.powerfrom) / 100;
+                    row.powerzoneto = Number(interval.powerto) / 100;
+                } else {
+                    row.powerfrom = Number(interval.powerfrom);
+                    row.powerto = Number(interval.powerto);
+                }
+            }
             list.push(row);
         }
         return {
@@ -1413,6 +1477,22 @@
             });
             rows.push(Object.assign({ start, durationSeconds: duration }, intervalCopy));
             series.forEach(serie => {
+                // For the power series, check if we have a power ramp (powerfrom/powerto)
+                if (serie.key === 'power' &&
+                    interval['__enabled_powerfrom'] !== false &&
+                    interval['__enabled_powerto'] !== false &&
+                    interval.powerfrom !== undefined && interval.powerto !== undefined) {
+                    const rampUnit = interval.powerrampunit || 'W';
+                    const fromVal = rampUnit === '% FTP'
+                        ? Number(interval.powerfrom) / 100 * (state.ftp || 200)
+                        : Number(interval.powerfrom);
+                    const toVal = rampUnit === '% FTP'
+                        ? Number(interval.powerto) / 100 * (state.ftp || 200)
+                        : Number(interval.powerto);
+                    serie.points.push({ x: start, y: fromVal });
+                    serie.points.push({ x: end, y: toVal });
+                    return;
+                }
                 // Skip disabled fields in the chart
                 const isEnabled = interval['__enabled_' + serie.key] !== false;
                 if (!isEnabled) {

--- a/src/inner_templates/workouteditor/workout-editor.js
+++ b/src/inner_templates/workouteditor/workout-editor.js
@@ -197,7 +197,7 @@
                 backgroundColor: fillColor,
                 unit: series.unit || '',
                 yAxisID: series.axis || 'y',
-                stepped: true,
+                stepped: series.stepped !== false,
                 borderWidth: series.lineWidth || 2,
                 fill: Boolean(series.fill),
                 tension: 0,

--- a/src/templateinfosenderbuilder.cpp
+++ b/src/templateinfosenderbuilder.cpp
@@ -81,6 +81,9 @@ QString openEndedRowLabel(const trainrow &row) {
     item[QStringLiteral("lower_requested_peloton_resistance")] = row.lower_requested_peloton_resistance;    \
     item[QStringLiteral("upper_requested_peloton_resistance")] = row.upper_requested_peloton_resistance;    \
     item[QStringLiteral("power")] = row.power;                                                              \
+    item[QStringLiteral("rampIsFtpFraction")] = row.rampIsFtpFraction;                                      \
+    item[QStringLiteral("rampPowerFromOriginal")] = row.rampPowerFromOriginal;                               \
+    item[QStringLiteral("rampPowerToOriginal")] = row.rampPowerToOriginal;                                   \
     item[QStringLiteral("cadence")] = row.cadence;                                                          \
     item[QStringLiteral("lower_cadence")] = row.lower_cadence;                                              \
     item[QStringLiteral("upper_cadence")] = row.upper_cadence;                                              \
@@ -576,20 +579,58 @@ void TemplateInfoSenderBuilder::onGetTrainingProgram(const QJsonValue &msgConten
     QString fileXml;
     if (homeform::singleton() && homeform::singleton()->trainingProgram()) {
         QList<trainrow> lst = homeform::singleton()->trainingProgram()->loadedRows;
-        for (auto &row : lst) {
-            QJsonObject item;
-            TRAINPROGRAM_FIELD_TO_STRING();
-            if (!row.textEvents.isEmpty()) {
-                QJsonArray textEvents;
-                for (const auto &evt : row.textEvents) {
-                    QJsonObject textEvent;
-                    textEvent[QStringLiteral("timeoffset")] = static_cast<int>(evt.timeoffset);
-                    textEvent[QStringLiteral("message")] = evt.message;
-                    textEvents.append(textEvent);
+        int idx = 0;
+        while (idx < lst.size()) {
+            const trainrow &curRow = lst[idx];
+            if (curRow.rampPowerFromOriginal >= 0.0) {
+                double fromOrig = curRow.rampPowerFromOriginal;
+                double toOrig = curRow.rampPowerToOriginal;
+                bool isFtp = curRow.rampIsFtpFraction;
+                trainrow firstRow = curRow;
+                int totalSecs = 0;
+                while (idx < lst.size() &&
+                       lst[idx].rampPowerFromOriginal == fromOrig &&
+                       lst[idx].rampPowerToOriginal == toOrig) {
+                    totalSecs += QTime(0,0,0).secsTo(lst[idx].duration);
+                    idx++;
                 }
-                item[QStringLiteral("textEvents")] = textEvents;
+                QJsonObject item;
+                {
+                    trainrow compactRow = firstRow;
+                    compactRow.duration = QTime(0,0,0).addSecs(totalSecs);
+                    compactRow.rampPowerFromOriginal = -1.0;
+                    compactRow.rampPowerToOriginal = -1.0;
+                    const trainrow &row = compactRow;
+                    TRAINPROGRAM_FIELD_TO_STRING();
+                }
+                item[QStringLiteral("duration")] = QTime(0,0,0).addSecs(totalSecs).toString(QStringLiteral("hh:mm:ss"));
+                if (isFtp) {
+                    item[QStringLiteral("powerzonefrom")] = fromOrig;
+                    item[QStringLiteral("powerzoneto")] = toOrig;
+                    item[QStringLiteral("powerrampunit")] = QStringLiteral("% FTP");
+                } else {
+                    item[QStringLiteral("powerfrom")] = (int)fromOrig;
+                    item[QStringLiteral("powerto")] = (int)toOrig;
+                    item[QStringLiteral("powerrampunit")] = QStringLiteral("W");
+                }
+                outArr.append(item);
+            } else {
+                QJsonObject item;
+                const trainrow &row = curRow;
+                TRAINPROGRAM_FIELD_TO_STRING();
+                if (!curRow.textEvents.isEmpty()) {
+                    QJsonArray textEvents;
+                    for (const auto &evt : curRow.textEvents) {
+                        QJsonObject textEvent;
+                        textEvent[QStringLiteral("timeoffset")] = static_cast<int>(evt.timeoffset);
+                        textEvent[QStringLiteral("message")] = evt.message;
+                        textEvents.append(textEvent);
+                    }
+                    item[QStringLiteral("textEvents")] = textEvents;
+                }
+                outArr.append(item);
+                idx++;
             }
-            outArr.append(item);
         }
         outObj[QStringLiteral("device")] =
             trainprogram::deviceTypeToXmlKey(homeform::singleton()->trainingProgram()->loadedDeviceType);
@@ -881,6 +922,7 @@ void TemplateInfoSenderBuilder::onWorkoutEditorEnv(TemplateInfoSender *tempSende
     QSettings settings;
     bool miles = settings.value(QZSettings::miles_unit, QZSettings::default_miles_unit).toBool();
     outObj[QStringLiteral("miles")] = miles;
+    outObj[QStringLiteral("ftp")] = settings.value(QZSettings::ftp, QZSettings::default_ftp).toDouble();
     if (device) {
         outObj[QStringLiteral("device")] = trainprogram::deviceTypeToXmlKey(device->deviceType());
     } else {
@@ -1123,6 +1165,24 @@ void TemplateInfoSenderBuilder::onSaveTrainingProgram(const QJsonValue &msgConte
             }
             if (row.contains(QStringLiteral("power"))) {
                 tR.power = row[QStringLiteral("power")].toInt();
+            }
+            if (row.contains(QStringLiteral("powerfrom")) && row.contains(QStringLiteral("powerto"))) {
+                double from = row[QStringLiteral("powerfrom")].toDouble();
+                double to = row[QStringLiteral("powerto")].toDouble();
+                tR.power = (int)from;
+                tR.rampPowerFromOriginal = from;
+                tR.rampPowerToOriginal = to;
+                tR.rampIsFtpFraction = false;
+            }
+            if (row.contains(QStringLiteral("powerzonefrom")) && row.contains(QStringLiteral("powerzoneto"))) {
+                QSettings localSettings;
+                double from = row[QStringLiteral("powerzonefrom")].toDouble();
+                double to = row[QStringLiteral("powerzoneto")].toDouble();
+                double ftp = localSettings.value(QZSettings::ftp, QZSettings::default_ftp).toDouble();
+                tR.power = (int)(from * ftp);
+                tR.rampPowerFromOriginal = from;
+                tR.rampPowerToOriginal = to;
+                tR.rampIsFtpFraction = true;
             }
             if (row.contains(QStringLiteral("cadence"))) {
                 tR.cadence = row[QStringLiteral("cadence")].toInt();

--- a/src/trainprogram.cpp
+++ b/src/trainprogram.cpp
@@ -2115,16 +2115,15 @@ QList<trainrow> trainprogram::loadXML(const QString &filename, BLUETOOTH_TYPE de
                 for (int i = 0; i < speedDelta; i++) {
                     trainrow rowI(row);
                     int spare = 0;
-                    if (spareSeconds)
-                        spare = (i % spareSeconds == 0 && i > 0) ? 1 : 0;
-                    spareSum += spare;
-                    if (i == speedDelta && spareSum < spareSeconds) {
-                        spare += (spareSeconds - spareSum) - durationStep;
-                        spareSum = spareSeconds;
+                    if (spareSeconds) {
+                        int before = (int)((qint64)i * spareSeconds / speedDelta);
+                        int after = (int)((qint64)(i + 1) * spareSeconds / speedDelta);
+                        spare = after - before;
                     }
+                    spareSum += spare;
                     rowI.duration = QTime(0, 0, 0, 0).addSecs(durationStep + spare);
-                    rowI.rampElapsed = QTime(0, 0, 0, 0).addSecs((durationStep * i) + spareSum);
-                    rowI.rampDuration = QTime(0, 0, 0, 0).addSecs(durationS - (durationStep * i) - spareSum - durationStep + spare);
+                    rowI.rampElapsed = QTime(0, 0, 0, 0).addSecs((durationStep * i) + spareSum - spare);
+                    rowI.rampDuration = QTime(0, 0, 0, 0).addSecs(durationS - (durationStep * (i + 1)) - spareSum);
                     rowI.forcespeed = 1;
                     if (speedFrom < speedTo) {
                         if(device_type == TREADMILL) {
@@ -2181,16 +2180,15 @@ QList<trainrow> trainprogram::loadXML(const QString &filename, BLUETOOTH_TYPE de
                 for (int i = 0; i < powerDelta; i++) {
                     trainrow rowI(row);
                     int spare = 0;
-                    if (spareSeconds)
-                        spare = (i % spareSeconds == 0 && i > 0) ? 1 : 0;
-                    spareSum += spare;
-                    if (i == powerDelta && spareSum < spareSeconds) {
-                        spare += (spareSeconds - spareSum) - durationStep;
-                        spareSum = spareSeconds;
+                    if (spareSeconds) {
+                        int before = (int)((qint64)i * spareSeconds / powerDelta);
+                        int after = (int)((qint64)(i + 1) * spareSeconds / powerDelta);
+                        spare = after - before;
                     }
+                    spareSum += spare;
                     rowI.duration = QTime(0, 0, 0, 0).addSecs(durationStep + spare);
-                    rowI.rampElapsed = QTime(0, 0, 0, 0).addSecs((durationStep * i) + spareSum);
-                    rowI.rampDuration = QTime(0, 0, 0, 0).addSecs(durationS - (durationStep * i) - spareSum - durationStep + spare);
+                    rowI.rampElapsed = QTime(0, 0, 0, 0).addSecs((durationStep * i) + spareSum - spare);
+                    rowI.rampDuration = QTime(0, 0, 0, 0).addSecs(durationS - (durationStep * (i + 1)) - spareSum);
                     if (powerFrom <= powerTo) {
                         rowI.power = (int)(powerFrom + (powerStep * i));
                     } else {

--- a/src/trainprogram.cpp
+++ b/src/trainprogram.cpp
@@ -1764,7 +1764,15 @@ bool trainprogram::saveXML(const QString &filename, const QList<trainrow> &rows,
             if (row.upper_cadence >= 0) {
                 stream.writeAttribute(QStringLiteral("upper_cadence"), QString::number(row.upper_cadence));
             }
-            if (row.power >= 0) {
+            if (row.rampPowerFromOriginal >= 0.0 && row.rampPowerToOriginal >= 0.0) {
+                if (row.rampIsFtpFraction) {
+                    stream.writeAttribute(QStringLiteral("powerzonefrom"), QString::number(row.rampPowerFromOriginal, 'f', 4));
+                    stream.writeAttribute(QStringLiteral("powerzoneto"), QString::number(row.rampPowerToOriginal, 'f', 4));
+                } else {
+                    stream.writeAttribute(QStringLiteral("powerfrom"), QString::number((int)row.rampPowerFromOriginal));
+                    stream.writeAttribute(QStringLiteral("powerto"), QString::number((int)row.rampPowerToOriginal));
+                }
+            } else if (row.power >= 0) {
                 stream.writeAttribute(QStringLiteral("power"), QString::number(row.power));
             }
             if (row.waitForLap) {
@@ -2135,7 +2143,63 @@ QList<trainrow> trainprogram::loadXML(const QString &filename, BLUETOOTH_TYPE de
                                          settings.value(QZSettings::ftp, QZSettings::default_ftp).toDouble();
                         }
                     }
+                    rowI.rampIsFtpFraction = true;
+                    rowI.rampPowerFromOriginal = speedFrom;
+                    rowI.rampPowerToOriginal = speedTo;
                     qDebug() << "TrainRow" << rowI.toString();
+                    if (insideRepeat) {
+                        repeatRows.append(rowI);
+                    } else {
+                        list.append(rowI);
+                    }
+                }
+                ramp = true;
+            }
+            if (atts.hasAttribute(QStringLiteral("powerfrom")) && atts.hasAttribute(QStringLiteral("powerto")) &&
+                atts.hasAttribute(QStringLiteral("duration"))) {
+                int powerFrom = atts.value(QStringLiteral("powerfrom")).toInt();
+                int powerTo = atts.value(QStringLiteral("powerto")).toInt();
+                QTime duration = QTime::fromString(atts.value(QStringLiteral("duration")).toString(), QStringLiteral("hh:mm:ss"));
+                int durationS = duration.hour() * 3600 + duration.minute() * 60 + duration.second();
+                int powerDelta = abs(powerTo - powerFrom);
+                int durationStep;
+                double powerStep;
+                int spareSeconds;
+                if (powerDelta == 0)
+                    powerDelta = 1;
+                if (powerDelta <= durationS) {
+                    durationStep = durationS / powerDelta;
+                    powerStep = 1.0;
+                    spareSeconds = durationS % powerDelta;
+                } else {
+                    durationStep = 1;
+                    powerStep = (double)abs(powerTo - powerFrom) / (durationS - 1);
+                    powerDelta = durationS - 1;
+                    spareSeconds = 0;
+                }
+                int spareSum = 0;
+                for (int i = 0; i < powerDelta; i++) {
+                    trainrow rowI(row);
+                    int spare = 0;
+                    if (spareSeconds)
+                        spare = (i % spareSeconds == 0 && i > 0) ? 1 : 0;
+                    spareSum += spare;
+                    if (i == powerDelta && spareSum < spareSeconds) {
+                        spare += (spareSeconds - spareSum) - durationStep;
+                        spareSum = spareSeconds;
+                    }
+                    rowI.duration = QTime(0, 0, 0, 0).addSecs(durationStep + spare);
+                    rowI.rampElapsed = QTime(0, 0, 0, 0).addSecs((durationStep * i) + spareSum);
+                    rowI.rampDuration = QTime(0, 0, 0, 0).addSecs(durationS - (durationStep * i) - spareSum - durationStep + spare);
+                    if (powerFrom <= powerTo) {
+                        rowI.power = (int)(powerFrom + (powerStep * i));
+                    } else {
+                        rowI.power = (int)(powerFrom - (powerStep * i));
+                    }
+                    rowI.rampIsFtpFraction = false;
+                    rowI.rampPowerFromOriginal = (double)powerFrom;
+                    rowI.rampPowerToOriginal = (double)powerTo;
+                    qDebug() << "TrainRow (power ramp)" << rowI.toString();
                     if (insideRepeat) {
                         repeatRows.append(rowI);
                     } else {

--- a/src/trainprogram.h
+++ b/src/trainprogram.h
@@ -58,6 +58,9 @@ class trainrow {
     double minSpeed = -1;
     int8_t maxResistance = -1;
     int32_t power = -1;
+    bool rampIsFtpFraction = false;
+    double rampPowerFromOriginal = -1.0;
+    double rampPowerToOriginal = -1.0;
     int32_t mets = -1;
     bool waitForLap = false;
     QTime rampDuration = QTime(0, 0, 0, 0); // QZ split the ramp in 1 second segments. This field will tell you how long


### PR DESCRIPTION
## Summary

Adds native power ramp interval support to the built-in workout editor, allowing users to define intervals where power increases or decreases linearly from one value to another over the interval duration.

- **Two new fields in Advanced mode** (bike / rower only): *Ramp From* and *Ramp To*
- **Unit combo box**: switch between absolute **W** (watts) and **% FTP** (fraction of FTP, e.g. 27 → 60 means 27 % FTP → 60 % FTP)
- **Round-trip safe**: save → reload shows one compact ramp row in the editor, not hundreds of 1-second segments
- **Chart preview** renders a sloped line for ramp intervals; % FTP values are converted to watts using the current FTP for correct visual scale
- **Existing Zwift `.zwo` ramp support unchanged** (`<Warmup>`, `<Ramp>`, `<Cooldown>` tags keep working as before)

## How it works

### XML format

| User selects | XML saved |
|---|---|
| W | `powerfrom="40" powerto="90"` |
| % FTP | `powerzonefrom="0.2700" powerzoneto="0.6000"` |

At load time both formats are expanded into 1-second `trainrow` segments with linearly interpolated power (same mechanism used by Zwift workouts). Each expanded row carries the original endpoints (`rampPowerFromOriginal` / `rampPowerToOriginal`) so the backend can collapse them back into a single compact row when the editor requests the program.

### Data flow

```
Editor (JS)
  └─ buildPayload()  →  powerfrom/powerto  OR  powerzonefrom/powerzoneto
       └─ onSaveTrainingProgram()  →  trainrow{rampPowerFromOriginal, rampPowerToOriginal, rampIsFtpFraction}
            └─ saveXML()  →  compact XML attribute
                 └─ loadXML()  →  N × 1-second trainrow (for training execution)
                      └─ onGetTrainingProgram()  →  collapses N rows → 1 compact JSON row
                           └─ convertRow() in JS  →  interval with powerrampunit + powerfrom/powerto
```

## Files changed

| File | Change |
|---|---|
| `src/trainprogram.h` | Added `rampIsFtpFraction`, `rampPowerFromOriginal`, `rampPowerToOriginal` to `trainrow` |
| `src/trainprogram.cpp` | `saveXML`: writes compact ramp attributes; `loadXML`: tags expanded rows with original endpoints |
| `src/templateinfosenderbuilder.cpp` | `onGetTrainingProgram`: collapses ramp sequences; `onSaveTrainingProgram`: parses both ramp formats |
| `src/inner_templates/workouteditor/workout-editor-app.js` | New `select` field type, 3 new FIELD_DEFS entries, `buildPayload` ramp override, `convertRow` ramp detection, chart slope rendering |

## Test plan

- [ ] Add a ramp interval in W (e.g. 40 W → 90 W, 2 min), save, reload → editor shows one row with correct values
- [ ] Add a ramp interval in % FTP (e.g. 27 % → 60 %, 2 min), save, reload → editor shows one row with correct % values
- [ ] Start a saved ramp workout → power ramps correctly during execution
- [ ] Switch unit combo W → % FTP → suffix on Ramp From/To fields updates immediately
- [ ] Chart preview shows a sloped line for ramp intervals
- [ ] Load an existing Zwift `.zwo` file with `<Warmup>`/`<Ramp>`/`<Cooldown>` → still works, no regression
- [ ] Non-ramp (steady) intervals unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)