### PR TITLE
[codex] Stabilize Android floating window touch handling

### DIFF
--- a/src/android/src/FloatingWindowGFG.java
+++ b/src/android/src/FloatingWindowGFG.java
@@ -15,6 +15,7 @@ import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
 import android.view.View;
+import android.view.ViewConfiguration;
 import android.view.ViewGroup;
 import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
@@ -106,6 +107,7 @@ public class FloatingWindowGFG extends Service {
                   webView.measure(100, 100);
                   webView.setAlpha(Float.valueOf(FloatingHandler._alpha) / 100.0f);
                   settings.setBuiltInZoomControls(true);
+                  settings.setDisplayZoomControls(false);
                   settings.setUseWideViewPort(true);
                   settings.setDomStorageEnabled(true);
                   QLog.d("QZ","loadurl");
@@ -173,7 +175,7 @@ public class FloatingWindowGFG extends Service {
 				float initialTouchX;
 				float initialTouchY;
 				boolean isDragging = false;
-				final int TOUCH_THRESHOLD = 10; // Threshold for distinguishing tap vs drag
+				final int TOUCH_THRESHOLD = ViewConfiguration.get(FloatingWindowGFG.this).getScaledTouchSlop(); // density-aware threshold for distinguishing tap vs drag
 
 				@Override
 				public boolean onTouch(View v, MotionEvent event) {

--- a/src/inner_templates/floating/hfloating.htm
+++ b/src/inner_templates/floating/hfloating.htm
@@ -511,6 +511,7 @@
                       event.target.closest("#metric-selector") === null &&
                       event.target.closest("#complete-panel") === null &&
                       event.target.closest(".quick-actions") === null &&
+                      event.target.closest("button") === null &&
                       !event.target.classList.contains("quick-action-btn")) {
                     toggleControlsPanel();
                   }


### PR DESCRIPTION
## Summary
- Hide Android WebView on-screen zoom controls in the floating window so they do not overlap in-window controls.
- Use the platform touch slop instead of a hard-coded drag threshold for floating window movement.

## Why
Users reported the floating window jumping while adjusting Peloton/resistance controls, with the WebView zoom button interfering with +/- controls.

## Validation
- Installed and tested the latest GitHub full release APK on device 192.168.0.210 as a baseline.
- Opened the regular floating window, scrolled to RESISTANCE/P.RESISTANCE, and tapped +/- without reproducing a jump.
- Local Android rebuild was not run for this small Java-only change.
