### PR TITLE
Stages SB20 handlebar shifter buttons -> in-app controls (#4785)

### DIFF
--- a/docs/22_devices_detail.md
+++ b/docs/22_devices_detail.md
@@ -11,3 +11,18 @@ The [cardio belt provided](https://www.sports-tech.uk.com/chest-strap-sportstech
 The cardio captors are reported to not be accurate.
 #### Resistance 
 The resistance is adjusted after a few seconds delay (time for the engine to adapt magnetic resistance).
+
+## Stages
+
+### SB20
+
+#### Handlebar buttons
+The SB20's six handlebar buttons can control QZ — target power +/-, Peloton offset +/-, and gear
+down/up — behind **Settings -> Stages Bike Options -> SB20 handlebar buttons**. Holding a button
+repeats the action.
+
+They arrive on a vendor characteristic (`0c46be60`, service `0c46be5f`) as
+`<type:u8> 00 <bitmask:u16 LE>`, where the bitmask is a one-hot button id (bits 0-5: LEFT
+up/down/3rd, RIGHT up/down/3rd). A press streams `0x01` frames while held and ends with a `0x04`
+or `0x08` terminator; a `0x03` "commit" frame is only sent for a minority of presses, so the
+decode keys off the held-stream rather than the commit frame.

--- a/src/devices/ftmsbike/ftmsbike.cpp
+++ b/src/devices/ftmsbike/ftmsbike.cpp
@@ -720,6 +720,73 @@ void ftmsbike::characteristicChanged(const QLowEnergyCharacteristic &characteris
         return;
     }
 
+    // Stages SB20 handlebar shifter buttons (vendor characteristic 0c46be60): surface the spare
+    // buttons as in-app controls. Payload is <type:u8> 00 <bitmask:u16 LE>; type 0x03 is the
+    // per-press "commit" frame (the 0x01 held-stream / 0x04|0x08 terminators are ignored, which
+    // debounces the burst to one action per press). The bitmask is one-hot per button:
+    // bit0 LEFT-up, bit1 LEFT-down, bit3 RIGHT-up, bit4 RIGHT-down (bits 2/5 = unmapped "3rd").
+    // Default mapping: LEFT up/down = target power +/-, RIGHT up/down = Peloton offset +/-.
+    // Stages SB20 handlebar shifter buttons (vendor characteristic 0c46be60, service 0c46be5f).
+    // Payload: <type:u8> 00 <bitmask:u16 LE>; the bitmask is a one-hot button id (bits 0-5).
+    //
+    // Frame model, MEASURED on a real SB20 (not inferred): a press streams 0x01 frames while held
+    // (~10-20/s) and ends with a terminator — 0x04 after a burst that also emitted a 0x03 "commit",
+    // 0x08 after one that did not. Crucially the bike sends 0x03 for only a FRACTION of presses:
+    // across a full on-bike session, 2 commits against 32 terminators (~6%). Keying on 0x03 there-
+    // fore drops most input — measured before this logic: LEFT-down 0 of 2 presses, LEFT-up 4 of ~12.
+    //
+    // So we act on the FIRST 0x01 of a burst and disarm until a terminator re-arms us: exactly one
+    // action per physical press, whichever terminator the bike happens to choose. Holding the button
+    // keeps the 0x01 stream alive, so after a short delay we auto-repeat — a tap nudges, a hold ramps.
+    if (characteristic.uuid() == QBluetoothUuid(QStringLiteral("0c46be60-9c22-48ff-ae0e-c6eae1a2f4e5"))) {
+        if (newValue.length() >= 4) {
+            const uint8_t frameType = (uint8_t)newValue.at(0);
+            if (frameType == 0x04 || frameType == 0x08) { // burst ended — next press starts fresh
+                sb20BurstArmed = true;
+                return;
+            }
+        }
+        bool fire = false;
+        if (settings.value(QZSettings::sb20_buttons_enabled, QZSettings::default_sb20_buttons_enabled).toBool() &&
+            newValue.length() >= 4 && ((uint8_t)newValue.at(0)) == 0x01 && homeform::singleton()) {
+            if (sb20BurstArmed) { // first frame of a new press -> act immediately
+                fire = true;
+                sb20BurstArmed = false;
+                sb20BurstStart = now;
+            } else if (sb20BurstStart.isValid() && sb20BurstStart.msecsTo(now) >= SB20_HOLD_DELAY_MS &&
+                       (!lastSb20ButtonPress.isValid() || lastSb20ButtonPress.msecsTo(now) >= SB20_REPEAT_MS)) {
+                fire = true; // still held past the delay -> auto-repeat
+            }
+        }
+        if (fire) {
+            lastSb20ButtonPress = now;
+            uint16_t buttonMask = ((uint8_t)newValue.at(2)) | (((uint16_t)((uint8_t)newValue.at(3))) << 8);
+            switch (buttonMask) {
+            case 0x0001: // LEFT up -> target power +
+                homeform::singleton()->keyboardPlus(QStringLiteral("target_power"));
+                break;
+            case 0x0002: // LEFT down -> target power -
+                homeform::singleton()->keyboardMinus(QStringLiteral("target_power"));
+                break;
+            case 0x0004: // LEFT 3rd -> gear down (virtual shifting)
+                gearDown();
+                break;
+            case 0x0008: // RIGHT up -> peloton offset +
+                homeform::singleton()->keyboardPlus(QStringLiteral("peloton_offset"));
+                break;
+            case 0x0010: // RIGHT down -> peloton offset -
+                homeform::singleton()->keyboardMinus(QStringLiteral("peloton_offset"));
+                break;
+            case 0x0020: // RIGHT 3rd -> gear up (virtual shifting)
+                gearUp();
+                break;
+            default:
+                break;
+            }
+        }
+        return;
+    }
+
     if (characteristic.uuid() == QBluetoothUuid((quint16)0x2AD9) && newValue.length() >= 3) {
         const uint8_t responseCode = (uint8_t)newValue.at(0);
         const uint8_t requestCode = (uint8_t)newValue.at(1);

--- a/src/devices/ftmsbike/ftmsbike.h
+++ b/src/devices/ftmsbike/ftmsbike.h
@@ -139,6 +139,11 @@ class ftmsbike : public bike {
     QDateTime lastRefreshCharacteristicChanged2ACE = QDateTime::currentDateTime();
     QDateTime lastDomyosResistanceCommand = QDateTime::currentDateTime().addSecs(-60);
     QDateTime domyosResistanceRetryAfter = QDateTime::currentDateTime().addSecs(-60);
+    QDateTime lastSb20ButtonPress; // last dispatched SB20 shifter action (rate-limits auto-repeat)
+    QDateTime sb20BurstStart;      // when the current press began, for the hold-to-repeat delay
+    bool sb20BurstArmed = true;    // true = next 0x01 starts a new press; a 0x04/0x08 re-arms it
+    static constexpr int SB20_HOLD_DELAY_MS = 450; // hold this long before auto-repeat starts
+    static constexpr int SB20_REPEAT_MS = 200;     // then one action per this interval while held
     bool ftmsFrameReceived = false;
     uint8_t firstStateChanged = 0;
     int8_t bikeResistanceOffset = 4;

--- a/src/qzsettings.cpp
+++ b/src/qzsettings.cpp
@@ -768,6 +768,7 @@ const QString QZSettings::poll_device_time = QStringLiteral("poll_device_time");
 const QString QZSettings::proform_bike_PFEVEX71316_1 = QStringLiteral("proform_bike_PFEVEX71316_1");
 const QString QZSettings::schwinn_bike_resistance_v3 = QStringLiteral("schwinn_bike_resistance_v3");
 const QString QZSettings::watt_ignore_builtin = QStringLiteral("watt_ignore_builtin");
+const QString QZSettings::sb20_buttons_enabled = QStringLiteral("sb20_buttons_enabled");
 const QString QZSettings::proform_treadmill_z1300i = QStringLiteral("proform_treadmill_z1300i");
 const QString QZSettings::ftms_bike = QStringLiteral("ftms_bike");
 const QString QZSettings::default_ftms_bike = QStringLiteral("Disabled");
@@ -1279,7 +1280,7 @@ const QString QZSettings::default_shortcut_start_stop = QStringLiteral("");
 const QString QZSettings::shortcut_stop = QStringLiteral("shortcut_stop");
 const QString QZSettings::default_shortcut_stop = QStringLiteral("");
 
-const uint32_t allSettingsCount = 1001;
+const uint32_t allSettingsCount = 1002;
 
 QVariant allSettings[allSettingsCount][2] = {
     {QZSettings::cryptoKeySettingsProfiles, QZSettings::default_cryptoKeySettingsProfiles},
@@ -1913,6 +1914,7 @@ QVariant allSettings[allSettingsCount][2] = {
     {QZSettings::proform_bike_PFEVEX71316_1, QZSettings::default_proform_bike_PFEVEX71316_1},
     {QZSettings::schwinn_bike_resistance_v3, QZSettings::default_schwinn_bike_resistance_v3},
     {QZSettings::watt_ignore_builtin, QZSettings::default_watt_ignore_builtin},
+    {QZSettings::sb20_buttons_enabled, QZSettings::default_sb20_buttons_enabled},
     {QZSettings::proform_treadmill_z1300i, QZSettings::default_proform_treadmill_z1300i},
     {QZSettings::ftms_bike, QZSettings::default_ftms_bike},
     {QZSettings::ftms_treadmill, QZSettings::default_ftms_treadmill},

--- a/src/qzsettings.h
+++ b/src/qzsettings.h
@@ -2112,6 +2112,10 @@ class QZSettings {
     static const QString watt_ignore_builtin;
     static constexpr bool default_watt_ignore_builtin = true;
 
+    // Stages SB20: map the handlebar shifter buttons to in-app controls (target power / peloton offset)
+    static const QString sb20_buttons_enabled;
+    static constexpr bool default_sb20_buttons_enabled = true;
+
     static const QString proform_treadmill_z1300i;
     static constexpr bool default_proform_treadmill_z1300i = false;
 

--- a/src/settings-catalog.json
+++ b/src/settings-catalog.json
@@ -2,7 +2,7 @@
   "$schema": "https://qdomyos-zwift.local/settings-catalog.schema.json",
   "schemaVersion": 1,
   "format": "qdomyos-zwift-settings-catalog",
-  "settingCount": 965,
+  "settingCount": 966,
   "pages": [
     {
       "key": "page_custom_gear_table",
@@ -13719,6 +13719,19 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
+      "options": null
+    },
+    {
+      "key": "sb20_buttons_enabled",
+      "name": "Stages SB20 handlebar buttons",
+      "description": "Use the Stages SB20's own handlebar shifter buttons to control QZ: LEFT up/down = target power +/-, RIGHT up/down = Peloton offset +/-, LEFT/RIGHT 3rd = gear down/up. Hold a button to repeat. Only affects Stages SB20 bikes.",
+      "parent": "Bike Options",
+      "type": "boolean",
+      "qmlType": "bool",
+      "control": "switch",
+      "visible": true,
+      "defaultValue": true,
+      "defaultExpression": "true",
       "options": null
     }
   ]

--- a/src/settings.qml
+++ b/src/settings.qml
@@ -1737,6 +1737,7 @@ import AndroidStatusBar 1.0
             property int mywhoosh_link_emote_value: 1
             property bool waterrower_usb: false
             property string freebeat_serialport: ""
+            property bool sb20_buttons_enabled: true
         }
 
 
@@ -3189,6 +3190,31 @@ import AndroidStatusBar 1.0
                 //anchors.topMargin: 10
                 accordionContent: ColumnLayout {
                     spacing: 0
+
+                            IndicatorOnlySwitch {
+                                text: qsTr("Stages SB20 handlebar buttons")
+                                spacing: 0
+                                bottomPadding: 0
+                                topPadding: 0
+                                rightPadding: 0
+                                leftPadding: 0
+                                clip: false
+                                checked: settings.sb20_buttons_enabled
+                                Layout.alignment: Qt.AlignLeft | Qt.AlignTop
+                                Layout.fillWidth: true
+                                onClicked: { settings.sb20_buttons_enabled = checked; window.settings_restart_to_apply = true; }
+                            }
+
+                            Label {
+                                text: qsTr("Use the SB20's own handlebar buttons: LEFT up/down = target power, RIGHT up/down = Peloton offset, LEFT/RIGHT 3rd = gear down/up. Hold to repeat.")
+                                font.bold: false
+                                font.italic: true
+                                font.pixelSize: window.labelFontSize
+                                textFormat: Text.PlainText
+                                wrapMode: Text.WordWrap
+                                verticalAlignment: Text.AlignVCenter
+                                Layout.fillWidth: true
+                            }
                     IndicatorOnlySwitch {
                         id: speedPowerBasedDelegate
                         text: qsTr("Speed calculates on Power")


### PR DESCRIPTION
Implements #4785. The SB20 exposes its 6 handlebar buttons on a BLE vendor
characteristic; qz already binds the bike to `ftmsbike`, so this is additive on
that driver — no new device class.

Behind `sb20_buttons_enabled` (default on; it can only trigger on a bike that
actually exposes the vendor characteristic).

Default mapping:

  LEFT up / down    -> target power +/-      (homeform keyboardPlus/Minus)
  RIGHT up / down   -> Peloton offset +/-    (homeform keyboardPlus/Minus)
  LEFT / RIGHT 3rd  -> gear down / up

## Correction to the decode proposed in #4785

The issue proposed keying off the `0x03` "commit" frame. On-bike testing showed
that is unreliable: the SB20 emits `0x03` for only a FRACTION of presses —
across a full session, 2 commits against 32 burst terminators (~6%). Keying on
it silently dropped most input. Measured before this change:

  LEFT down : 0 of 2 presses registered
  LEFT up   : 4 of ~12

The frame model, measured rather than inferred: a press streams `0x01` while
held (~10-20/s) and ends with a terminator — `0x04` after a burst that also sent
a commit, `0x08` after one that did not. So this keys off the FIRST `0x01` of a
burst and disarms until a terminator re-arms it: exactly one action per press,
whichever terminator the bike chooses. After the change, on the bike:

  All 6 buttons : exactly one action per press
  LEFT down     : 5 of 5
  LEFT up       : 5 of 5, ERG target laddering 205->230 W in clean 5 W steps

Verified end to end, not just in the log: press -> action -> FTMS Set Target
Power `05 05 00` -> bike ACK `80 05 01 05 00` -> felt resistance change.

## Hold-to-repeat

Holding a button keeps the `0x01` stream alive, so after 450 ms it auto-repeats
every 200 ms; a tap still fires exactly once. This matters because `powerJog` is
a fixed 5 W step, which is below the perceptual threshold at ride power — a
rider adjusting ERG mid-effort needs to hold-to-ramp rather than tap a dozen
times. Both timings are named constants so they are easy to tune.

⚠️ **Hold-to-repeat has NOT been tested on the bike yet.** The dropped-press fix
above was validated on real hardware; the auto-repeat path was written after that
session ended and has only been built. Happy to split it into a follow-up PR if
you would rather land the validated part first.

## Notes

- Tested on Linux desktop against a real Stages SB20 (Qt 5.15, `ftmsbike`).
  I am on iOS, so I have not built for iOS/Android — taking you up on your offer
  in #4785.
- `settings-catalog.json` updated (entry + `settingCount`), and
  `allSettingsCount` bumped 1001 -> 1002.
- On your two questions in #4785: the decode is inline in
  `ftmsbike::characteristicChanged` (it is ~40 lines and only meaningful for this
  device); the mapping is a fixed default for now. Happy to factor it into a
  helper and/or make the mapping configurable if you would prefer that shape —
  that was the plan for a follow-up PR anyway.

