### PR TITLE
fix: wahoo setSimGrade sent before setSimMode (KICKR CORE race condition)

### DIFF
--- a/src/devices/wahookickrsnapbike/wahookickrsnapbike.cpp
+++ b/src/devices/wahookickrsnapbike/wahookickrsnapbike.cpp
@@ -717,6 +717,8 @@ void wahookickrsnapbike::stateChanged(QLowEnergyService::ServiceState state) {
 
     qDebug() << QStringLiteral("all services discovered!");
 
+    const QBluetoothUuid cyclingPowerMeasurementUuid = QBluetoothUuid::CyclingPowerMeasurement;
+
     for (QLowEnergyService *s : qAsConst(gattCommunicationChannelService)) {
         if (s->state() == QLowEnergyService::ServiceDiscovered) {
             // establish hook into notifications
@@ -743,6 +745,15 @@ void wahookickrsnapbike::stateChanged(QLowEnergyService::ServiceState state) {
                     qDebug() << QStringLiteral("Custom service and Control Point found");
                     gattWriteCharacteristic = c;
                     gattPowerChannelService = s;
+                }
+
+                // Only subscribe to CyclingPowerMeasurement to avoid a race where the
+                // descriptorWritten counter (17 descriptors on KICKR CORE) hasn't reached
+                // zero before Zwift sends the first indoor-bike-simulation-parameters
+                // write, causing setSimGrade to be sent without a prior setSimMode.
+                if (c.uuid() != cyclingPowerMeasurementUuid) {
+                    qDebug() << QStringLiteral("skipping subscription for") << s->serviceUuid() << c.uuid();
+                    continue;
                 }
 
                 if ((c.properties() & QLowEnergyCharacteristic::Notify) == QLowEnergyCharacteristic::Notify) {
@@ -782,6 +793,15 @@ void wahookickrsnapbike::stateChanged(QLowEnergyService::ServiceState state) {
                 }
             }
         }
+    }
+
+    // If no CyclingPowerMeasurement subscription was established (e.g. device not yet
+    // advertising that characteristic), fire init immediately so setSimMode is always
+    // sent before the first setSimGrade arrives from Zwift.
+    if (!notificationSubscribed) {
+        qDebug() << QStringLiteral("No CyclingPowerMeasurement subscription established, firing init immediately");
+        initRequest = true;
+        emit connectedAndDiscovered();
     }
 
     // ******************************************* virtual bike init *************************************


### PR DESCRIPTION
## Problem

On KICKR CORE (and similar Wahoo devices), `setSimGrade` was being sent to the trainer **before** `setSimMode` had ever been sent.

### Root cause

`stateChanged()` subscribes to **all** notifiable/indicatable characteristics across all BLE services. On a KICKR CORE this amounts to 17 descriptor writes (`notificationSubscribed = 17`). The `descriptorWritten` callbacks arrive slowly from the BLE stack — in the reported log only 9 of the 17 had arrived by the time Zwift sent its first `indoor bike simulation parameters` FTMS command (~30 seconds after connection).

Since `notificationSubscribed` never reached 0, `initRequest` was never set to `true`, so the `update()` init block (which sends `unlock` → `setSimMode` → `setWheelCircumference`) never ran.

Meanwhile Zwift's FTMS write flows through a direct signal/slot path:
`CharacteristicWriteProcessor2AD9 → changeSlope → inclinationChanged → setSimGrade`
…which bypasses `initRequest` entirely, sending `setSimGrade` to a trainer that had never received `setSimMode`.

## Fix

Subscribe **only to `CyclingPowerMeasurement`** during `stateChanged()` — at most 1 descriptor write — so `descriptorWritten` fires almost immediately and the init sequence (including `setSimMode`) completes before Zwift can send the first slope command.

A fallback is also added: if no `CyclingPowerMeasurement` subscription was established at all, `initRequest` is set directly from `stateChanged()` so the init always runs.

This is a minimal, targeted fix. A previous attempt ([PR #4530](https://github.com/cagnulein/qdomyos-zwift/pull/4530), closed as wontfix) addressed the same issue with additional unrelated changes; this PR contains only the essential change.

## Test plan

- [ ] Connect KICKR CORE and verify `setSimMode` appears in the log before the first `setSimGrade`
- [ ] Ride in Zwift: resistance/slope changes should work correctly from the start
- [ ] Verify no regression for KICKR SNAP and KICKR BIKE (ERG mode, gear mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)