### PR TITLE
feat: add V-BLE-R support to ftmsrower without init request

### DIFF
--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -2153,6 +2153,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                         b.name().toUpper().startsWith(QStringLiteral("COACH 2")) ||
                         b.name().toUpper().startsWith(QStringLiteral("ROGUE CONSOLE ")) ||
                         b.name().toUpper().startsWith(QStringLiteral("DFIT-L-R")) ||
+                        b.name().toUpper().startsWith(QStringLiteral("V-BLE-R-")) ||
                         !b.name().compare(ftms_rower, Qt::CaseInsensitive) ||
                         (b.name().toUpper().startsWith(QStringLiteral("PM5")) &&
                          b.name().toUpper().endsWith(QStringLiteral("ROW")))) &&

--- a/src/devices/ftmsrower/ftmsrower.cpp
+++ b/src/devices/ftmsrower/ftmsrower.cpp
@@ -78,15 +78,17 @@ void ftmsrower::update() {
     }
 
     if (initRequest) {
-        if(I_ROWER || SF_RW || ROWER || MRK_R06) {
-            uint8_t write[] = {FTMS_REQUEST_CONTROL};
-            writeCharacteristic(write, sizeof(write), "start", false, true);
+        if (!V_BLE_R) {
+            if(I_ROWER || SF_RW || ROWER || MRK_R06) {
+                uint8_t write[] = {FTMS_REQUEST_CONTROL};
+                writeCharacteristic(write, sizeof(write), "start", false, true);
 
-            uint8_t write1[] = {FTMS_START_RESUME};
-            writeCharacteristic(write1, sizeof(write1), "start simulation", false, true);
-        } else {
-            uint8_t write[] = {FTMS_START_RESUME};
-            writeCharacteristic(write, sizeof(write), "start simulation", false, true);
+                uint8_t write1[] = {FTMS_START_RESUME};
+                writeCharacteristic(write1, sizeof(write1), "start simulation", false, true);
+            } else {
+                uint8_t write[] = {FTMS_START_RESUME};
+                writeCharacteristic(write, sizeof(write), "start simulation", false, true);
+            }
         }
 
         initRequest = false;
@@ -880,6 +882,9 @@ void ftmsrower::deviceDiscovered(const QBluetoothDeviceInfo &device) {
         } else if (device.name().toUpper().startsWith(QStringLiteral("DOMYOS-ROW-"))) {
             DOMYOS = true;
             qDebug() << "DOMYOS found!";
+        } else if (device.name().toUpper().startsWith(QStringLiteral("V-BLE-R-"))) {
+            V_BLE_R = true;
+            qDebug() << "V-BLE-R found! skipping init request";
         } else if (deviceName.size() >= 7 && deviceName.startsWith(QStringLiteral("WDK")) &&
                    deviceName.at(3).isDigit() && deviceName.at(4).isDigit() &&
                    deviceName.at(5).isDigit() && deviceName.at(6).isDigit()) {

--- a/src/devices/ftmsrower/ftmsrower.cpp
+++ b/src/devices/ftmsrower/ftmsrower.cpp
@@ -607,10 +607,10 @@ void ftmsrower::stateChanged(QLowEnergyService::ServiceState state) {
             connect(s, &QLowEnergyService::descriptorWritten, this, &ftmsrower::descriptorWritten);
             connect(s, &QLowEnergyService::descriptorRead, this, &ftmsrower::descriptorRead);
 
-            if (I_ROWER || SF_RW || ROWER || MRK_R06 || DOMYOS) {
+            if (I_ROWER || SF_RW || ROWER || MRK_R06 || DOMYOS || V_BLE_R) {
                 QBluetoothUuid ftmsService((quint16)0x1826);
                 if (s->serviceUuid() != ftmsService) {
-                    qDebug() << QStringLiteral("I-ROWER/SF-RW/ROWER/MRK-R06/DOMYOS wants to be subscribed only to FTMS service in order to send metrics")
+                    qDebug() << QStringLiteral("I-ROWER/SF-RW/ROWER/MRK-R06/DOMYOS/V-BLE-R wants to be subscribed only to FTMS service in order to send metrics")
                              << s->serviceUuid();
                     continue;
                 }

--- a/src/devices/ftmsrower/ftmsrower.h
+++ b/src/devices/ftmsrower/ftmsrower.h
@@ -83,6 +83,7 @@ class ftmsrower : public rower {
     bool ROWER = false;
     bool MRK_R06 = false;
     bool MRK_R11S = false;
+    bool V_BLE_R = false;
     QDateTime lastStroke = QDateTime::currentDateTime();
     double lastStrokesCount = 0;
     


### PR DESCRIPTION
## Summary
- Adds recognition of devices with name prefix `V-BLE-R-` in `ftmsrower`
- Introduces a `V_BLE_R` boolean flag (mirroring the pattern of other device-specific flags)
- When `V_BLE_R` is set, the FTMS control-point init sequence (`FTMS_REQUEST_CONTROL` / `FTMS_START_RESUME`) is skipped entirely on connection

## Test plan
- [ ] Connect a device advertising as `V-BLE-R-*` and verify no init write is sent
- [ ] Connect any other FTMS rower and verify init behaviour is unchanged
- [ ] Verify I-ROWER / SF-RW / ROWER / MRK-R06 still send the two-step init

🤖 Generated with [Claude Code](https://claude.com/claude-code)