### PR TITLE
fix: FS- beta treadmills discover only FTMS service (0x1826)

### DIFF
--- a/src/devices/horizontreadmill/horizontreadmill.cpp
+++ b/src/devices/horizontreadmill/horizontreadmill.cpp
@@ -2621,6 +2621,11 @@ void horizontreadmill::serviceScanDone(void) {
                 qDebug() << s << "skipping (DOMYOS-TC will use only FTMS)";
                 continue;
             }
+            // FS- beta devices: discover only FTMS (1826) to avoid issues with other services
+            if (FS_BETA_TREADMILL && s != _FTMSServiceId) {
+                qDebug() << s << "skipping (FS- beta: using only FTMS 0x1826)";
+                continue;
+            }
 
             qDebug() << s << "discovering...";
             gattCommunicationChannelService.append(m_control->createServiceObject(s));
@@ -2779,6 +2784,10 @@ void horizontreadmill::deviceDiscovered(const QBluetoothDeviceInfo &device) {
             qDebug() << QStringLiteral("FS- treadmill found");
             FS_TREADMILL = true;
             maxInclination = 40.0;
+            if (device.name().contains(QStringLiteral("(beta)"))) {
+                qDebug() << QStringLiteral("FS- beta treadmill: will use only FTMS service (0x1826)");
+                FS_BETA_TREADMILL = true;
+            }
         }
 
         if (device.name().toUpper().startsWith(QStringLiteral("TRX3500"))) {

--- a/src/devices/horizontreadmill/horizontreadmill.h
+++ b/src/devices/horizontreadmill/horizontreadmill.h
@@ -127,6 +127,7 @@ class horizontreadmill : public treadmill {
     bool TM4500 = false;
     bool TM6500 = false;
     bool FS_TREADMILL = false;
+    bool FS_BETA_TREADMILL = false;
     bool WT_TREADMILL = false;
     bool THERUN_T15 = false;
     bool MERACH_TREADMILL = false;


### PR DESCRIPTION
## Summary

Closes #4808

Devices handled by `horizontreadmill` that start with `FS-` and contain `(beta)` in the name were performing a full BLE service discovery, which could cause connection issues. This PR limits discovery to the FTMS service (`0x1826`) only for these devices.

- Add `FS_BETA_TREADMILL` flag in `horizontreadmill.h`
- Set the flag in `deviceDiscovered()` when the device name starts with `"FS-"` and contains `"(beta)"`
- In `serviceScanDone()`, skip all services except `0x1826` when `FS_BETA_TREADMILL` is true (same pattern already used for DOMYOS-TC devices)

## Test plan

- [ ] Connect a device whose name starts with `FS-` and contains `(beta)` and verify only service `0x1826` is discovered in the debug log
- [ ] Connect a regular `FS-` device (without `(beta)`) and verify full service discovery still happens
- [ ] Verify no regression on other treadmill types handled by `horizontreadmill`

🤖 Generated with [Claude Code](https://claude.com/claude-code)