### PR TITLE
fix: write true local time in FIT TimestampCorrelation local_timestamp

### DIFF
--- a/src/qfit.cpp
+++ b/src/qfit.cpp
@@ -867,10 +867,11 @@ void qfit::save(const QString &filename, QList<SessionLine> session, BLUETOOTH_T
     // System Timestamp: Same as timestamp (session start)
     timestampCorrelationMesg.SetSystemTimestamp(sessionStartTimestamp);
 
-    // Local Timestamp: User's local time at session start
-    // Convert the local time to FIT format
-    fit::DateTime localDateTime((time_t)session.at(firstRealIndex).time.toSecsSinceEpoch());
-    timestampCorrelationMesg.SetLocalTimestamp(localDateTime.GetTimeStamp());
+    // Local Timestamp: session start expressed in the user's local wall-clock time.
+    // Per the FIT spec, local_timestamp = timestamp + UTC offset, so consumers can
+    // derive the offset as (local_timestamp - timestamp).
+    qint64 utcOffsetSeconds = session.at(firstRealIndex).time.offsetFromUtc();
+    timestampCorrelationMesg.SetLocalTimestamp(sessionStartTimestamp + utcOffsetSeconds);
 
     encode.Write(timestampCorrelationMesg);
 


### PR DESCRIPTION
## Summary
- `local_timestamp` in the `TimestampCorrelationMesg` (added in #4146) was being set to exactly the same value as `timestamp`, i.e. no UTC offset was ever applied. This means the field carried no actual local-time information, defeating the purpose of the timestamp correlation record for companion-app timezone syncing (see cagnulein/QZCompanionGarmin#9).
- Now `local_timestamp = timestamp + offsetFromUtc()`, matching the FIT spec, so consumers can derive the local UTC offset as `local_timestamp - timestamp`.

## Test plan
- [ ] Generate a FIT file and confirm `local_timestamp` in the TimestampCorrelation message differs from `timestamp`/`system_timestamp` by the local UTC offset in seconds