### PR TITLE
Fix iOS build error in waterrowerusb: virtualbike_ios() returns void

### DIFF
--- a/src/devices/waterrowerusb/waterrowerusb.cpp
+++ b/src/devices/waterrowerusb/waterrowerusb.cpp
@@ -304,8 +304,8 @@ void waterrowerusb::update() {
         bool ios_peloton_workaround =
             settings.value(QZSettings::ios_peloton_workaround, QZSettings::default_ios_peloton_workaround).toBool();
         if (ios_peloton_workaround && cadence && h && firstStateChanged) {
-            h->virtualbike_ios()->setCadence(currentCrankRevolutions(), lastCrankEventTime());
-            h->virtualbike_ios()->setHeartRate((uint8_t)currentHeart().value());
+            h->virtualbike_setCadence(currentCrankRevolutions(), lastCrankEventTime());
+            h->virtualbike_setHeartRate((uint8_t)currentHeart().value());
         }
 #endif
 #endif
@@ -329,7 +329,7 @@ void waterrowerusb::update() {
 #ifdef Q_OS_IOS
 #ifndef IO_UNDER_QT
             if (h) {
-                h->virtualbike_ios()->setHeartRate((uint8_t)currentHeart().value());
+                h->virtualbike_setHeartRate((uint8_t)currentHeart().value());
             }
 #endif
 #endif


### PR DESCRIPTION
Chaining ->setCadence()/->setHeartRate() off virtualbike_ios() failed to compile since the method returns void. Use virtualbike_setCadence() and virtualbike_setHeartRate() instead, matching other rower devices.