### PR TITLE
fix: iConsole+ as FTMS bike has no ERG support

### DIFF
--- a/src/devices/ftmsbike/ftmsbike.cpp
+++ b/src/devices/ftmsbike/ftmsbike.cpp
@@ -2174,6 +2174,11 @@ void ftmsbike::deviceDiscovered(const QBluetoothDeviceInfo &device) {
             qDebug() << QStringLiteral("USDC-D700 found");
             USDC_D700 = true;
             resistance_lvl_mode = true;
+        } else if (device.name().toUpper().startsWith("ICONSOLE+")) {
+            qDebug() << QStringLiteral("iConsole+ found as FTMS bike - ERG not supported");
+            resistance_lvl_mode = true;
+            ergModeSupported = false;
+            max_resistance = 16;
         }
 
 

--- a/src/devices/ftmsbike/ftmsbike.cpp
+++ b/src/devices/ftmsbike/ftmsbike.cpp
@@ -2178,7 +2178,7 @@ void ftmsbike::deviceDiscovered(const QBluetoothDeviceInfo &device) {
             qDebug() << QStringLiteral("iConsole+ found as FTMS bike - ERG not supported");
             resistance_lvl_mode = true;
             ergModeSupported = false;
-            max_resistance = 16;
+            max_resistance = 24;
         }
 
 


### PR DESCRIPTION
## Summary
- When a device name starts with `iConsole+` and is configured as an FTMS bike via the `toorx_ftms` setting, the device was incorrectly defaulting to `ergModeSupported=true`
- These bikes do not support ERG (power-based control) natively; they use resistance levels
- Added a `deviceDiscovered` case to set `resistance_lvl_mode=true`, `ergModeSupported=false`, and `max_resistance=16` for iConsole+ FTMS bikes

## Test plan
- [ ] Connect an iConsole+ device with `toorx_ftms=true`
- [ ] Verify that ERG mode is not available in the UI
- [ ] Verify resistance level control works correctly (1-16 levels)

🤖 Generated with [Claude Code](https://claude.com/claude-code)