### PR TITLE
Add MRK-S36C device quirk for resistance-level ERG control

### DIFF
--- a/src/devices/ftmsbike/ftmsbike.cpp
+++ b/src/devices/ftmsbike/ftmsbike.cpp
@@ -2124,6 +2124,11 @@ void ftmsbike::deviceDiscovered(const QBluetoothDeviceInfo &device) {
             qDebug() << QStringLiteral("MRK-S28 found");
             MRK_S28 = true;
             resistance_lvl_mode = true;
+        } else if(device.name().toUpper().startsWith("MRK-S36C-")) {
+            qDebug() << QStringLiteral("MRK-S36C found");
+            MRK_S36C = true;
+            resistance_lvl_mode = true;
+            ergModeSupported = false; // this bike doesn't have ERG mode natively, target power must be converted to resistance
         } else if(device.name().toUpper().startsWith("HAMMER")) {
             qDebug() << QStringLiteral("HAMMER found");
             HAMMER = true;

--- a/src/devices/ftmsbike/ftmsbike.cpp
+++ b/src/devices/ftmsbike/ftmsbike.cpp
@@ -354,7 +354,7 @@ void ftmsbike::forceResistance(resistance_t requestResistance) {
                                 QStringLiteral("forceResistance ") + QString::number(requestResistance));
         } else {
             uint8_t write[] = {FTMS_SET_TARGET_RESISTANCE_LEVEL, 0x00};
-            if(_3G_Cardio_RB || SL010)
+            if(_3G_Cardio_RB || SL010 || MRK_S36C)
                 requestResistance = requestResistance * 10;
             write[1] = ((uint8_t)(requestResistance));
             writeCharacteristic(write, sizeof(write),

--- a/src/devices/ftmsbike/ftmsbike.h
+++ b/src/devices/ftmsbike/ftmsbike.h
@@ -199,6 +199,7 @@ class ftmsbike : public bike {
     bool MAGNUS = false;
     bool MRK_S26C = false;
     bool MRK_S28 = false;
+    bool MRK_S36C = false;
     bool HAMMER = false;
     bool YPBM = false;
     bool SPORT01 = false;


### PR DESCRIPTION
## Summary
- The MRK-S36C bike is a generic FTMS device that didn't match any name-based quirk, so it kept the default `ergModeSupported = true`.
- When a companion app (Rouvy, via Dircon) switches to ERG mode and sends `SetTargetPower`, `ftmsbike`'s power-request routing (`ftmsbike.cpp:578`) only forwards the request when the connected client is non-FTMS or a power sensor is configured. For this bike neither was true, so the target power request was silently dropped, and resistance froze at its last simulation-derived value instead of tracking the workout.
- Analysis based on a user-provided debug log: resistance updates worked fine while Rouvy sent slope/simulation packets, then froze the moment Rouvy issued an ERG `SetTargetPower` command.

Fix: detect `MRK-S36C-*` by name and set `resistance_lvl_mode = true` + `ergModeSupported = false`, consistent with other MRK bikes (MRK-S28), so target power gets converted to a resistance level via the erg table instead of being forwarded/dropped as a native ERG command.

## Test plan
- [ ] Confirm build compiles for affected platforms
- [ ] Manually verify with an MRK-S36C bike that resistance now follows Rouvy/Zwift ERG-mode target power changes, not just slope-based simulation