### PR TITLE
feat: add Wahoo KickRun treadmill driver

### DIFF
--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -1624,6 +1624,23 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                     emit searchingStop();
                 }
                 this->signalBluetoothDeviceConnected(lifefitnessTreadmill);
+            } else if (b.name().toUpper().startsWith(QStringLiteral("KICKR RUN")) &&
+                       !wahooKickRunTreadmill && filter) {
+                this->setLastBluetoothDevice(b);
+                this->stopDiscovery();
+                wahooKickRunTreadmill = new wahookickruntreadmill(noWriteResistance, noHeartService);
+#if !defined(Q_OS_ANDROID) && !defined(Q_OS_IOS)
+                stateFileRead();
+#endif
+                emit deviceConnected(b);
+                connect(wahooKickRunTreadmill, &bluetoothdevice::connectedAndDiscovered, this,
+                        &bluetooth::connectedAndDiscovered);
+                connect(wahooKickRunTreadmill, &wahookickruntreadmill::debug, this, &bluetooth::debug);
+                wahooKickRunTreadmill->deviceDiscovered(b);
+                if (this->discoveryAgent && !this->discoveryAgent->isActive()) {
+                    emit searchingStop();
+                }
+                this->signalBluetoothDeviceConnected(wahooKickRunTreadmill);
             } else if ((b.name().toUpper().startsWith(QStringLiteral("HORIZON")) ||
                         b.name().toUpper().startsWith(QStringLiteral("HZ_T101-")) ||
                         b.name().toUpper().startsWith(QStringLiteral("HZ_7.0AT-")) ||
@@ -1685,7 +1702,6 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                         b.name().toUpper().startsWith(QStringLiteral("FOCUS M3")) ||
                          b.name().toUpper().startsWith(QStringLiteral("ANPIUS-")) ||
                          b.name().toUpper().startsWith(QStringLiteral("SWALK LITE-")) ||
-                         b.name().toUpper().startsWith(QStringLiteral("KICKR RUN")) ||
                         b.name().toUpper().startsWith(QStringLiteral("SPERAX_RM-01")) ||
                         (b.name().toUpper().startsWith(QStringLiteral("TP1")) && b.name().length() == 3) ||
                         (b.name().toUpper().startsWith(QStringLiteral("KS-HD-Z1D"))) ||                     // Kingsmith WalkingPad Z1

--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -3761,6 +3761,11 @@ void bluetooth::restart() {
         delete horizonTreadmill;
         horizonTreadmill = nullptr;
     }
+    if (wahooKickRunTreadmill) {
+
+        delete wahooKickRunTreadmill;
+        wahooKickRunTreadmill = nullptr;
+    }
     if (speraXTreadmill) {
 
         delete speraXTreadmill;
@@ -4473,6 +4478,8 @@ bluetoothdevice *bluetooth::device() {
         return ultraSportBike;
     } else if (horizonTreadmill) {
         return horizonTreadmill;
+    } else if (wahooKickRunTreadmill) {
+        return wahooKickRunTreadmill;
     } else if (lifefitnessTreadmill) {
         return lifefitnessTreadmill;
     } else if (speraXTreadmill) {

--- a/src/devices/bluetooth.h
+++ b/src/devices/bluetooth.h
@@ -154,6 +154,7 @@
 #include "devices/ultrasportbike/ultrasportbike.h"
 #include "devices/wahookickrheadwind/wahookickrheadwind.h"
 #include "devices/wahookickrsnapbike/wahookickrsnapbike.h"
+#include "devices/wahookickruntreadmill/wahookickruntreadmill.h"
 #include "devices/yesoulbike/yesoulbike.h"
 #include "devices/ypooelliptical/ypooelliptical.h"
 #include "devices/ziprotreadmill/ziprotreadmill.h"
@@ -305,6 +306,7 @@ class bluetooth : public QObject, public SignalHandler {
     stagesbike *powerBike = nullptr;
     ultrasportbike *ultraSportBike = nullptr;
     wahookickrsnapbike *wahooKickrSnapBike = nullptr;
+    wahookickruntreadmill *wahooKickRunTreadmill = nullptr;
     ypooelliptical *ypooElliptical = nullptr;
     ziprotreadmill *ziproTreadmill = nullptr;
     kineticinroadbike *kineticInroadBike = nullptr;

--- a/src/devices/wahookickruntreadmill/wahookickruntreadmill.cpp
+++ b/src/devices/wahookickruntreadmill/wahookickruntreadmill.cpp
@@ -90,6 +90,18 @@ void wahookickruntreadmill::forceSpeed(double speed) {
                         QStringLiteral("forceSpeed ") + QString::number(speed));
 }
 
+void wahookickruntreadmill::changeSpeed(double speed) {
+    if (requestSpeed >= 0) {
+        // Another command is already pending (not yet sent by update()).
+        // Accumulate from the pending speed rather than the (stale) telemetry speed.
+        double step = speed - currentSpeed().value();
+        requestSpeed = qMax(0.0, requestSpeed + step);
+        RequestedSpeed = requestSpeed;
+    } else {
+        treadmill::changeSpeed(speed);
+    }
+}
+
 void wahookickruntreadmill::update() {
     if (!m_control || m_control->state() == QLowEnergyController::UnconnectedState) {
         emit disconnected();
@@ -120,9 +132,13 @@ void wahookickruntreadmill::update() {
     update_metrics(true, watts(settings.value(QZSettings::weight, QZSettings::default_weight).toFloat()));
 
     if (requestSpeed != -1) {
-        if (requestSpeed != currentSpeed().value() && requestSpeed >= 0) {
+        if (std::abs(requestSpeed - currentSpeed().value()) > 0.01 && requestSpeed >= 0) {
             emit debug(QStringLiteral("writing speed ") + QString::number(requestSpeed));
             forceSpeed(requestSpeed);
+            // Show commanded speed immediately; suppress telemetry overwrite until paddle push.
+            Speed = requestSpeed;
+            lastSpeed = requestSpeed;
+            paddlePending = true;
         }
         requestSpeed = -1;
     }
@@ -132,6 +148,7 @@ void wahookickruntreadmill::update() {
         if (lastSpeed == 0.0)
             lastSpeed = 0.5;
         forceSpeed(lastSpeed);
+        paddlePending = true;
         requestStart = -1;
         emit tapeStarted();
     }
@@ -171,6 +188,7 @@ void wahookickruntreadmill::characteristicChanged(const QLowEnergyCharacteristic
     // FD E0 01 [code_hi] [code_lo] → paddle pushed, treadmill issued challenge
     if (len >= 5 && (uint8_t)newValue.at(0) == 0xFD && (uint8_t)newValue.at(1) == 0xE0 &&
         (uint8_t)newValue.at(2) == 0x01) {
+        paddlePending = false;  // paddle was pushed; telemetry can now reflect actual belt speed
         QByteArray confirm;
         confirm.append((char)0xE0);
         confirm.append(newValue.at(3));
@@ -197,9 +215,13 @@ void wahookickruntreadmill::characteristicChanged(const QLowEnergyCharacteristic
 
         emit debug(QStringLiteral("KickRun speed=") + QString::number(tgt_kmh, 'f', 2));
 
-        if (Speed.value() != tgt_kmh)
-            emit speedChanged(tgt_kmh);
-        Speed = tgt_kmh;
+        // While waiting for the user to push the paddle, suppress telemetry overwrites
+        // so the UI keeps showing the commanded speed rather than the old belt speed.
+        if (!paddlePending) {
+            if (Speed.value() != tgt_kmh)
+                emit speedChanged(tgt_kmh);
+            Speed = tgt_kmh;
+        }
 
         if (tgt_kmh > 0) {
             lastSpeed = tgt_kmh;

--- a/src/devices/wahookickruntreadmill/wahookickruntreadmill.cpp
+++ b/src/devices/wahookickruntreadmill/wahookickruntreadmill.cpp
@@ -3,6 +3,7 @@
 #include "keepawakehelper.h"
 #include "virtualdevices/virtualtreadmill.h"
 #include <QBluetoothLocalDevice>
+#include <QLowEnergyConnectionParameters>
 #include <QDateTime>
 #include <QMetaEnum>
 #include <QSettings>

--- a/src/devices/wahookickruntreadmill/wahookickruntreadmill.cpp
+++ b/src/devices/wahookickruntreadmill/wahookickruntreadmill.cpp
@@ -1,0 +1,421 @@
+#include "wahookickruntreadmill.h"
+#include "homeform.h"
+#include "keepawakehelper.h"
+#include "virtualdevices/virtualtreadmill.h"
+#include <QBluetoothLocalDevice>
+#include <QDateTime>
+#include <QMetaEnum>
+#include <QSettings>
+#include <chrono>
+#include <cmath>
+
+using namespace std::chrono_literals;
+
+wahookickruntreadmill::wahookickruntreadmill(bool noWriteResistance, bool noHeartService) {
+    m_watt.setType(metric::METRIC_WATT, deviceType());
+    Speed.setType(metric::METRIC_SPEED);
+    this->noWriteResistance = noWriteResistance;
+    this->noHeartService = noHeartService;
+
+    refresh = new QTimer(this);
+    connect(refresh, &QTimer::timeout, this, &wahookickruntreadmill::update);
+    refresh->start(500ms);
+}
+
+void wahookickruntreadmill::writeCharacteristic(const QByteArray &data, const QString &info) {
+    if (!gattCmdCharacteristic.isValid() || !gattCmdService) {
+        emit debug(QStringLiteral("writeCharacteristic: cmd characteristic not valid"));
+        return;
+    }
+
+    if (writeBuffer)
+        delete writeBuffer;
+    writeBuffer = new QByteArray(data);
+
+    gattCmdService->writeCharacteristic(gattCmdCharacteristic, *writeBuffer,
+                                        QLowEnergyService::WriteWithoutResponse);
+    emit debug(QStringLiteral(" >> ") + writeBuffer->toHex(' ') + QStringLiteral(" // ") + info);
+}
+
+void wahookickruntreadmill::btinit() {
+    // Init sequence observed in HCI trace.
+    // Single-byte capability queries sent to the cmd characteristic.
+    static const QList<QByteArray> initCmds = {
+        QByteArray(1, 0x01),
+        QByteArray(1, 0x10),
+        QByteArray(1, 0x12),
+        QByteArray(1, 0x18),
+        QByteArray(1, 0x80),
+        QByteArray(1, 0x86), // response contains 4-byte device ID for the 0x87 follow-up
+        QByteArray(1, 0xf0),
+    };
+
+    for (const QByteArray &cmd : initCmds)
+        writeCharacteristic(cmd, QStringLiteral("init"));
+
+    // 0x87 + deviceId is sent after the 0x86 response arrives in characteristicChanged().
+    // Workout unlock (0x19 0x00) is sent once before the first speed command.
+
+    initDone = true;
+    emit connectedAndDiscovered();
+}
+
+void wahookickruntreadmill::forceSpeed(double speed) {
+    if (noWriteResistance)
+        return;
+
+    // Send 0x19 0x00 once to unlock workout/remote-control mode
+    if (!workoutModeStarted) {
+        workoutModeStarted = true;
+        uint8_t unlockCmd[] = {0x19, 0x00};
+        writeCharacteristic(QByteArray(reinterpret_cast<const char *>(unlockCmd), 2),
+                            QStringLiteral("workout start"));
+    }
+
+    // Speed in μm/s as uint24 little-endian
+    uint32_t um_s = static_cast<uint32_t>(std::round(speed / 3.6 * 1e6));
+    uint8_t flag = firstSpeedSent ? 0x0A : 0xFF;
+    firstSpeedSent = true;
+
+    uint8_t cmd[6];
+    cmd[0] = 0x02;
+    cmd[1] = um_s & 0xFF;
+    cmd[2] = (um_s >> 8) & 0xFF;
+    cmd[3] = (um_s >> 16) & 0xFF;
+    cmd[4] = 0x00;
+    cmd[5] = flag;
+
+    writeCharacteristic(QByteArray(reinterpret_cast<const char *>(cmd), 6),
+                        QStringLiteral("forceSpeed ") + QString::number(speed));
+}
+
+void wahookickruntreadmill::update() {
+    if (!m_control || m_control->state() == QLowEnergyController::UnconnectedState) {
+        emit disconnected();
+        return;
+    }
+
+    if (initRequest) {
+        initRequest = false;
+        btinit();
+        return;
+    }
+
+    if (!initDone || !gattCmdCharacteristic.isValid())
+        return;
+
+    // Create virtual treadmill on first valid update
+    if (!this->hasVirtualDevice()) {
+        QSettings settings;
+        if (settings.value(QZSettings::virtual_device_enabled, QZSettings::default_virtual_device_enabled).toBool()) {
+            emit debug(QStringLiteral("creating virtual treadmill interface..."));
+            auto *vt = new virtualtreadmill(this, noHeartService);
+            connect(vt, &virtualtreadmill::debug, this, &wahookickruntreadmill::debug);
+            this->setVirtualDevice(vt, VIRTUAL_DEVICE_MODE::PRIMARY);
+        }
+    }
+
+    QSettings settings;
+    update_metrics(true, watts(settings.value(QZSettings::weight, QZSettings::default_weight).toFloat()));
+
+    if (requestSpeed != -1) {
+        if (requestSpeed != currentSpeed().value() && requestSpeed >= 0) {
+            emit debug(QStringLiteral("writing speed ") + QString::number(requestSpeed));
+            forceSpeed(requestSpeed);
+        }
+        requestSpeed = -1;
+    }
+
+    if (requestStart != -1) {
+        emit debug(QStringLiteral("starting..."));
+        if (lastSpeed == 0.0)
+            lastSpeed = 0.5;
+        forceSpeed(lastSpeed);
+        requestStart = -1;
+        emit tapeStarted();
+    }
+
+    if (requestStop != -1) {
+        emit debug(QStringLiteral("stopping..."));
+        forceSpeed(0.0);
+        requestStop = -1;
+    }
+}
+
+void wahookickruntreadmill::serviceDiscovered(const QBluetoothUuid &gatt) {
+    emit debug(QStringLiteral("serviceDiscovered ") + gatt.toString());
+}
+
+void wahookickruntreadmill::characteristicChanged(const QLowEnergyCharacteristic &characteristic,
+                                                  const QByteArray &newValue) {
+    QSettings settings;
+    emit debug(QStringLiteral(" << ") + newValue.toHex(' ') + QStringLiteral(" uuid=") +
+               characteristic.uuid().toString());
+
+    const int len = newValue.length();
+
+    // --- Command/response channel (same char used for writes) ---
+    // FE 86 01 [id0 id1 id2 id3] ... → store device ID, send 87+id
+    if (len >= 7 && (uint8_t)newValue.at(0) == 0xFE && (uint8_t)newValue.at(1) == 0x86 &&
+        (uint8_t)newValue.at(2) == 0x01 && !deviceIdReceived) {
+        deviceId = newValue.mid(3, 4);
+        deviceIdReceived = true;
+        QByteArray cmd87;
+        cmd87.append((char)0x87);
+        cmd87.append(deviceId);
+        writeCharacteristic(cmd87, QStringLiteral("device id ack"));
+        return;
+    }
+
+    // FD E0 01 [code_hi] [code_lo] → paddle pushed, treadmill issued challenge
+    if (len >= 5 && (uint8_t)newValue.at(0) == 0xFD && (uint8_t)newValue.at(1) == 0xE0 &&
+        (uint8_t)newValue.at(2) == 0x01) {
+        QByteArray confirm;
+        confirm.append((char)0xE0);
+        confirm.append(newValue.at(3));
+        confirm.append(newValue.at(4));
+        writeCharacteristic(confirm, QStringLiteral("challenge response"));
+        emit debug(QStringLiteral("KickRun paddle confirmed, echoing challenge code"));
+        return;
+    }
+
+    // FD E0 02 00 00 → waiting for paddle push (informational, nothing to do)
+    if (len >= 3 && (uint8_t)newValue.at(0) == 0xFD && (uint8_t)newValue.at(1) == 0xE0 &&
+        (uint8_t)newValue.at(2) == 0x02) {
+        emit debug(QStringLiteral("KickRun waiting for paddle push"));
+        return;
+    }
+
+    // --- Telemetry channel: FF 01 [tgt_b0 b1 b2] 00 ... ---
+    if (len >= 5 && (uint8_t)newValue.at(0) == 0xFF && (uint8_t)newValue.at(1) == 0x01) {
+        // Target speed (bytes 2-4, LE24, μm/s) — echoes exactly what we commanded
+        uint32_t tgt_um_s = static_cast<uint8_t>(newValue.at(2)) |
+                            (static_cast<uint8_t>(newValue.at(3)) << 8) |
+                            (static_cast<uint8_t>(newValue.at(4)) << 16);
+        double tgt_kmh = tgt_um_s / 1e6 * 3.6;
+
+        emit debug(QStringLiteral("KickRun speed=") + QString::number(tgt_kmh, 'f', 2));
+
+        if (Speed.value() != tgt_kmh)
+            emit speedChanged(tgt_kmh);
+        Speed = tgt_kmh;
+
+        if (tgt_kmh > 0) {
+            lastSpeed = tgt_kmh;
+        }
+
+#ifdef Q_OS_ANDROID
+        if (settings.value(QZSettings::ant_heart, QZSettings::default_ant_heart).toBool())
+            Heart = (uint8_t)KeepAwakeHelper::heart();
+#endif
+
+        if (!firstCharacteristicChanged) {
+            Distance += ((Speed.value() / 3600.0) /
+                         (1000.0 / (double)lastTimeCharacteristicChanged.msecsTo(QDateTime::currentDateTime())));
+
+            if (watts(settings.value(QZSettings::weight, QZSettings::default_weight).toFloat()))
+                KCal += ((((0.048 *
+                            (double)watts(settings.value(QZSettings::weight, QZSettings::default_weight).toFloat()) +
+                            1.19) *
+                           settings.value(QZSettings::weight, QZSettings::default_weight).toFloat() * 3.5) /
+                          200.0) /
+                         (60000.0 / (double)lastTimeCharacteristicChanged.msecsTo(QDateTime::currentDateTime())));
+        }
+
+        lastTimeCharacteristicChanged = QDateTime::currentDateTime();
+        firstCharacteristicChanged = false;
+
+        cadenceFromAppleWatch();
+        return;
+    }
+}
+
+void wahookickruntreadmill::characteristicWritten(const QLowEnergyCharacteristic &characteristic,
+                                                  const QByteArray &newValue) {
+    Q_UNUSED(characteristic);
+    emit debug(QStringLiteral("characteristicWritten ") + newValue.toHex(' '));
+}
+
+void wahookickruntreadmill::descriptorWritten(const QLowEnergyDescriptor &descriptor,
+                                              const QByteArray &newValue) {
+    emit debug(QStringLiteral("descriptorWritten ") + descriptor.name() + QStringLiteral(" ") + newValue.toHex(' '));
+
+    // Trigger init after the first CCCD descriptor is written
+    if (!initDone) {
+        initRequest = true;
+    }
+}
+
+void wahookickruntreadmill::stateChanged(QLowEnergyService::ServiceState state) {
+    QMetaEnum metaEnum = QMetaEnum::fromType<QLowEnergyService::ServiceState>();
+    emit debug(QStringLiteral("BTLE stateChanged ") + QString::fromLocal8Bit(metaEnum.valueToKey(state)));
+
+    // Wait until all services are discovered
+    for (QLowEnergyService *s : qAsConst(gattServices)) {
+        if (s->state() != QLowEnergyService::ServiceDiscovered &&
+            s->state() != QLowEnergyService::InvalidService) {
+            return;
+        }
+    }
+
+    emit debug(QStringLiteral("all services discovered"));
+
+    for (QLowEnergyService *s : qAsConst(gattServices)) {
+        if (s->state() != QLowEnergyService::ServiceDiscovered)
+            continue;
+
+        connect(s, &QLowEnergyService::characteristicChanged, this,
+                &wahookickruntreadmill::characteristicChanged);
+        connect(s, &QLowEnergyService::characteristicWritten, this,
+                &wahookickruntreadmill::characteristicWritten);
+        connect(s, static_cast<void (QLowEnergyService::*)(QLowEnergyService::ServiceError)>(
+                       &QLowEnergyService::error),
+                this, &wahookickruntreadmill::errorService);
+        connect(s, &QLowEnergyService::descriptorWritten, this,
+                &wahookickruntreadmill::descriptorWritten);
+
+        const auto chars = s->characteristics();
+        for (const QLowEnergyCharacteristic &c : chars) {
+            emit debug(QStringLiteral("char uuid=") + c.uuid().toString() +
+                       QStringLiteral(" handle=0x") + QString::number(c.handle(), 16));
+
+            // The command characteristic is the one with BOTH Write-Without-Response and Notify.
+            // In the observed trace it sits at handle 0x0023.
+            bool hasWriteNoResp = c.properties() & QLowEnergyCharacteristic::WriteNoResponse;
+            bool hasNotify      = c.properties() & QLowEnergyCharacteristic::Notify;
+
+            if (hasWriteNoResp && hasNotify && !gattCmdCharacteristic.isValid()) {
+                gattCmdCharacteristic = c;
+                gattCmdService = s;
+                emit debug(QStringLiteral("KickRun cmd char found: handle=0x") +
+                           QString::number(c.handle(), 16));
+            }
+
+            // Subscribe to all notify/indicate characteristics
+            if (hasNotify) {
+                QByteArray descriptor;
+                descriptor.append((char)0x01);
+                descriptor.append((char)0x00);
+                if (c.descriptor(QBluetoothUuid::ClientCharacteristicConfiguration).isValid()) {
+                    s->writeDescriptor(c.descriptor(QBluetoothUuid::ClientCharacteristicConfiguration),
+                                       descriptor);
+                    notificationsSubscribed++;
+                    emit debug(QStringLiteral("subscribed notify: ") + c.uuid().toString());
+                }
+            } else if (c.properties() & QLowEnergyCharacteristic::Indicate) {
+                QByteArray descriptor;
+                descriptor.append((char)0x02);
+                descriptor.append((char)0x00);
+                if (c.descriptor(QBluetoothUuid::ClientCharacteristicConfiguration).isValid()) {
+                    s->writeDescriptor(c.descriptor(QBluetoothUuid::ClientCharacteristicConfiguration),
+                                       descriptor);
+                    notificationsSubscribed++;
+                    emit debug(QStringLiteral("subscribed indicate: ") + c.uuid().toString());
+                }
+            }
+        }
+    }
+}
+
+void wahookickruntreadmill::serviceScanDone(void) {
+    emit debug(QStringLiteral("serviceScanDone"));
+
+#ifdef Q_OS_ANDROID
+    QLowEnergyConnectionParameters c;
+    c.setIntervalRange(24, 40);
+    c.setLatency(0);
+    c.setSupervisionTimeout(420);
+    m_control->requestConnectionUpdate(c);
+#endif
+
+    const auto services = m_control->services();
+    for (const QBluetoothUuid &uuid : services) {
+        auto *s = m_control->createServiceObject(uuid);
+        gattServices.append(s);
+        connect(s, &QLowEnergyService::stateChanged, this, &wahookickruntreadmill::stateChanged);
+        s->discoverDetails();
+    }
+}
+
+void wahookickruntreadmill::errorService(QLowEnergyService::ServiceError err) {
+    QMetaEnum metaEnum = QMetaEnum::fromType<QLowEnergyService::ServiceError>();
+    emit debug(QStringLiteral("wahookickruntreadmill::errorService ") +
+               QString::fromLocal8Bit(metaEnum.valueToKey(err)) + m_control->errorString());
+}
+
+void wahookickruntreadmill::error(QLowEnergyController::Error err) {
+    QMetaEnum metaEnum = QMetaEnum::fromType<QLowEnergyController::Error>();
+    emit debug(QStringLiteral("wahookickruntreadmill::error ") +
+               QString::fromLocal8Bit(metaEnum.valueToKey(err)) + m_control->errorString());
+}
+
+void wahookickruntreadmill::deviceDiscovered(const QBluetoothDeviceInfo &device) {
+    emit debug(QStringLiteral("Found device: ") + device.name() + QStringLiteral(" (") +
+               device.address().toString() + ')');
+
+    bluetoothDevice = device;
+    m_control = QLowEnergyController::createCentral(bluetoothDevice, this);
+
+    connect(m_control, &QLowEnergyController::serviceDiscovered, this,
+            &wahookickruntreadmill::serviceDiscovered);
+    connect(m_control, &QLowEnergyController::discoveryFinished, this,
+            &wahookickruntreadmill::serviceScanDone);
+    connect(m_control,
+            static_cast<void (QLowEnergyController::*)(QLowEnergyController::Error)>(
+                &QLowEnergyController::error),
+            this, &wahookickruntreadmill::error);
+    connect(m_control, &QLowEnergyController::stateChanged, this,
+            &wahookickruntreadmill::controllerStateChanged);
+    connect(m_control,
+            static_cast<void (QLowEnergyController::*)(QLowEnergyController::Error)>(
+                &QLowEnergyController::error),
+            this, [this](QLowEnergyController::Error) {
+                emit debug(QStringLiteral("Cannot connect to remote device."));
+                emit disconnected();
+            });
+    connect(m_control, &QLowEnergyController::connected, this, [this]() {
+        emit debug(QStringLiteral("Controller connected. Discovering services..."));
+        m_control->discoverServices();
+    });
+    connect(m_control, &QLowEnergyController::disconnected, this, [this]() {
+        emit debug(QStringLiteral("LowEnergy controller disconnected"));
+        emit disconnected();
+    });
+
+    m_control->connectToDevice();
+}
+
+void wahookickruntreadmill::controllerStateChanged(QLowEnergyController::ControllerState state) {
+    qDebug() << QStringLiteral("controllerStateChanged") << state;
+    if (state == QLowEnergyController::UnconnectedState && m_control) {
+        qDebug() << QStringLiteral("trying to reconnect...");
+        initDone = false;
+        firstSpeedSent = false;
+        workoutModeStarted = false;
+        deviceIdReceived = false;
+        gattCmdCharacteristic = QLowEnergyCharacteristic();
+        gattCmdService = nullptr;
+        gattTelService = nullptr;
+        qDeleteAll(gattServices);
+        gattServices.clear();
+        m_control->connectToDevice();
+    }
+}
+
+bool wahookickruntreadmill::connected() {
+    if (!m_control)
+        return false;
+    return m_control->state() == QLowEnergyController::DiscoveredState;
+}
+
+bool wahookickruntreadmill::autoPauseWhenSpeedIsZero() {
+    if (lastStart == 0 || QDateTime::currentMSecsSinceEpoch() > (lastStart + 10000))
+        return true;
+    return false;
+}
+
+bool wahookickruntreadmill::autoStartWhenSpeedIsGreaterThenZero() {
+    if ((lastStop == 0 || QDateTime::currentMSecsSinceEpoch() > (lastStop + 25000)) && requestStop == -1)
+        return true;
+    return false;
+}

--- a/src/devices/wahookickruntreadmill/wahookickruntreadmill.cpp
+++ b/src/devices/wahookickruntreadmill/wahookickruntreadmill.cpp
@@ -280,12 +280,14 @@ void wahookickruntreadmill::stateChanged(QLowEnergyService::ServiceState state) 
             emit debug(QStringLiteral("char uuid=") + c.uuid().toString() +
                        QStringLiteral(" handle=0x") + QString::number(c.handle(), 16));
 
-            // The command characteristic is the one with BOTH Write-Without-Response and Notify.
-            // In the observed trace it sits at handle 0x0023.
-            bool hasWriteNoResp = c.properties() & QLowEnergyCharacteristic::WriteNoResponse;
-            bool hasNotify      = c.properties() & QLowEnergyCharacteristic::Notify;
+            // Command characteristic: UUID a026e03e at handle 0x0023.
+            // a026e002 (handle 0x0019) is the Wahoo debug/console stream — it also has
+            // WriteNoResponse+Notify so a property-only heuristic always picks it first,
+            // causing all init/speed writes to be silently swallowed by the wrong channel.
+            static const QBluetoothUuid cmdCharUuid(
+                QStringLiteral("a026e03e-0a7d-4ab3-97fa-f1500f9feb8b"));
 
-            if (hasWriteNoResp && hasNotify && !gattCmdCharacteristic.isValid()) {
+            if (c.uuid() == cmdCharUuid) {
                 gattCmdCharacteristic = c;
                 gattCmdService = s;
                 emit debug(QStringLiteral("KickRun cmd char found: handle=0x") +

--- a/src/devices/wahookickruntreadmill/wahookickruntreadmill.cpp
+++ b/src/devices/wahookickruntreadmill/wahookickruntreadmill.cpp
@@ -1,4 +1,5 @@
 #include "wahookickruntreadmill.h"
+#include "devices/ftmsbike/ftmsbike.h"
 #include "homeform.h"
 #include "keepawakehelper.h"
 #include "virtualdevices/virtualtreadmill.h"
@@ -36,6 +37,24 @@ void wahookickruntreadmill::writeCharacteristic(const QByteArray &data, const QS
     gattCmdService->writeCharacteristic(gattCmdCharacteristic, *writeBuffer,
                                         QLowEnergyService::WriteWithoutResponse);
     emit debug(QStringLiteral(" >> ") + writeBuffer->toHex(' ') + QStringLiteral(" // ") + info);
+}
+
+void wahookickruntreadmill::writeFTMSControlPoint(const QByteArray &data, const QString &info) {
+    if (!gattFTMSControlPointCharacteristic.isValid() || !gattFTMSService) {
+        emit debug(QStringLiteral("writeFTMSControlPoint: FTMS control point not valid"));
+        return;
+    }
+
+    if (writeBuffer)
+        delete writeBuffer;
+    writeBuffer = new QByteArray(data);
+
+    QLowEnergyService::WriteMode mode = QLowEnergyService::WriteWithResponse;
+    if (gattFTMSControlPointCharacteristic.properties() & QLowEnergyCharacteristic::WriteNoResponse)
+        mode = QLowEnergyService::WriteWithoutResponse;
+
+    gattFTMSService->writeCharacteristic(gattFTMSControlPointCharacteristic, *writeBuffer, mode);
+    emit debug(QStringLiteral(" >> ftms ") + writeBuffer->toHex(' ') + QStringLiteral(" // ") + info);
 }
 
 void wahookickruntreadmill::btinit() {
@@ -90,6 +109,38 @@ void wahookickruntreadmill::forceSpeed(double speed) {
                         QStringLiteral("forceSpeed ") + QString::number(speed));
 }
 
+void wahookickruntreadmill::forceIncline(double requestIncline) {
+    if (noWriteResistance)
+        return;
+
+    if (requestIncline < 0.0)
+        requestIncline = 0.0;
+    if (requestIncline > 15.0)
+        requestIncline = 15.0;
+
+    if (!ftmsControlStarted) {
+        ftmsControlStarted = true;
+        uint8_t requestControl[] = {FTMS_REQUEST_CONTROL};
+        writeFTMSControlPoint(QByteArray(reinterpret_cast<const char *>(requestControl), sizeof(requestControl)),
+                              QStringLiteral("ftms request control"));
+
+        uint8_t startResume[] = {FTMS_START_RESUME};
+        writeFTMSControlPoint(QByteArray(reinterpret_cast<const char *>(startResume), sizeof(startResume)),
+                              QStringLiteral("ftms start/resume"));
+    }
+
+    const int16_t incline = static_cast<int16_t>(std::round(requestIncline * 10.0));
+    uint8_t cmd[] = {
+        FTMS_SET_TARGET_INCLINATION,
+        static_cast<uint8_t>(incline & 0xFF),
+        static_cast<uint8_t>((incline >> 8) & 0xFF),
+    };
+
+    writeFTMSControlPoint(QByteArray(reinterpret_cast<const char *>(cmd), sizeof(cmd)),
+                          QStringLiteral("forceIncline ") + QString::number(requestIncline));
+    Inclination = requestIncline;
+}
+
 void wahookickruntreadmill::changeSpeed(double speed) {
     if (requestSpeed >= 0) {
         // Another command is already pending (not yet sent by update()).
@@ -124,6 +175,8 @@ void wahookickruntreadmill::update() {
             emit debug(QStringLiteral("creating virtual treadmill interface..."));
             auto *vt = new virtualtreadmill(this, noHeartService);
             connect(vt, &virtualtreadmill::debug, this, &wahookickruntreadmill::debug);
+            connect(vt, &virtualtreadmill::changeInclination, this,
+                    &wahookickruntreadmill::changeInclinationRequested);
             this->setVirtualDevice(vt, VIRTUAL_DEVICE_MODE::PRIMARY);
         }
     }
@@ -141,6 +194,14 @@ void wahookickruntreadmill::update() {
             paddlePending = true;
         }
         requestSpeed = -1;
+    }
+
+    if (requestInclination != -100) {
+        if (std::abs(requestInclination - currentInclination().value()) > 0.01 && requestInclination >= 0) {
+            emit debug(QStringLiteral("writing incline ") + QString::number(requestInclination));
+            forceIncline(requestInclination);
+        }
+        requestInclination = -100;
     }
 
     if (requestStart != -1) {
@@ -164,6 +225,10 @@ void wahookickruntreadmill::serviceDiscovered(const QBluetoothUuid &gatt) {
     emit debug(QStringLiteral("serviceDiscovered ") + gatt.toString());
 }
 
+void wahookickruntreadmill::changeInclinationRequested(double grade, double percentage) {
+    changeInclination(grade, percentage);
+}
+
 void wahookickruntreadmill::characteristicChanged(const QLowEnergyCharacteristic &characteristic,
                                                   const QByteArray &newValue) {
     QSettings settings;
@@ -171,6 +236,16 @@ void wahookickruntreadmill::characteristicChanged(const QLowEnergyCharacteristic
                characteristic.uuid().toString());
 
     const int len = newValue.length();
+
+    if (gattFTMSControlPointCharacteristic.isValid() &&
+        characteristic.uuid() == gattFTMSControlPointCharacteristic.uuid() && len >= 3 &&
+        static_cast<uint8_t>(newValue.at(0)) == FTMS_RESPONSE_CODE) {
+        emit debug(QStringLiteral("KickRun FTMS response request=0x") +
+                   QString::number(static_cast<uint8_t>(newValue.at(1)), 16) +
+                   QStringLiteral(" result=0x") +
+                   QString::number(static_cast<uint8_t>(newValue.at(2)), 16));
+        return;
+    }
 
     // --- Command/response channel (same char used for writes) ---
     // FE 86 01 [id0 id1 id2 id3] ... → store device ID, send 87+id
@@ -308,11 +383,22 @@ void wahookickruntreadmill::stateChanged(QLowEnergyService::ServiceState state) 
             // causing all init/speed writes to be silently swallowed by the wrong channel.
             static const QBluetoothUuid cmdCharUuid(
                 QStringLiteral("a026e03e-0a7d-4ab3-97fa-f1500f9feb8b"));
+            static const QBluetoothUuid ftmsServiceUuid(
+                QStringLiteral("00001826-0000-1000-8000-00805f9b34fb"));
+            static const QBluetoothUuid ftmsControlPointUuid(
+                QStringLiteral("00002ad9-0000-1000-8000-00805f9b34fb"));
 
             if (c.uuid() == cmdCharUuid) {
                 gattCmdCharacteristic = c;
                 gattCmdService = s;
                 emit debug(QStringLiteral("KickRun cmd char found: handle=0x") +
+                           QString::number(c.handle(), 16));
+            }
+
+            if (s->serviceUuid() == ftmsServiceUuid && c.uuid() == ftmsControlPointUuid) {
+                gattFTMSControlPointCharacteristic = c;
+                gattFTMSService = s;
+                emit debug(QStringLiteral("KickRun FTMS control point found: handle=0x") +
                            QString::number(c.handle(), 16));
             }
 
@@ -419,10 +505,13 @@ void wahookickruntreadmill::controllerStateChanged(QLowEnergyController::Control
         initDone = false;
         firstSpeedSent = false;
         workoutModeStarted = false;
+        ftmsControlStarted = false;
         deviceIdReceived = false;
         gattCmdCharacteristic = QLowEnergyCharacteristic();
+        gattFTMSControlPointCharacteristic = QLowEnergyCharacteristic();
         gattCmdService = nullptr;
         gattTelService = nullptr;
+        gattFTMSService = nullptr;
         qDeleteAll(gattServices);
         gattServices.clear();
         m_control->connectToDevice();

--- a/src/devices/wahookickruntreadmill/wahookickruntreadmill.cpp
+++ b/src/devices/wahookickruntreadmill/wahookickruntreadmill.cpp
@@ -294,6 +294,8 @@ void wahookickruntreadmill::stateChanged(QLowEnergyService::ServiceState state) 
                            QString::number(c.handle(), 16));
             }
 
+            bool hasNotify = c.properties() & QLowEnergyCharacteristic::Notify;
+
             // Subscribe to all notify/indicate characteristics
             if (hasNotify) {
                 QByteArray descriptor;

--- a/src/devices/wahookickruntreadmill/wahookickruntreadmill.cpp
+++ b/src/devices/wahookickruntreadmill/wahookickruntreadmill.cpp
@@ -138,7 +138,32 @@ void wahookickruntreadmill::forceIncline(double requestIncline) {
 
     writeFTMSControlPoint(QByteArray(reinterpret_cast<const char *>(cmd), sizeof(cmd)),
                           QStringLiteral("forceIncline ") + QString::number(requestIncline));
-    Inclination = requestIncline;
+}
+
+wahookickruntreadmill::FtmsTreadmillData wahookickruntreadmill::parseFtmsTreadmillData(const QByteArray &data) {
+    FtmsTreadmillData parsed;
+    if (data.length() < 2)
+        return parsed;
+
+    const quint16 flags = static_cast<quint8>(data.at(0)) |
+                          (static_cast<quint16>(static_cast<quint8>(data.at(1))) << 8);
+    int index = 2;
+
+    // FTMS Treadmill Data fields are optional and ordered by the flags.
+    if (!(flags & 0x0001)) // Instantaneous Speed
+        index += 2;
+    if (flags & 0x0002) // Average Speed
+        index += 2;
+    if (flags & 0x0004) // Total Distance
+        index += 3;
+    if (!(flags & 0x0008) || data.length() < index + 2)
+        return parsed;
+
+    const quint16 rawInclination = static_cast<quint8>(data.at(index)) |
+                                  (static_cast<quint16>(static_cast<quint8>(data.at(index + 1))) << 8);
+    parsed.hasInclination = true;
+    parsed.inclination = static_cast<qint16>(rawInclination) / 10.0;
+    return parsed;
 }
 
 void wahookickruntreadmill::changeSpeed(double speed) {
@@ -244,6 +269,15 @@ void wahookickruntreadmill::characteristicChanged(const QLowEnergyCharacteristic
                    QString::number(static_cast<uint8_t>(newValue.at(1)), 16) +
                    QStringLiteral(" result=0x") +
                    QString::number(static_cast<uint8_t>(newValue.at(2)), 16));
+        return;
+    }
+
+    if (characteristic.uuid() == QBluetoothUuid(static_cast<quint16>(0x2ACD))) {
+        const FtmsTreadmillData ftmsData = parseFtmsTreadmillData(newValue);
+        if (ftmsData.hasInclination) {
+            Inclination = ftmsData.inclination;
+            emit debug(QStringLiteral("KickRun inclination=") + QString::number(Inclination.value(), 'f', 1));
+        }
         return;
     }
 

--- a/src/devices/wahookickruntreadmill/wahookickruntreadmill.cpp
+++ b/src/devices/wahookickruntreadmill/wahookickruntreadmill.cpp
@@ -113,10 +113,7 @@ void wahookickruntreadmill::forceIncline(double requestIncline) {
     if (noWriteResistance)
         return;
 
-    if (requestIncline < 0.0)
-        requestIncline = 0.0;
-    if (requestIncline > 15.0)
-        requestIncline = 15.0;
+    requestIncline = qBound(-3.0, requestIncline, 15.0);
 
     if (!ftmsControlStarted) {
         ftmsControlStarted = true;
@@ -129,15 +126,18 @@ void wahookickruntreadmill::forceIncline(double requestIncline) {
                               QStringLiteral("ftms start/resume"));
     }
 
-    const int16_t incline = static_cast<int16_t>(std::round(requestIncline * 10.0));
-    uint8_t cmd[] = {
-        FTMS_SET_TARGET_INCLINATION,
-        static_cast<uint8_t>(incline & 0xFF),
-        static_cast<uint8_t>((incline >> 8) & 0xFF),
-    };
-
-    writeFTMSControlPoint(QByteArray(reinterpret_cast<const char *>(cmd), sizeof(cmd)),
+    writeFTMSControlPoint(encodeFtmsInclination(requestIncline),
                           QStringLiteral("forceIncline ") + QString::number(requestIncline));
+}
+
+QByteArray wahookickruntreadmill::encodeFtmsInclination(double inclination) {
+    const int16_t rawInclination = static_cast<int16_t>(std::round(inclination * 10.0));
+    const uint8_t cmd[] = {
+        FTMS_SET_TARGET_INCLINATION,
+        static_cast<uint8_t>(rawInclination & 0xFF),
+        static_cast<uint8_t>((rawInclination >> 8) & 0xFF),
+    };
+    return QByteArray(reinterpret_cast<const char *>(cmd), sizeof(cmd));
 }
 
 wahookickruntreadmill::FtmsTreadmillData wahookickruntreadmill::parseFtmsTreadmillData(const QByteArray &data) {
@@ -222,7 +222,7 @@ void wahookickruntreadmill::update() {
     }
 
     if (requestInclination != -100) {
-        if (std::abs(requestInclination - currentInclination().value()) > 0.01 && requestInclination >= 0) {
+        if (std::abs(requestInclination - currentInclination().value()) > 0.01) {
             emit debug(QStringLiteral("writing incline ") + QString::number(requestInclination));
             forceIncline(requestInclination);
         }

--- a/src/devices/wahookickruntreadmill/wahookickruntreadmill.h
+++ b/src/devices/wahookickruntreadmill/wahookickruntreadmill.h
@@ -56,8 +56,10 @@ class wahookickruntreadmill : public treadmill {
 
   private:
     void writeCharacteristic(const QByteArray &data, const QString &info);
+    void writeFTMSControlPoint(const QByteArray &data, const QString &info);
     void btinit();
     void forceSpeed(double speed);
+    void forceIncline(double requestIncline);
     void startDiscover();
 
     bool noWriteResistance = false;
@@ -66,6 +68,7 @@ class wahookickruntreadmill : public treadmill {
     bool initRequest = false;
     bool firstSpeedSent = false;    // tracks whether to use 0xFF or 0x0A flag
     bool workoutModeStarted = false;
+    bool ftmsControlStarted = false;
 
     QByteArray deviceId;            // 4-byte device ID from the 0x86 init response
     bool deviceIdReceived = false;
@@ -75,8 +78,10 @@ class wahookickruntreadmill : public treadmill {
     QList<QLowEnergyService *> gattServices;
     QLowEnergyService *gattCmdService = nullptr;    // service owning the cmd char
     QLowEnergyService *gattTelService = nullptr;    // service owning the telemetry char
+    QLowEnergyService *gattFTMSService = nullptr;   // Fitness Machine service for standard incline control
     QLowEnergyCharacteristic gattCmdCharacteristic; // write+notify: handle 0x0023
     QLowEnergyCharacteristic gattTelCharacteristic; // notify only: handle 0x0026
+    QLowEnergyCharacteristic gattFTMSControlPointCharacteristic;
 
     int notificationsSubscribed = 0;
 
@@ -99,6 +104,7 @@ class wahookickruntreadmill : public treadmill {
     void controllerStateChanged(QLowEnergyController::ControllerState state);
     void serviceDiscovered(const QBluetoothUuid &gatt);
     void serviceScanDone(void);
+    void changeInclinationRequested(double grade, double percentage);
     void update();
     void error(QLowEnergyController::Error err);
     void errorService(QLowEnergyService::ServiceError);

--- a/src/devices/wahookickruntreadmill/wahookickruntreadmill.h
+++ b/src/devices/wahookickruntreadmill/wahookickruntreadmill.h
@@ -1,0 +1,105 @@
+#ifndef WAHOOKICKRUNTREADMILL_H
+#define WAHOOKICKRUNTREADMILL_H
+
+#include <QBluetoothDeviceDiscoveryAgent>
+#include <QtBluetooth/qlowenergyadvertisingdata.h>
+#include <QtBluetooth/qlowenergyadvertisingparameters.h>
+#include <QtBluetooth/qlowenergycharacteristic.h>
+#include <QtBluetooth/qlowenergycharacteristicdata.h>
+#include <QtBluetooth/qlowenergycontroller.h>
+#include <QtBluetooth/qlowenergydescriptordata.h>
+#include <QtBluetooth/qlowenergyservice.h>
+#include <QtBluetooth/qlowenergyservicedata.h>
+#include <QtCore/qbytearray.h>
+
+#ifndef Q_OS_ANDROID
+#include <QtCore/qcoreapplication.h>
+#else
+#include <QtGui/qguiapplication.h>
+#endif
+#include <QtCore/qlist.h>
+#include <QtCore/qmutex.h>
+#include <QtCore/qscopedpointer.h>
+#include <QtCore/qtimer.h>
+
+#include <QDateTime>
+#include <QObject>
+
+#include "treadmill.h"
+
+// Wahoo KickRun treadmill - proprietary protocol
+//
+// Protocol summary (all commands/notifies on the "cmd" characteristic,
+// which is the one having both Write-Without-Response and Notify):
+//
+// Speed command (app→device):
+//   02 [b0 b1 b2] 00 [flag]
+//   b0..b2 = uint24 LE, speed in μm/s (= round(km/h / 3.6 * 1e6))
+//   flag   = 0xFF for first speed cmd of a workout session, 0x0A for subsequent
+//
+// Challenge-response (device→app, then app→device):
+//   device sends: FD E0 01 [code_hi] [code_lo]  (after user presses paddle)
+//   app replies:  E0 [code_hi] [code_lo]
+//
+// Telemetry (notify on the separate telemetry characteristic, ~2 Hz):
+//   FF 01 [tgt_b0 tgt_b1 tgt_b2] 00 [cur_b0 cur_b1 cur_b2] ...
+//   tgt = target speed (μm/s LE24); cur = current belt speed (μm/s LE24)
+
+class wahookickruntreadmill : public treadmill {
+    Q_OBJECT
+  public:
+    wahookickruntreadmill(bool noWriteResistance, bool noHeartService);
+    bool connected() override;
+    bool autoPauseWhenSpeedIsZero() override;
+    bool autoStartWhenSpeedIsGreaterThenZero() override;
+
+  private:
+    void writeCharacteristic(const QByteArray &data, const QString &info);
+    void btinit();
+    void forceSpeed(double speed);
+    void startDiscover();
+
+    bool noWriteResistance = false;
+    bool noHeartService = false;
+    bool initDone = false;
+    bool initRequest = false;
+    bool firstSpeedSent = false;    // tracks whether to use 0xFF or 0x0A flag
+    bool workoutModeStarted = false;
+
+    QByteArray deviceId;            // 4-byte device ID from the 0x86 init response
+    bool deviceIdReceived = false;
+
+    QTimer *refresh;
+    QList<QLowEnergyService *> gattServices;
+    QLowEnergyService *gattCmdService = nullptr;    // service owning the cmd char
+    QLowEnergyService *gattTelService = nullptr;    // service owning the telemetry char
+    QLowEnergyCharacteristic gattCmdCharacteristic; // write+notify: handle 0x0023
+    QLowEnergyCharacteristic gattTelCharacteristic; // notify only: handle 0x0026
+
+    int notificationsSubscribed = 0;
+
+    QByteArray lastPacket;
+    QDateTime lastTimeCharacteristicChanged;
+    bool firstCharacteristicChanged = true;
+
+  Q_SIGNALS:
+    void disconnected();
+    void debug(QString string);
+
+  public slots:
+    void deviceDiscovered(const QBluetoothDeviceInfo &device);
+
+  private slots:
+    void characteristicChanged(const QLowEnergyCharacteristic &characteristic, const QByteArray &newValue);
+    void characteristicWritten(const QLowEnergyCharacteristic &characteristic, const QByteArray &newValue);
+    void descriptorWritten(const QLowEnergyDescriptor &descriptor, const QByteArray &newValue);
+    void stateChanged(QLowEnergyService::ServiceState state);
+    void controllerStateChanged(QLowEnergyController::ControllerState state);
+    void serviceDiscovered(const QBluetoothUuid &gatt);
+    void serviceScanDone(void);
+    void update();
+    void error(QLowEnergyController::Error err);
+    void errorService(QLowEnergyService::ServiceError);
+};
+
+#endif // WAHOOKICKRUNTREADMILL_H

--- a/src/devices/wahookickruntreadmill/wahookickruntreadmill.h
+++ b/src/devices/wahookickruntreadmill/wahookickruntreadmill.h
@@ -52,6 +52,7 @@ class wahookickruntreadmill : public treadmill {
     bool connected() override;
     bool autoPauseWhenSpeedIsZero() override;
     bool autoStartWhenSpeedIsGreaterThenZero() override;
+    void changeSpeed(double speed) override;
 
   private:
     void writeCharacteristic(const QByteArray &data, const QString &info);
@@ -68,6 +69,7 @@ class wahookickruntreadmill : public treadmill {
 
     QByteArray deviceId;            // 4-byte device ID from the 0x86 init response
     bool deviceIdReceived = false;
+    bool paddlePending = false;     // speed command sent, waiting for paddle push
 
     QTimer *refresh;
     QList<QLowEnergyService *> gattServices;

--- a/src/devices/wahookickruntreadmill/wahookickruntreadmill.h
+++ b/src/devices/wahookickruntreadmill/wahookickruntreadmill.h
@@ -55,6 +55,7 @@ class wahookickruntreadmill : public treadmill {
 
     wahookickruntreadmill(bool noWriteResistance, bool noHeartService);
     static FtmsTreadmillData parseFtmsTreadmillData(const QByteArray &data);
+    static QByteArray encodeFtmsInclination(double inclination);
     bool connected() override;
     bool autoPauseWhenSpeedIsZero() override;
     bool autoStartWhenSpeedIsGreaterThenZero() override;

--- a/src/devices/wahookickruntreadmill/wahookickruntreadmill.h
+++ b/src/devices/wahookickruntreadmill/wahookickruntreadmill.h
@@ -48,7 +48,13 @@
 class wahookickruntreadmill : public treadmill {
     Q_OBJECT
   public:
+    struct FtmsTreadmillData {
+        bool hasInclination = false;
+        double inclination = 0.0;
+    };
+
     wahookickruntreadmill(bool noWriteResistance, bool noHeartService);
+    static FtmsTreadmillData parseFtmsTreadmillData(const QByteArray &data);
     bool connected() override;
     bool autoPauseWhenSpeedIsZero() override;
     bool autoStartWhenSpeedIsGreaterThenZero() override;

--- a/src/qdomyos-zwift.pri
+++ b/src/qdomyos-zwift.pri
@@ -338,6 +338,7 @@ devices/trxappgateusbbike/trxappgateusbbike.cpp \
 devices/ultrasportbike/ultrasportbike.cpp \
 virtualdevices/virtualrower.cpp \
 devices/wahookickrsnapbike/wahookickrsnapbike.cpp \
+devices/wahookickruntreadmill/wahookickruntreadmill.cpp \
 devices/yesoulbike/yesoulbike.cpp \
 trainprogram.cpp \
 devices/trxappgateusbtreadmill/trxappgateusbtreadmill.cpp \
@@ -873,6 +874,7 @@ virtualdevices/virtualrower.h \
 virtualdevices/virtualtreadmill.h \
 devices/domyosbike/domyosbike.h \
 devices/wahookickrsnapbike/wahookickrsnapbike.h \
+devices/wahookickruntreadmill/wahookickruntreadmill.h \
 wobjectdefs.h \
 wobjectimpl.h \
 devices/yesoulbike/yesoulbike.h \

--- a/tst/Devices/TestWahooKickrRunParser.cpp
+++ b/tst/Devices/TestWahooKickrRunParser.cpp
@@ -1,0 +1,1 @@
+#include "TestWahooKickrRunParser.h"

--- a/tst/Devices/TestWahooKickrRunParser.h
+++ b/tst/Devices/TestWahooKickrRunParser.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <QByteArray>
+#include <gtest/gtest.h>
+
+#include "devices/wahookickruntreadmill/wahookickruntreadmill.h"
+
+TEST(WahooKickrRunFtmsRegressionTest, ParsesActualInclinationFromStephanLoggedTreadmillData) {
+    const auto onePercent = wahookickruntreadmill::parseFtmsTreadmillData(
+        QByteArray::fromHex("0c002c018d00000a00ff7f"));
+    const auto twoPercent = wahookickruntreadmill::parseFtmsTreadmillData(
+        QByteArray::fromHex("0c002c018f00001400ff7f"));
+
+    ASSERT_TRUE(onePercent.hasInclination);
+    EXPECT_NEAR(onePercent.inclination, 1.0, 0.001);
+    ASSERT_TRUE(twoPercent.hasInclination);
+    EXPECT_NEAR(twoPercent.inclination, 2.0, 0.001);
+}
+
+TEST(WahooKickrRunFtmsRegressionTest, HandlesTreadmillDataWithoutAnInclinationField) {
+    const auto data = wahookickruntreadmill::parseFtmsTreadmillData(
+        QByteArray::fromHex("00002c01"));
+
+    EXPECT_FALSE(data.hasInclination);
+}

--- a/tst/Devices/TestWahooKickrRunParser.h
+++ b/tst/Devices/TestWahooKickrRunParser.h
@@ -23,3 +23,9 @@ TEST(WahooKickrRunFtmsRegressionTest, HandlesTreadmillDataWithoutAnInclinationFi
 
     EXPECT_FALSE(data.hasInclination);
 }
+
+TEST(WahooKickrRunFtmsRegressionTest, EncodesSignedInclinationWithinKickrRunRange) {
+    EXPECT_EQ(wahookickruntreadmill::encodeFtmsInclination(-3.0), QByteArray::fromHex("03e2ff"));
+    EXPECT_EQ(wahookickruntreadmill::encodeFtmsInclination(-2.0), QByteArray::fromHex("03ecff"));
+    EXPECT_EQ(wahookickruntreadmill::encodeFtmsInclination(15.0), QByteArray::fromHex("039600"));
+}

--- a/tst/qdomyos-zwift-tests.pro
+++ b/tst/qdomyos-zwift-tests.pro
@@ -32,6 +32,7 @@ SOURCES += \
         Devices/TestZwiftRideController.cpp \
         Devices/TestApexBikeParser.cpp \
         Devices/TestKeepBikeParser.cpp \
+        Devices/TestWahooKickrRunParser.cpp \
         main.cpp
 
 # Avoid the "File too big" error building in Windows. This has happened when a template class is used with Google Test / typed tests
@@ -63,6 +64,7 @@ HEADERS += \
     Devices/TestSchwinn411510EParser.h \
     Devices/TestApexBikeParser.h \
     Devices/TestKeepBikeParser.h \
+    Devices/TestWahooKickrRunParser.h \
     Devices/TestOctaneTreadmillZR8.h \
     Devices/TestSunnyfitStepper.h \
     Erg/ergtabletestsuite.h \


### PR DESCRIPTION
## Summary

- Adds dedicated `wahookickruntreadmill` driver for the Wahoo KickRun treadmill (previously routed through `horizonTreadmill` which only supports inclination)
- Protocol reverse-engineered from HCI btsnoop log: proprietary BLE over a single Write-Without-Response + Notify characteristic (handle 0x0023)
- Implements the full init sequence (`01 10 12 18 80 86 f0`), device-ID handshake (`87 + [4-byte ID]`), and workout-mode unlock (`19 00`)
- Speed command: `02 [μm/s LE24] 00 [flag]` where flag = `0xFF` for first command of session, `0x0A` for subsequent; confirmed against captured traces at 2.4, 4.8 and 5.0 km/h
- Handles the hardware challenge-response safety interlock: treadmill sends `FD E0 01 [XX YY]` after user presses the physical paddle, driver immediately echoes `E0 [XX YY]` to confirm
- Telemetry parsed from characteristic 0x0026: `FF 01 [tgt_b0 b1 b2] 00 …` — bytes 2–4 are the commanded speed in μm/s LE24 (confirmed from trace)
- Note: the physical paddle push before each speed change is enforced in treadmill firmware and **cannot** be bypassed via BLE configuration commands (all init commands are read-only queries or one-shot unlocks)

## Test plan

- [ ] Build compiles on Android/iOS/Linux/macOS
- [ ] Device named `KICKR RUN *` is picked up by the new driver (not routed to `horizonTreadmill`)
- [ ] Init sequence completes and `connectedAndDiscovered` fires
- [ ] Speed commands reach the treadmill after paddle push
- [ ] Telemetry updates `Speed` metric correctly
- [ ] Reconnect after BLE drop resets state and re-inits

🤖 Generated with [Claude Code](https://claude.com/claude-code)