### PR TITLE
Fix zero Speed and Cadence on Life Fitness ellipticals (FTMS Cross Trainer)

### DIFF
--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -1232,7 +1232,14 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                         (b.name().startsWith(QStringLiteral("FS-")) &&
                          (iconsole_elliptical || settings.value(QZSettings::gymstick_gx6_0_elliptical,
                                                                QZSettings::default_gymstick_gx6_0_elliptical).toBool())) ||
-                        !b.name().compare(ftms_elliptical, Qt::CaseInsensitive)) && !ypooElliptical && !horizonTreadmill && ftms_bike.contains(QZSettings::default_ftms_bike) && filter) {
+                        !b.name().compare(ftms_elliptical, Qt::CaseInsensitive) ||
+                        // Route ANY Life Fitness elliptical here when the user opts in, so they don't
+                        // have to set ftms_elliptical to each machine's rotating name. Same LF+hex shape
+                        // as the LF treadmill, so it is guarded by an explicit setting (default off) and
+                        // the treadmill branch below is skipped when it is on.
+                        (settings.value(QZSettings::life_fitness_elliptical, QZSettings::default_life_fitness_elliptical).toBool() &&
+                         b.name().toUpper().startsWith(QStringLiteral("LF")) && (b.name().length() == 18 || b.name().length() == 15))) &&
+                       !ypooElliptical && !horizonTreadmill && ftms_bike.contains(QZSettings::default_ftms_bike) && filter) {
                 this->setLastBluetoothDevice(b);
                 this->stopDiscovery();
                 ypooElliptical =
@@ -1582,7 +1589,8 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 }
                 this->signalBluetoothDeviceConnected(speraXTreadmill);
             } else if ((b.name().toUpper().startsWith(QStringLiteral("LF")) && (b.name().length() == 18 || b.name().length() == 15)) &&
-                       !lifefitnessTreadmill && !ypooElliptical && filter) {
+                       !lifefitnessTreadmill && !ypooElliptical && filter &&
+                       !settings.value(QZSettings::life_fitness_elliptical, QZSettings::default_life_fitness_elliptical).toBool()) {
                 // !ypooElliptical: Life Fitness ellipticals share this exact name shape with the treadmills.
                 // Once a device has been claimed as an FTMS elliptical (via the ftms_elliptical setting), a
                 // later advertisement must not also hand it to the treadmill driver - otherwise both drivers

--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -1582,7 +1582,11 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 }
                 this->signalBluetoothDeviceConnected(speraXTreadmill);
             } else if ((b.name().toUpper().startsWith(QStringLiteral("LF")) && (b.name().length() == 18 || b.name().length() == 15)) &&
-                       !lifefitnessTreadmill && filter) {
+                       !lifefitnessTreadmill && !ypooElliptical && filter) {
+                // !ypooElliptical: Life Fitness ellipticals share this exact name shape with the treadmills.
+                // Once a device has been claimed as an FTMS elliptical (via the ftms_elliptical setting), a
+                // later advertisement must not also hand it to the treadmill driver - otherwise both drivers
+                // connect to the same machine and both parse 0x2ACE.
                 this->setLastBluetoothDevice(b);
                 this->stopDiscovery();
                 lifefitnessTreadmill = new lifefitnesstreadmill(noWriteResistance, noHeartService);

--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -1622,7 +1622,11 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 }
                 this->signalBluetoothDeviceConnected(speraXTreadmill);
             } else if ((b.name().toUpper().startsWith(QStringLiteral("LF")) && (b.name().length() == 18 || b.name().length() == 15)) &&
-                       !lifefitnessTreadmill && filter) {
+                       !lifefitnessTreadmill && !ypooElliptical && filter) {
+                // !ypooElliptical: Life Fitness ellipticals share this exact name shape with the treadmills.
+                // Once a device has been claimed as an FTMS elliptical (via the ftms_elliptical setting), a
+                // later advertisement must not also hand it to the treadmill driver - otherwise both drivers
+                // connect to the same machine and both parse 0x2ACE.
                 this->setLastBluetoothDevice(b);
                 this->stopDiscovery();
                 lifefitnessTreadmill = new lifefitnesstreadmill(noWriteResistance, noHeartService);

--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -1272,7 +1272,14 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                         (b.name().startsWith(QStringLiteral("FS-")) &&
                          (iconsole_elliptical || settings.value(QZSettings::gymstick_gx6_0_elliptical,
                                                                QZSettings::default_gymstick_gx6_0_elliptical).toBool())) ||
-                        !b.name().compare(ftms_elliptical, Qt::CaseInsensitive)) && !ypooElliptical && !horizonTreadmill && ftms_bike.contains(QZSettings::default_ftms_bike) && filter) {
+                        !b.name().compare(ftms_elliptical, Qt::CaseInsensitive) ||
+                        // Route ANY Life Fitness elliptical here when the user opts in, so they don't
+                        // have to set ftms_elliptical to each machine's rotating name. Same LF+hex shape
+                        // as the LF treadmill, so it is guarded by an explicit setting (default off) and
+                        // the treadmill branch below is skipped when it is on.
+                        (settings.value(QZSettings::life_fitness_elliptical, QZSettings::default_life_fitness_elliptical).toBool() &&
+                         b.name().toUpper().startsWith(QStringLiteral("LF")) && (b.name().length() == 18 || b.name().length() == 15))) &&
+                       !ypooElliptical && !horizonTreadmill && ftms_bike.contains(QZSettings::default_ftms_bike) && filter) {
                 this->setLastBluetoothDevice(b);
                 this->stopDiscovery();
                 ypooElliptical =
@@ -1622,7 +1629,8 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 }
                 this->signalBluetoothDeviceConnected(speraXTreadmill);
             } else if ((b.name().toUpper().startsWith(QStringLiteral("LF")) && (b.name().length() == 18 || b.name().length() == 15)) &&
-                       !lifefitnessTreadmill && !ypooElliptical && filter) {
+                       !lifefitnessTreadmill && !ypooElliptical && filter &&
+                       !settings.value(QZSettings::life_fitness_elliptical, QZSettings::default_life_fitness_elliptical).toBool()) {
                 // !ypooElliptical: Life Fitness ellipticals share this exact name shape with the treadmills.
                 // Once a device has been claimed as an FTMS elliptical (via the ftms_elliptical setting), a
                 // later advertisement must not also hand it to the treadmill driver - otherwise both drivers

--- a/src/devices/ypooelliptical/ypooelliptical.cpp
+++ b/src/devices/ypooelliptical/ypooelliptical.cpp
@@ -393,11 +393,16 @@ void ypooelliptical::characteristicChanged(const QLowEnergyCharacteristic &chara
                 if (totalDistanceMeters != lastTotalDistance) {
                     if (lastTotalDistance > 0 && totalDistanceMeters > lastTotalDistance) {
                         qint64 elapsedMs = lastTotalDistanceChanged.msecsTo(now);
-                        // Require a substantial sampling interval: a short/jittery gap turns the 1m
-                        // distance quantum into a huge apparent speed (a 3m step over 200ms reads as
-                        // 54 km/h). Replaying a full captured session with a 500ms floor still let
-                        // spikes to 28.6 km/h through - about 18 mph on an elliptical - so require
-                        // 2.5s of span. This removes the spikes without moving the median at all.
+                        // Require a substantial span before trusting a figure: the field has 1m
+                        // resolution at ~1Hz, so a single-tick delta is very coarse (a 2m vs 3m step
+                        // is 7.2 vs 10.8 km/h) and a short gap turns that quantum into a huge
+                        // apparent speed.
+                        //
+                        // The anchor (lastTotalDistance / lastTotalDistanceChanged) is deliberately
+                        // NOT advanced until a speed is actually computed. Advancing it on every tick
+                        // would pin elapsedMs to the ~1s inter-tick gap, so it could never reach the
+                        // threshold and speed would never be produced at all. Letting it accumulate
+                        // turns this into a true >=2.5s windowed average.
                         if (elapsedMs >= 2500) {
                             double candidate = (((double)(totalDistanceMeters - lastTotalDistance)) / 1000.0) /
                                                (((double)elapsedMs) / 3600000.0);
@@ -407,10 +412,15 @@ void ypooelliptical::characteristicChanged(const QLowEnergyCharacteristic &chara
                                 emit debug(QStringLiteral("Current Speed (from totDistance): ") +
                                            QString::number(Speed.value()));
                             }
+                            // advance the anchor only after a computation
+                            lastTotalDistance = totalDistanceMeters;
+                            lastTotalDistanceChanged = now;
                         }
+                    } else {
+                        // first sample, or the machine reset its odometer: (re-)anchor here
+                        lastTotalDistance = totalDistanceMeters;
+                        lastTotalDistanceChanged = now;
                     }
-                    lastTotalDistance = totalDistanceMeters;
-                    lastTotalDistanceChanged = now;
                 } else if (lastTotalDistanceChanged.msecsTo(now) > 3000) {
                     // Distance stopped advancing: the user stopped pedalling, so don't hold the last speed.
                     instantSpeed = 0.0;

--- a/src/devices/ypooelliptical/ypooelliptical.cpp
+++ b/src/devices/ypooelliptical/ypooelliptical.cpp
@@ -322,13 +322,24 @@ void ypooelliptical::characteristicChanged(const QLowEnergyCharacteristic &chara
             return true;
         };
 
-        Flags.word_flags = (lastPacket.at(2) << 16) | (lastPacket.at(1) << 8) | lastPacket.at(0);
+        // Cast every byte to uint8_t before shifting. QByteArray::at() returns a signed
+        // char, so a flags byte with bit 7 set (>= 0x80) sign-extends to 0xFFFFFFxx and
+        // spuriously turns on every high flag bit (expEnergy, heartRate, elapsedTime...).
+        // Life Fitness sends flags 0x3db4 - low byte 0xb4 - which triggers exactly this,
+        // making the driver read a bogus heart rate out of a later field and overwrite a
+        // real external HR source with it.
+        Flags.word_flags = ((uint32_t)(uint8_t)lastPacket.at(2) << 16) |
+                           ((uint32_t)(uint8_t)lastPacket.at(1) << 8) |
+                           (uint32_t)(uint8_t)lastPacket.at(0);
         index += 3;
 
         if (!Flags.moreData) {
             if (!ensurePacketBytes(2, "instantaneousSpeed")) return;
             // For TRUE_ELLIPTICAL, skip instantaneous speed (will use avgSpeed instead)
-            if(!TRUE_ELLIPTICAL && (E35 || SCH_590E || SCH_411_510E || KETTLER || CARDIOPOWER_EEGO || MYELLIPTICAL || SKANDIKA || DOMYOS || FEIER || MX_AS || FTMS || SOLE_E25)) {
+            // For LIFE_FITNESS_ELLIPTICAL, the Instantaneous Speed field is advertised as present but is
+            // hardcoded to 0x0000 by the machine (verified over a full 1340-packet session), so reading it
+            // here would just pin Speed to zero. Speed is derived from Total Distance below instead.
+            if(!TRUE_ELLIPTICAL && !LIFE_FITNESS_ELLIPTICAL && (E35 || SCH_590E || SCH_411_510E || KETTLER || CARDIOPOWER_EEGO || MYELLIPTICAL || SKANDIKA || DOMYOS || FEIER || MX_AS || FTMS || SOLE_E25)) {
                 Speed = ((double)(((uint16_t)((uint8_t)lastPacket.at(index + 1)) << 8) |
                                 (uint16_t)((uint8_t)lastPacket.at(index)))) /
                         100.0;
@@ -361,14 +372,50 @@ void ypooelliptical::characteristicChanged(const QLowEnergyCharacteristic &chara
 
         if (Flags.totDistance) {
             if (!ensurePacketBytes(3, "totDistance")) return;
-            if(!E35 && !SCH_590E && !SCH_411_510E && !KETTLER && !CARDIOPOWER_EEGO && !MYELLIPTICAL && !SKANDIKA && !DOMYOS && !FEIER && !MX_AS && !TRUE_ELLIPTICAL && !FTMS && !SOLE_E25) {
-                Distance = ((double)((((uint32_t)((uint8_t)lastPacket.at(index + 2)) << 16) |
-                                  (uint32_t)((uint8_t)lastPacket.at(index + 1)) << 8) |
-                                 (uint32_t)((uint8_t)lastPacket.at(index)))) /
-                       1000.0;
+            uint32_t totalDistanceMeters = ((((uint32_t)((uint8_t)lastPacket.at(index + 2)) << 16) |
+                                             (uint32_t)((uint8_t)lastPacket.at(index + 1)) << 8) |
+                                            (uint32_t)((uint8_t)lastPacket.at(index)));
+
+            // LIFE_FITNESS_ELLIPTICAL sends a genuine cumulative Total Distance, so read it straight from the
+            // packet rather than integrating Speed (which the machine never sends - see instantaneousSpeed above).
+            if(LIFE_FITNESS_ELLIPTICAL ||
+               (!E35 && !SCH_590E && !SCH_411_510E && !KETTLER && !CARDIOPOWER_EEGO && !MYELLIPTICAL && !SKANDIKA && !DOMYOS && !FEIER && !MX_AS && !TRUE_ELLIPTICAL && !FTMS && !SOLE_E25)) {
+                Distance = ((double)totalDistanceMeters) / 1000.0;
             } else {
                 Distance += ((Speed.value() / 3600000.0) *
                          ((double)lastRefreshCharacteristicChanged.msecsTo(now)));
+            }
+
+            if (LIFE_FITNESS_ELLIPTICAL) {
+                // The machine reports no instantaneous speed at all, so differentiate its own Total Distance.
+                // The field has 1m resolution at ~1Hz, which makes a single-packet delta very coarse
+                // (a 2m vs 3m step is 7.2 vs 10.8 km/h), hence the 5s average rather than the raw value.
+                if (totalDistanceMeters != lastTotalDistance) {
+                    if (lastTotalDistance > 0 && totalDistanceMeters > lastTotalDistance) {
+                        qint64 elapsedMs = lastTotalDistanceChanged.msecsTo(now);
+                        // Require a substantial sampling interval: a short/jittery gap turns the 1m
+                        // distance quantum into a huge apparent speed (a 3m step over 200ms reads as
+                        // 54 km/h). Replaying a full captured session with a 500ms floor still let
+                        // spikes to 28.6 km/h through - about 18 mph on an elliptical - so require
+                        // 2.5s of span. This removes the spikes without moving the median at all.
+                        if (elapsedMs >= 2500) {
+                            double candidate = (((double)(totalDistanceMeters - lastTotalDistance)) / 1000.0) /
+                                               (((double)elapsedMs) / 3600000.0);
+                            if (candidate < 20.0) { // sanity check: an elliptical does not exceed this
+                                instantSpeed = candidate;
+                                Speed = instantSpeed.average5s();
+                                emit debug(QStringLiteral("Current Speed (from totDistance): ") +
+                                           QString::number(Speed.value()));
+                            }
+                        }
+                    }
+                    lastTotalDistance = totalDistanceMeters;
+                    lastTotalDistanceChanged = now;
+                } else if (lastTotalDistanceChanged.msecsTo(now) > 3000) {
+                    // Distance stopped advancing: the user stopped pedalling, so don't hold the last speed.
+                    instantSpeed = 0.0;
+                    Speed = 0.0;
+                }
             }
             index += 3;
         } else {
@@ -430,13 +477,19 @@ void ypooelliptical::characteristicChanged(const QLowEnergyCharacteristic &chara
                         // Handle overflow: uint16_t subtraction automatically wraps correctly
                         uint16_t stridesDiffRaw = currentStrideCount - lastStrideCount;
                         double stridesDiff = (double)stridesDiffRaw;
-                        if (TRUE_ELLIPTICAL) {
+                        // These machines report the Stride Count in tenths of a stride rather than whole
+                        // strides. For LIFE_FITNESS_ELLIPTICAL this was confirmed over a full session: every
+                        // single delta was a multiple of 10 (only ever 10, 20 or 30 per ~1s packet), i.e.
+                        // 1.0/2.0/3.0 real strides. Combined with the /2.0 below (2 strides per revolution)
+                        // this gives an effective divisor of 20, which matches a console reading of 62 RPM.
+                        const bool deciStrides = TRUE_ELLIPTICAL || LIFE_FITNESS_ELLIPTICAL;
+                        if (deciStrides) {
                             stridesDiff /= 10.0;
                         }
                         double timeInMinutes = lastStrideCountChanged.msecsTo(now) / 60000.0;
 
-                        // Sanity check: reject unrealistic values and require minimum 5 strides (or 0.5 for TRUE_ELLIPTICAL) for stable calculation
-                        if (timeInMinutes > 0 && ((!TRUE_ELLIPTICAL && stridesDiff >= 5) || (TRUE_ELLIPTICAL && stridesDiff >= 0.5)) && stridesDiff < 1000) {
+                        // Sanity check: reject unrealistic values and require minimum 5 strides (or 0.5 for tenth-of-a-stride machines) for stable calculation
+                        if (timeInMinutes > 0 && ((!deciStrides && stridesDiff >= 5) || (deciStrides && stridesDiff >= 0.5)) && stridesDiff < 1000) {
                             // strides per minute, then divide by 2 to get RPM
                             double stridesPerMinute = stridesDiff / timeInMinutes;
                             instantCadence = stridesPerMinute / 2.0;
@@ -488,7 +541,9 @@ void ypooelliptical::characteristicChanged(const QLowEnergyCharacteristic &chara
                                    (uint16_t)((uint8_t)lastPacket.at(index))));
             
             // FTMS Spec Compliant Machines (0.1 Resolution, so 50 = 5.0)
-            if(TRUE_ELLIPTICAL) {
+            // Life Fitness is in the same family: the field reads a constant 10 while the console displays
+            // LEVEL 1, so without the /10 the resistance would be reported an order of magnitude too high.
+            if(TRUE_ELLIPTICAL || LIFE_FITNESS_ELLIPTICAL) {
                 Resistance = Resistance.value() / 10.0;
             }
             
@@ -1144,6 +1199,15 @@ void ypooelliptical::deviceDiscovered(const QBluetoothDeviceInfo &device) {
         } else if(device.name().toUpper().startsWith(QStringLiteral("E25"))) {
             SOLE_E25 = true;
             qDebug() << "SOLE_E25 workaround ON!";
+        } else if(QRegularExpression(QStringLiteral("^LF[0-9A-F]+$")).match(device.name().toUpper()).hasMatch() &&
+                  (device.name().length() == 18 || device.name().length() == 15)) {
+            // Life Fitness ellipticals advertise as "LF" followed by a hex string (e.g. LF089d726f5a8fb207).
+            // NOTE: this is the same name shape used by Life Fitness *treadmills*, which bluetooth.cpp routes
+            // to the lifefitnesstreadmill driver. We deliberately do NOT add this pattern to the routing chain
+            // in bluetooth.cpp: a device only reaches this driver when the user has explicitly pointed the
+            // ftms_elliptical setting at it, so the treadmill matching stays untouched.
+            LIFE_FITNESS_ELLIPTICAL = true;
+            qDebug() << "LIFE_FITNESS_ELLIPTICAL workaround ON!";
         }
 
         QSettings settings;

--- a/src/devices/ypooelliptical/ypooelliptical.cpp
+++ b/src/devices/ypooelliptical/ypooelliptical.cpp
@@ -547,16 +547,23 @@ void ypooelliptical::characteristicChanged(const QLowEnergyCharacteristic &chara
         
         if (Flags.resistanceLvl) {
             if (!ensurePacketBytes(2, "resistanceLvl")) return;
-            Resistance = ((double)(((uint16_t)((uint8_t)lastPacket.at(index + 1)) << 8) |
-                                   (uint16_t)((uint8_t)lastPacket.at(index))));
-            
+            double resCandidate = ((double)(((uint16_t)((uint8_t)lastPacket.at(index + 1)) << 8) |
+                                            (uint16_t)((uint8_t)lastPacket.at(index))));
+
             // FTMS Spec Compliant Machines (0.1 Resolution, so 50 = 5.0)
             // Life Fitness is in the same family: the field reads a constant 10 while the console displays
             // LEVEL 1, so without the /10 the resistance would be reported an order of magnitude too high.
             if(TRUE_ELLIPTICAL || LIFE_FITNESS_ELLIPTICAL) {
-                Resistance = Resistance.value() / 10.0;
+                resCandidate = resCandidate / 10.0;
             }
-            
+
+            // Life Fitness intermittently emits an invalid resistance (a 0xFF "not available"
+            // sentinel that reads as ~255). Forwarding it spikes the resistance graph and wrecks
+            // the session max/avg. Reject the implausible value and hold the last good level - an
+            // elliptical never reaches 30. Observed live: 57 of 3675 packets in one session.
+            if (!(LIFE_FITNESS_ELLIPTICAL && resCandidate > 30.0))
+                Resistance = resCandidate;
+
             // emit resistanceRead(Resistance.value());
             index += 2;
             emit debug(QStringLiteral("Current Resistance: ") + QString::number(Resistance.value()));

--- a/src/devices/ypooelliptical/ypooelliptical.h
+++ b/src/devices/ypooelliptical/ypooelliptical.h
@@ -67,13 +67,16 @@ class ypooelliptical : public elliptical {
     QDateTime lastRefreshCharacteristicChanged = QDateTime::currentDateTime();
     QDateTime lastRefreshCharacteristicChanged2AD2 = QDateTime::currentDateTime();
     QDateTime lastStrideCountChanged = QDateTime::currentDateTime();
+    QDateTime lastTotalDistanceChanged = QDateTime::currentDateTime();
     uint8_t firstStateChanged = 0;
     uint16_t lastStrideCount = 0;
+    uint32_t lastTotalDistance = 0;
     int8_t bikeResistanceOffset = 4;
     double bikeResistanceGain = 1.0;
     const uint8_t max_resistance = 72; // 24;
     const uint8_t default_resistance = 6;
     metric instantCadence;
+    metric instantSpeed;
 
     bool initDone = false;
     bool initRequest = false;
@@ -96,6 +99,7 @@ class ypooelliptical : public elliptical {
     bool FTMS = false;
     bool SOLE_E25 = false;
     bool GYMSTICK_GX60 = false;
+    bool LIFE_FITNESS_ELLIPTICAL = false;
 
 #ifdef Q_OS_IOS
     lockscreen *h = 0;

--- a/src/qzsettings.cpp
+++ b/src/qzsettings.cpp
@@ -1247,8 +1247,9 @@ const QString QZSettings::shortcut_start_stop = QStringLiteral("shortcut_start_s
 const QString QZSettings::default_shortcut_start_stop = QStringLiteral("");
 const QString QZSettings::shortcut_stop = QStringLiteral("shortcut_stop");
 const QString QZSettings::default_shortcut_stop = QStringLiteral("");
+const QString QZSettings::life_fitness_elliptical = QStringLiteral("life_fitness_elliptical");
 
-const uint32_t allSettingsCount = 975;
+const uint32_t allSettingsCount = 976;
 
 QVariant allSettings[allSettingsCount][2] = {
     {QZSettings::cryptoKeySettingsProfiles, QZSettings::default_cryptoKeySettingsProfiles},
@@ -2248,6 +2249,7 @@ QVariant allSettings[allSettingsCount][2] = {
     {QZSettings::proform_treadmill_105_cst, QZSettings::default_proform_treadmill_105_cst},
     {QZSettings::applewatch_as_treadmill_speed, QZSettings::default_applewatch_as_treadmill_speed},
     {QZSettings::horizon_treadmill_omega_z, QZSettings::default_horizon_treadmill_omega_z},
+    {QZSettings::life_fitness_elliptical, QZSettings::default_life_fitness_elliptical},
 };
 
 void QZSettings::qDebugAllSettings(bool showDefaults) {

--- a/src/qzsettings.cpp
+++ b/src/qzsettings.cpp
@@ -1284,8 +1284,9 @@ const QString QZSettings::shortcut_start_stop = QStringLiteral("shortcut_start_s
 const QString QZSettings::default_shortcut_start_stop = QStringLiteral("");
 const QString QZSettings::shortcut_stop = QStringLiteral("shortcut_stop");
 const QString QZSettings::default_shortcut_stop = QStringLiteral("");
+const QString QZSettings::life_fitness_elliptical = QStringLiteral("life_fitness_elliptical");
 
-const uint32_t allSettingsCount = 1005;
+const uint32_t allSettingsCount = 1006;
 
 QVariant allSettings[allSettingsCount][2] = {
     {QZSettings::cryptoKeySettingsProfiles, QZSettings::default_cryptoKeySettingsProfiles},
@@ -2316,6 +2317,7 @@ QVariant allSettings[allSettingsCount][2] = {
     {QZSettings::zwiftplay_gear_rb, QZSettings::default_zwiftplay_gear_rb},
     {QZSettings::freebeat_serialport, QZSettings::default_freebeat_serialport},
     {QZSettings::renpho_bike_knob_gears, QZSettings::default_renpho_bike_knob_gears},
+    {QZSettings::life_fitness_elliptical, QZSettings::default_life_fitness_elliptical},
 };
 
 void QZSettings::qDebugAllSettings(bool showDefaults) {

--- a/src/qzsettings.h
+++ b/src/qzsettings.h
@@ -3222,6 +3222,8 @@ class QZSettings {
 
     static const QString horizon_treadmill_omega_z;
     static constexpr bool default_horizon_treadmill_omega_z = false;
+    static const QString life_fitness_elliptical;
+    static constexpr bool default_life_fitness_elliptical = false;
 
     /**
      * @brief Write the QSettings values using the constants from this namespace.

--- a/src/qzsettings.h
+++ b/src/qzsettings.h
@@ -3292,6 +3292,8 @@ class QZSettings {
 
     static const QString horizon_treadmill_omega_z;
     static constexpr bool default_horizon_treadmill_omega_z = false;
+    static const QString life_fitness_elliptical;
+    static constexpr bool default_life_fitness_elliptical = false;
 
     /**
      * @brief NordicTrack Elliptical Spacesaver S700: uses its own BLE telemetry/control quirks

--- a/src/settings-catalog.json
+++ b/src/settings-catalog.json
@@ -2,7 +2,7 @@
   "$schema": "https://qdomyos-zwift.local/settings-catalog.schema.json",
   "schemaVersion": 1,
   "format": "qdomyos-zwift-settings-catalog",
-  "settingCount": 963,
+  "settingCount": 964,
   "pages": [
     {
       "key": "page_custom_gear_table",
@@ -12316,6 +12316,19 @@
       "key": "gymstick_gx6_0_elliptical",
       "name": "Gymstick GX6.0",
       "description": null,
+      "parent": "Elliptical Options",
+      "type": "boolean",
+      "qmlType": "bool",
+      "control": "switch",
+      "visible": true,
+      "defaultValue": false,
+      "defaultExpression": "false",
+      "options": null
+    },
+    {
+      "key": "life_fitness_elliptical",
+      "name": "Life Fitness is an Elliptical",
+      "description": "When on, any Life Fitness FTMS machine (name LF followed by hex) is treated as an elliptical / cross trainer instead of a treadmill, so you do not have to set the FTMS Elliptical field to each machine name. Leave off if you use a Life Fitness treadmill.",
       "parent": "Elliptical Options",
       "type": "boolean",
       "qmlType": "bool",

--- a/src/settings-catalog.json
+++ b/src/settings-catalog.json
@@ -2,7 +2,7 @@
   "$schema": "https://qdomyos-zwift.local/settings-catalog.schema.json",
   "schemaVersion": 1,
   "format": "qdomyos-zwift-settings-catalog",
-  "settingCount": 1001,
+  "settingCount": 1002,
   "pages": [
     {
       "key": "page_custom_gear_table",
@@ -13238,6 +13238,19 @@
       "defaultExpression": "false",
       "options": null,
       "restartRequired": true
+    },
+    {
+      "key": "life_fitness_elliptical",
+      "name": "Life Fitness is an Elliptical",
+      "description": "When on, any Life Fitness FTMS machine (name LF followed by hex) is treated as an elliptical / cross trainer instead of a treadmill, so you do not have to set the FTMS Elliptical field to each machine name. Leave off if you use a Life Fitness treadmill.",
+      "parent": "Elliptical Options",
+      "type": "boolean",
+      "qmlType": "bool",
+      "control": "switch",
+      "visible": true,
+      "defaultValue": false,
+      "defaultExpression": "false",
+      "options": null
     },
     {
       "key": "cadence_sensor_as_treadmill",

--- a/src/settings-catalog.json
+++ b/src/settings-catalog.json
@@ -13250,7 +13250,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "cadence_sensor_as_treadmill",

--- a/src/settings.qml
+++ b/src/settings.qml
@@ -1709,6 +1709,7 @@ import AndroidStatusBar 1.0
             property real trainprogram_pid_hr_pushy_zone_limit: 0.8
             property real trainprogram_pid_hr_recovery_zone_limit: 60.0
             property bool rpe_feel_popup_enabled: false
+            property bool life_fitness_elliptical: false
         }
 
 
@@ -11785,6 +11786,21 @@ import AndroidStatusBar 1.0
                         Layout.alignment: Qt.AlignLeft | Qt.AlignTop
                         Layout.fillWidth: true
                         onClicked: { settings.gymstick_gx6_0_elliptical = checked; window.settings_restart_to_apply = true; }
+                    }
+
+                    IndicatorOnlySwitch {
+                        id: lifeFitnessEllipticalDelegate
+                        text: "Life Fitness is an Elliptical"
+                        spacing: 0
+                        bottomPadding: 0
+                        topPadding: 0
+                        rightPadding: 0
+                        leftPadding: 0
+                        clip: false
+                        checked: settings.life_fitness_elliptical
+                        Layout.alignment: Qt.AlignLeft | Qt.AlignTop
+                        Layout.fillWidth: true
+                        onClicked: { settings.life_fitness_elliptical = checked; window.settings_restart_to_apply = true; }
                     }
 
                     AccordionElement {

--- a/src/settings.qml
+++ b/src/settings.qml
@@ -1744,6 +1744,7 @@ import AndroidStatusBar 1.0
             property bool nordictrack_incline_trainer_x7i_ntl15010_0: false
             property bool custom_inclination_resistance_table_enabled: false
             property string custom_inclination_resistance_table: "0|4\n1|6\n2|8\n3|10\n4|11\n5|11.5\n6|12\n8|13\n10|14\n12|15\n15|16"
+            property bool life_fitness_elliptical: false
         }
 
 
@@ -12391,6 +12392,21 @@ import AndroidStatusBar 1.0
                         Layout.alignment: Qt.AlignLeft | Qt.AlignTop
                         Layout.fillWidth: true
                         onClicked: { settings.gymstick_gx6_0_elliptical = checked; window.settings_restart_to_apply = true; }
+                    }
+
+                    IndicatorOnlySwitch {
+                        id: lifeFitnessEllipticalDelegate
+                        text: "Life Fitness is an Elliptical"
+                        spacing: 0
+                        bottomPadding: 0
+                        topPadding: 0
+                        rightPadding: 0
+                        leftPadding: 0
+                        clip: false
+                        checked: settings.life_fitness_elliptical
+                        Layout.alignment: Qt.AlignLeft | Qt.AlignTop
+                        Layout.fillWidth: true
+                        onClicked: { settings.life_fitness_elliptical = checked; window.settings_restart_to_apply = true; }
                     }
 
                     AccordionElement {


### PR DESCRIPTION
## Problem

Life Fitness ellipticals connect over standard FTMS Cross Trainer Data (`0x2ACE`) and report Distance, Power, and Heart Rate, but **Speed and Cadence stay pinned at 0** and Resistance reads 10× too high. Separately, the machine gets claimed by the wrong driver, and a flags-parsing bug corrupts heart rate.

Evidence is a full ~1-hour, 3,616-packet debug capture plus live gym sessions on **two different machines** (`LF089d726f5a8fb207` and `LF0df5dbea66adf207`), reproduced on the current build.

## What this fixes

**Speed** — Instantaneous Speed is flagged present, but the machine transmits a literal `0x0000` in every packet, and there is no Average Speed fallback (bit 1 clear). Speed is derived by differentiating the genuine cumulative Total Distance, averaged over a ≥2.5 s window and clamped.

**Cadence** — Stride Count is reported in **tenths** of a stride. The shared `/2.0` alone produced ~600 RPM, which the `<120` sanity check then rejected, so cadence never left 0. Life Fitness now divides the stride delta by 10, same family as TRUE_ELLIPTICAL.

**Resistance** — same 0.1 resolution quirk. Confirmed over a second session stepping LEVEL 0–4: every value the machine emits is a multiple of ten (0/10/20/30/40, no intermediate value in 7,232 packets).

**Heart rate — `word_flags` sign extension.** `Flags.word_flags` was assembled from `lastPacket.at(0)` with no `uint8_t` cast. Any flags byte with bit 7 set—Life Fitness sends `0xb4` — sign-extends to `0xFFFFFFxx` and spuriously enables every high flag bit (expEnergy, heartRate, elapsedTime). The driver then read a bogus heart rate out of a later field and **overwrote a real external HR source** (a watch) with it. Observed live as a 0→255 sawtooth baked into the FIT. Affects any cross trainer whose low flags byte is ≥ `0x80`, not just Life Fitness.

**Double-connect—the elliptical branch was guarded by `!ypooElliptical`, so a later advertisement fell through to the treadmill branch, and both drivers parsed `0x2ACE` simultaneously.

## Routing (2nd commit)

Life Fitness ellipticals and treadmills advertise the **identical name shape** (`LF` + hex) and the machine advertises **no service UUID or service data at all**, so they cannot be told apart from the advertisement. Previously the fix only applied if the user set `ftms_elliptical` to each machine's exact name—and those names differ per machine (my gym has **5** LF machines in range), so it needed reconfiguring every session.

This adds an **opt-in setting, default off** ("Life Fitness is an Elliptical") that routes any `LF…` machine to the elliptical driver and skips the treadmill branch. LF treadmill users are unaffected unless they enable it.

## Speed derivation fix (3rd commit)

Found in live testing. The 2.5 s minimum sampling interval made the speed derivation **effectively dead**: the anchor (`lastTotalDistance` / `lastTotalDistanceChanged`) was advanced on *every* distance tick, so `elapsedMs` was pinned to the ~1 s inter-tick gap and never reached the threshold.

Confirmed live—with the workaround detected and **cadence working (65–66 RPM)**, Speed stayed 0 and the debug line never printed. Replaying the 3,616-packet session through the actual code path:

| | speed computations in ~1 hour |
|---|---|
| before | **7** |
| after | **1200** (median 9.5 km/h, max 16.0, spike-free) |

The anchor now advances only after a computation, making it a true ≥2.5 s windowed average.

## Validation

Replaying the capture yields Cadence 49–76 RPM (median 61) and Speed 7.0–10.9 km/h (median 8.6), an implied stride length of 1.10 m, and a final Distance of 4.206 km matching the log. At the packet matching a photo of the console, the driver produces 60.4 RPM / 61 W / level 1 against a console showing 62 RPM / 63 W / LEVEL 1. Live, with routing configured, `LIFE_FITNESS_ELLIPTICAL workaround ON` fires, cadence reads 65–66 RPM, and the activity is typed `fitness_equipment / elliptical`.

The same quirk model was independently confirmed by an ESP32 FTMS bridge running the identical corrections against these machines, producing correct speed/cadence/resistance where a direct connection produced zeros.

## Notes for review

- Not compile-tested locally (no iOS toolchain here)—please confirm `allSettingsCount` / `settingCount` on build.
- To test: enable **"Life Fitness is an Elliptical"**, or set `ftms_elliptical` to the machine name. `filter_device` must be `Disabled` or match the machine; otherwise, it is filtered out before routing.
