### PR TITLE
Compute power from resistance for MOK Fitness S10 Ultra bike

### DIFF
--- a/src/devices/ftmsbike/ftmsbike.cpp
+++ b/src/devices/ftmsbike/ftmsbike.cpp
@@ -976,6 +976,9 @@ void ftmsbike::characteristicChanged(const QLowEnergyCharacteristic &characteris
             if (SMARTBIKE_3DIGIT && manualResistancePowerAdjustmentActive) {
                 m_watt = cscbike::customResistanceAdjustedWatts(currentCadence().value(), manualResistanceTarget);
                 emit debug(QStringLiteral("Current Watt (custom resistance table): ") + QString::number(m_watt.value()));
+            } else if (MOK_FITNESS && cscbike::useCustomResistancePowerTable()) {
+                m_watt = cscbike::customResistanceAdjustedWatts(currentCadence().value(), Resistance.value());
+                emit debug(QStringLiteral("Current Watt (custom resistance table): ") + QString::number(m_watt.value()));
             } else if(DU30_bike) {
                 m_watt = wattsFromResistance(Resistance.value());
                 emit debug(QStringLiteral("Current Watt: ") + QString::number(m_watt.value()));
@@ -2149,6 +2152,10 @@ void ftmsbike::deviceDiscovered(const QBluetoothDeviceInfo &device) {
             ergModeSupported = false;
             max_resistance = 10;
             Resistance = 1; // Initialize resistance to 1 for SPORT01
+        } else if(device.name().toUpper().startsWith("MOKFITNESS-")) {
+            qDebug() << QStringLiteral("MOKFITNESS found");
+            MOK_FITNESS = true;
+            max_resistance = 32;
         } else if (isSmartBikeThreeDigitName(device.name())) {
             qDebug() << QStringLiteral("SMARTBIKE-### found");
             SMARTBIKE_3DIGIT = true;

--- a/src/devices/ftmsbike/ftmsbike.h
+++ b/src/devices/ftmsbike/ftmsbike.h
@@ -210,6 +210,7 @@ class ftmsbike : public bike {
     bool USDC_D700 = false;
     bool TOPUTURE_TEB5 = false;
     bool SMARTBIKE_3DIGIT = false;
+    bool MOK_FITNESS = false;
 
     uint8_t secondsToResetTimer = 5;
 


### PR DESCRIPTION
## Summary
- Detects the MOK Fitness S10 Ultra bike by its BLE name (`MOKFITNESS-*`)
- When the existing "Custom CSC Resistance/Watt Table" setting is enabled, power is now computed from cadence and the bike's native resistance level (reusing `cscbike::customResistanceAdjustedWatts`) instead of the bike's reported FTMS power, which stays constant regardless of resistance changes

Fixes #4844

## Test plan
- [ ] User to confirm on-device with a build that enabling "Custom CSC Resistance/Watt Table" and configuring 2 resistance/watt points now makes power react to resistance changes on the MOK Fitness S10 Ultra