### PR TITLE
fix: restore B628 mph-to-km/h speed conversion in nautilusbike

### DIFF
--- a/src/devices/nautilusbike/nautilusbike.cpp
+++ b/src/devices/nautilusbike/nautilusbike.cpp
@@ -213,14 +213,20 @@ void nautilusbike::characteristicChanged(const QLowEnergyCharacteristic &charact
 
 double nautilusbike::GetSpeedFromPacket(const QByteArray &packet) {
     const double miles = 1.60934;
-    QSettings settings;
-    const bool milesUnit = settings.value(QZSettings::miles_unit, QZSettings::default_miles_unit).toBool();
     uint16_t convertedData = 0;
     double data = 0;
     convertedData = (packet.at(4) << 8) | ((uint8_t)packet.at(3));
     data = (double)convertedData / 100.0f;
-    if (milesUnit)
+    if (B616) {
+        // B616 sends speed in km/h, but in mph when the bike unit is set to miles
+        QSettings settings;
+        const bool milesUnit = settings.value(QZSettings::miles_unit, QZSettings::default_miles_unit).toBool();
+        if (milesUnit)
+            data = data * miles;
+    } else {
+        // B628 and other models always send speed in mph; convert to km/h
         data = data * miles;
+    }
 
     return data;
 }


### PR DESCRIPTION
## Summary

- Commit 19ffdd6 ("B616 can be miles too") replaced `if (!B616)` with `if (milesUnit)` to support B616 bikes configured in miles mode
- This broke B628 (and other non-B616 models) which always send speed in mph — without the conversion, QZ displays ~22 km/h instead of the correct ~36 km/h
- The ratio between displayed and expected value is ~1.609 (exactly the mph→km/h factor), confirming the missing conversion

**Fix**: restore per-model logic in `GetSpeedFromPacket`:
- **B616**: only convert when `milesUnit` is true (device sends km/h normally, mph when bike is in miles mode)
- **non-B616 (B628 etc.)**: always convert mph→km/h

Closes #4838

## Test plan

- [ ] B628 user with `miles_unit = false`: should now show ~36 km/h matching the bike console (was ~23 before)
- [ ] B628 user with `miles_unit = true`: should show the correct mph value (~22.4 mph)
- [ ] B616 user with `miles_unit = false`: unchanged — device sends km/h, no conversion applied
- [ ] B616 user with `miles_unit = true`: unchanged — multiplies by 1.60934

🤖 Generated with [Claude Code](https://claude.com/claude-code)