### PR TITLE
fix: sportsplusrower (CARE rower) watt and calorie fixes

### DIFF
--- a/src/devices/sportsplusrower/sportsplusrower.cpp
+++ b/src/devices/sportsplusrower/sportsplusrower.cpp
@@ -186,7 +186,7 @@ void sportsplusrower::characteristicChanged(const QLowEnergyCharacteristic &char
     }
 
     Resistance = requestResistance;
-    KCal = kcal;
+    KCal += kcal;
     if (settings.value(QZSettings::cadence_sensor_name, QZSettings::default_cadence_sensor_name)
             .toString()
             .startsWith(QStringLiteral("Disabled"))) {

--- a/src/devices/sportsplusrower/sportsplusrower.cpp
+++ b/src/devices/sportsplusrower/sportsplusrower.cpp
@@ -136,14 +136,19 @@ void sportsplusrower::characteristicChanged(const QLowEnergyCharacteristic &char
     double kcal = 0;
     bool cadence_eval = false;
 
-    m_watt = ((newValue.at(10) >> 4) * 10) + (newValue.at(10) & 0x0F);
-    emit debug(QStringLiteral("Current watt: ") + QString::number(m_watt.value()));
-
     if(newValue.at(1) == 0x10) {
         Cadence = ((newValue.at(3) >> 4) * 10) + (newValue.at(3) & 0x0F);
         Speed = 0.37497622 * ((double)Cadence.value());
         emit debug(QStringLiteral("Current speed: ") + QString::number(Speed.value()));
     }
+
+    if (Speed.value() > 0) {
+        double paceSeconds = 1800.0 / Speed.value();
+        m_watt = rower::calculateWattsFromPace(paceSeconds);
+    } else {
+        m_watt = 0;
+    }
+    emit debug(QStringLiteral("Current watt: ") + QString::number(m_watt.value()));
 
     if (!firstCharChanged) {
         double elapsedMs = lastTimeCharChanged.msecsTo(now);


### PR DESCRIPTION
## Summary

Two fixes for CARE Jet 600 rower (`CARE10692135`) and other CARE rowers handled by `sportsplusrower`:

### 1. Watt: use Concept2 rowing power formula instead of device byte

The device reports only 8–17 W via BLE (byte[10] BCD), unrealistically low. Replaced with the standard Concept2 formula already in the `rower` base class:

```
Watts = 2.8 * (500 / paceSeconds)^3
```

Speed is already calculated from cadence SPM (`0.37497622 * cadence`).  
Pace derives from speed: `paceSeconds = 1800.0 / speed_km_h`.

At 18 SPM (~6.75 km/h): ~19 W → at 33 SPM (~12.4 km/h): ~114 W — realistic values.

The cadence/speed update is now moved before the watt calculation so each packet uses the freshest speed value.

### 2. Calorie counter always zero

`KCal = kcal` was assigning a local variable (reset to `0` on each `characteristicChanged` call) rather than accumulating. Changed to `KCal += kcal`.

Closes #4819

## Test plan
- [ ] Connect CARE Jet 600 rower (`CARE10692135`)
- [ ] Row at different intensities and verify watts scale with effort (Concept2 formula)
- [ ] Confirm calorie counter increases steadily throughout the session

🤖 Generated with [Claude Code](https://claude.com/claude-code)