### PR TITLE
fix: virtualrower stroke count zero breaks avatar arm animation in MyWhoosh

### DIFF
--- a/src/devices/sportsplusrower/sportsplusrower.cpp
+++ b/src/devices/sportsplusrower/sportsplusrower.cpp
@@ -146,8 +146,10 @@ void sportsplusrower::characteristicChanged(const QLowEnergyCharacteristic &char
     }
 
     if (!firstCharChanged) {
-        Distance +=
-            ((Speed.value() / 3600.0) / (1000.0 / (lastTimeCharChanged.msecsTo(now))));
+        double elapsedMs = lastTimeCharChanged.msecsTo(now);
+        Distance += ((Speed.value() / 3600.0) / (1000.0 / elapsedMs));
+        // Accumulate stroke count from cadence since the device doesn't send it directly
+        StrokesCount += (Cadence.value() / 60.0) * (elapsedMs / 1000.0);
     }
 
     lastTimeCharChanged = now;

--- a/src/virtualdevices/virtualrower.cpp
+++ b/src/virtualdevices/virtualrower.cpp
@@ -475,10 +475,15 @@ void virtualrower::rowerProvider() {
     uint32_t strokeCount = 0;
     if (Rower->deviceType() == ROWING) {
         strokeCount = ((rower *)Rower)->currentStrokesCount().value();
-    } else {
-        // For bikes/other devices, estimate strokes from cadence
-        strokeCount = (uint32_t)(Rower->currentCadence().value() * 2 * Rower->movingTime().hour() * 3600 +
-                                 Rower->movingTime().minute() * 60 + Rower->movingTime().second());
+    }
+    // If the device doesn't expose stroke count, estimate from cadence × elapsed time.
+    // MyWhoosh drives avatar arm animation from an incrementing stroke count, not stroke rate,
+    // so a perpetual zero keeps the avatar frozen even when stroke rate is non-zero.
+    if (strokeCount == 0 && Rower->currentCadence().value() > 0) {
+        double totalSeconds = Rower->movingTime().hour() * 3600.0 +
+                              Rower->movingTime().minute() * 60.0 +
+                              Rower->movingTime().second();
+        strokeCount = (uint32_t)(Rower->currentCadence().value() * totalSeconds / 60.0);
     }
 
     // Get pace based on device type


### PR DESCRIPTION
## Summary

Fixes #4810

- **Root cause**: when a ROWING device (e.g. CARE Jet 600) doesn't expose `strokeCount` in its BLE packets, `currentStrokesCount()` returns 0. The FTMS 0x2AD1 packet was therefore always transmitting `strokeCount = 0`, even while the boat was moving and stroke rate was non-zero.
- **Why the avatar freezes**: MyWhoosh drives the avatar arm animation from an *incrementing* stroke count, not from stroke rate alone. A constant zero tells MyWhoosh no strokes have ever occurred → avatar stays frozen.
- **Secondary fix**: the previous fallback formula for non-ROWING devices (`cadence * 2 * hours * 3600 + minutes * 60 + seconds`) was dimensionally incorrect and produced a garbage value. Replaced with `cadence * totalSeconds / 60`.

## Change

When `strokeCount` is 0 after reading from the device but cadence is non-zero, compute an estimated stroke count from `cadence × elapsedSeconds / 60`. This is the same approach already used in `buildPM5StrokeData()` for the PM5 path.

## Test plan

- [ ] Connect a rower that exposes `strokeCount` natively — behaviour unchanged (device value takes priority, fallback is skipped because `strokeCount > 0`)
- [ ] Connect CARE Jet 600 or any rower where `currentStrokesCount()` returns 0 — stroke count now increments correctly and avatar arms animate in MyWhoosh
- [ ] Verify non-ROWING devices (bikes used as virtual rower) produce a sensible stroke count

🤖 Generated with [Claude Code](https://claude.com/claude-code)