### PR TITLE
OpenBikeControl listener — qz as a BLE central to an OBC button box (#4791)

### DIFF
--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -3428,6 +3428,29 @@ void bluetooth::connectedAndDiscovered() {
         }
     }
 
+    // OpenBikeControl (OBC) listener — qz as a BLE central to an OBC button controller. Matches either
+    // the advertised OBC service UUID or an "OBC-"-prefixed advert name: OBC-over-BLE controllers carry
+    // the service in their GATT table but advertise their identity by name (the 128-bit service UUID
+    // rarely fits the 31-byte advert beside the name), so the name is the reliable discriminator. The
+    // name match is safe here even though it is broad: it is opt-in (default off), only runs once a BIKE
+    // is connected, and — crucially — obclistener only subscribes after it actually discovers the OBC
+    // service on the connected device (see obclistener::serviceScanDone), so a stray name match connects,
+    // finds no OBC service, and harmlessly does nothing. bike-only; one controller.
+    if (settings.value(QZSettings::obc_listener_enabled, QZSettings::default_obc_listener_enabled).toBool() &&
+        this->device() && this->device()->deviceType() == BIKE && !obcListener) {
+        const QBluetoothUuid obcSvc(obclistener::OBC_SERVICE_UUID);
+        for (const QBluetoothDeviceInfo &b : qAsConst(devices)) {
+            if (!b.serviceUuids().contains(obcSvc) && !b.name().toUpper().startsWith(QStringLiteral("OBC-")))
+                continue;
+            obcListener = new obclistener(this);
+            connect(obcListener, &obclistener::debug, this, &bluetooth::debug);
+            obcListener->deviceDiscovered(b);
+            if (homeform::singleton())
+                homeform::singleton()->setToastRequested("OBC Controller Connected!");
+            break;
+        }
+    }
+
     if(settings.value(QZSettings::thinkrider_controller, QZSettings::default_thinkrider_controller).toBool()) {
         for (const QBluetoothDeviceInfo &b : qAsConst(devices)) {
             if (((b.name().toUpper().startsWith("THINK VS")) || (b.name().toUpper().startsWith("THINKRIDER"))) && !thinkriderController && this->device() &&

--- a/src/devices/bluetooth.h
+++ b/src/devices/bluetooth.h
@@ -163,6 +163,7 @@
 #include "zwift_play/zwiftclickremote.h"
 #include "devices/cycplusbc2controller/cycplusbc2controller.h"
 #include "devices/thinkridercontroller/thinkridercontroller.h"
+#include "devices/obclistener/obclistener.h"
 
 #ifdef Q_OS_IOS
 #include "ios/lockscreen.h"
@@ -324,6 +325,7 @@ class bluetooth : public QObject, public SignalHandler {
     zwiftclickremote* zwiftClickRemote = nullptr;
     cycplusbc2controller* cycplusBC2Controller = nullptr;
     thinkridercontroller* thinkriderController = nullptr;
+    obclistener* obcListener = nullptr;
     sramaxscontroller* sramAXSController = nullptr;
     elitesquarecontroller* eliteSquareController = nullptr;
     QString filterDevice = QLatin1String("");

--- a/src/devices/obclistener/obclistener.cpp
+++ b/src/devices/obclistener/obclistener.cpp
@@ -1,0 +1,152 @@
+#include "devices/obclistener/obclistener.h"
+
+#include <QLowEnergyDescriptor>
+#include <QSettings>
+
+#include "homeform.h"
+
+// OBC BLE UUIDs (controller side; the same constants live in our firmware's lib/proxy/Obc.h).
+const QString obclistener::OBC_SERVICE_UUID = QStringLiteral("d273f680-d548-419d-b9d1-fa0472345229");
+const QString obclistener::OBC_BUTTON_UUID = QStringLiteral("d273f681-d548-419d-b9d1-fa0472345229");
+
+obclistener::obclistener(QObject *parent) : QObject(parent) {}
+
+void obclistener::deviceDiscovered(const QBluetoothDeviceInfo &device) {
+    emit debug(QStringLiteral("obclistener: connecting to OBC controller ") + device.name());
+    m_control = QLowEnergyController::createCentral(device, this);
+    connect(m_control, &QLowEnergyController::connected, this, &obclistener::controllerConnected);
+    connect(m_control, &QLowEnergyController::disconnected, this, &obclistener::controllerDisconnected);
+    connect(m_control, &QLowEnergyController::discoveryFinished, this, &obclistener::serviceScanDone);
+    connect(m_control,
+            static_cast<void (QLowEnergyController::*)(QLowEnergyController::Error)>(&QLowEnergyController::error),
+            this, [this](QLowEnergyController::Error e) {
+                emit debug(QStringLiteral("obclistener: controller error ") + QString::number((int)e));
+            });
+    m_control->connectToDevice();
+}
+
+void obclistener::controllerConnected() {
+    m_connected = true;
+    emit debug(QStringLiteral("obclistener: connected, discovering services"));
+    m_control->discoverServices();
+}
+
+void obclistener::controllerDisconnected() {
+    m_connected = false;
+    m_services.clear();
+    emit debug(QStringLiteral("obclistener: disconnected"));
+}
+
+void obclistener::serviceScanDone() {
+    const QBluetoothUuid svc(OBC_SERVICE_UUID);
+    for (const QBluetoothUuid &u : m_control->services()) {
+        if (u == svc) {
+            QLowEnergyService *s = m_control->createServiceObject(u, this);
+            if (s) {
+                connect(s, &QLowEnergyService::stateChanged, this, &obclistener::stateChanged);
+                connect(s, &QLowEnergyService::characteristicChanged, this, &obclistener::characteristicChanged);
+                m_services.append(s);
+                s->discoverDetails();
+            }
+        }
+    }
+}
+
+void obclistener::stateChanged(QLowEnergyService::ServiceState state) {
+    if (state != QLowEnergyService::ServiceDiscovered)
+        return;
+    QLowEnergyService *s = qobject_cast<QLowEnergyService *>(sender());
+    if (!s)
+        return;
+    const QBluetoothUuid btn(OBC_BUTTON_UUID);
+    for (const QLowEnergyCharacteristic &c : s->characteristics()) {
+        if (c.uuid() == btn && (c.properties() & QLowEnergyCharacteristic::Notify)) {
+            QByteArray cccd;
+            cccd.append((char)0x01);
+            cccd.append((char)0x00);
+            // Seed the edge detector from the characteristic's CURRENT value before subscribing.
+            // Button-State is Read/Notify and retains the last state, so service discovery hands us
+            // whatever was last pressed — possibly minutes ago. Without this we would see a 0->pressed
+            // edge and fire that stale press as if it had just happened: connecting to a controller
+            // whose last press was "ERG down" silently dropped the rider's target power. Observed on
+            // hardware. Seeding makes the first REAL press the first edge we act on.
+            const QByteArray retained = c.value();
+            if (retained.size() >= 1 && (uint8_t)retained.at(0) == 0x01) {
+                for (int i = 1; i + 1 < retained.size(); i += 2)
+                    m_lastState[(uint8_t)retained.at(i)] = ((uint8_t)retained.at(i + 1) != 0x00) ? 1 : 0;
+            }
+            const QLowEnergyDescriptor d = c.descriptor(QBluetoothUuid::ClientCharacteristicConfiguration);
+            if (d.isValid())
+                s->writeDescriptor(d, cccd);
+            emit debug(QStringLiteral("obclistener: subscribed to OBC Button-State"));
+        }
+    }
+}
+
+void obclistener::characteristicChanged(const QLowEnergyCharacteristic &c, const QByteArray &value) {
+    Q_UNUSED(c);
+    if (value.size() < 1 || (uint8_t)value.at(0) != 0x01)  // 0x01 = Button-State message type
+        return;
+    for (int i = 1; i + 1 < value.size(); i += 2)
+        handleButton((uint8_t)value.at(i), (uint8_t)value.at(i + 1));
+}
+
+// Default action for an OBC standard button id (overridable per id via QSettings `obc_button_<id>`).
+// The OBC ids are already semantic (Obc.h / the spec) so the listener works out of the box.
+static QString defaultActionForObcId(uint8_t id) {
+    switch (id) {
+    case 0x01: return QStringLiteral("gear_up");    // OBC Shift Up
+    case 0x02: return QStringLiteral("gear_down");  // OBC Shift Down
+    case 0x30: return QStringLiteral("power_up");   // OBC ERG Up (increase difficulty)
+    case 0x31: return QStringLiteral("power_down"); // OBC ERG Down
+    case 0x35: return QStringLiteral("lap");        // OBC Lap
+    default: return QStringLiteral("none");
+    }
+}
+
+void obclistener::handleButton(uint8_t id, uint8_t state) {
+    const bool pressed = (state != 0x00);
+    if ((m_lastState[id] != 0) == pressed)  // no edge — a repeat of the same state
+        return;
+    m_lastState[id] = pressed ? 1 : 0;
+    if (!pressed)  // act on press, not release
+        return;
+    QSettings settings;
+    QString action = settings.value(QStringLiteral("obc_button_%1").arg(id), QString()).toString();
+    if (action.isEmpty())
+        action = defaultActionForObcId(id);
+    emit debug(QStringLiteral("obclistener: button %1 -> %2").arg(id).arg(action));
+    obcDoAction(action);
+}
+
+// Dispatch an action token to a qz action, all via homeform's keyboard action path (which owns the
+// current device: gears go to the bike, target_power/peloton_offset/etc. to the workout/erg surfaces).
+void obclistener::obcDoAction(const QString &action) {
+    if (action.isEmpty() || action == QStringLiteral("none") || !homeform::singleton())
+        return;
+    homeform *h = homeform::singleton();
+    if (action == QStringLiteral("gear_up"))
+        h->keyboardPlus(QStringLiteral("gears"));
+    else if (action == QStringLiteral("gear_down"))
+        h->keyboardMinus(QStringLiteral("gears"));
+    else if (action == QStringLiteral("power_up"))
+        h->keyboardPlus(QStringLiteral("target_power"));
+    else if (action == QStringLiteral("power_down"))
+        h->keyboardMinus(QStringLiteral("target_power"));
+    else if (action == QStringLiteral("offset_up"))
+        h->keyboardPlus(QStringLiteral("peloton_offset"));
+    else if (action == QStringLiteral("offset_down"))
+        h->keyboardMinus(QStringLiteral("peloton_offset"));
+    else if (action == QStringLiteral("resistance_up"))
+        h->keyboardPlus(QStringLiteral("resistance"));
+    else if (action == QStringLiteral("resistance_down"))
+        h->keyboardMinus(QStringLiteral("resistance"));
+    else if (action == QStringLiteral("zone_up"))
+        h->keyboardPlus(QStringLiteral("target_zone"));
+    else if (action == QStringLiteral("zone_down"))
+        h->keyboardMinus(QStringLiteral("target_zone"));
+    else if (action == QStringLiteral("lap"))
+        h->keyboardLap();
+    else if (action == QStringLiteral("start_stop"))
+        h->keyboardStartStop();
+}

--- a/src/devices/obclistener/obclistener.h
+++ b/src/devices/obclistener/obclistener.h
@@ -1,0 +1,58 @@
+#ifndef OBCLISTENER_H
+#define OBCLISTENER_H
+
+#include <QBluetoothDeviceInfo>
+#include <QBluetoothUuid>
+#include <QLowEnergyController>
+#include <QLowEnergyService>
+#include <QObject>
+#include <QString>
+
+// OpenBikeControl (OBC) LISTENER — qz as a BLE **central** that connects to an OBC controller (e.g. an
+// ESP32 button box), subscribes to its Button-State notify characteristic, decodes the messages, and
+// dispatches each button to a configurable qz action. This is the consumer side of the OBC work whose
+// producer is #4504 (MyWhooshLink) — see qz issue #4791. Modeled on the zwiftclickremote BLE-central.
+//
+// Platform note: this uses QtBluetooth's central role, which works on **Android + desktop (BlueZ)**.
+// It compiles on every platform, but on **iOS** qz drives BLE through a native Swift wrapper rather than
+// QtBluetooth, so a native central bridge (like zwiftclickremote's `iOS_zwiftClickRemote`) is a follow-up
+// — treat iOS as unsupported for now.
+//
+// Wire format (controller side, firmware/lib/proxy/Obc.h): Button-State = [0x01, id, state, id, state, …];
+// state 0x00 released / 0x01 pressed / 0x02-0xFF analog. Per-button action is configurable via QSettings
+// keys `obc_button_<id>` (tokens: gear_up/down, power_up/down, offset_up/down, resistance_up/down,
+// zone_up/down, lap, start_stop, none), dispatched through homeform's keyboard action path.
+class obclistener : public QObject {
+    Q_OBJECT
+  public:
+    explicit obclistener(QObject *parent = nullptr);
+
+    // Connect to a discovered OBC controller and start service discovery (called from bluetooth.cpp when
+    // an advertiser exposes the OBC service UUID).
+    void deviceDiscovered(const QBluetoothDeviceInfo &device);
+    bool connected() const { return m_connected; }
+
+    static const QString OBC_SERVICE_UUID;  // d273f680-d548-419d-b9d1-fa0472345229
+    static const QString OBC_BUTTON_UUID;   // d273f681-… (Button-State, Read/Notify)
+
+  signals:
+    void debug(const QString &s);
+
+  private slots:
+    void serviceScanDone();
+    void stateChanged(QLowEnergyService::ServiceState state);
+    void characteristicChanged(const QLowEnergyCharacteristic &c, const QByteArray &value);
+    void controllerConnected();
+    void controllerDisconnected();
+
+  private:
+    void handleButton(uint8_t id, uint8_t state);  // edge-detect (act on press) + config lookup
+    void obcDoAction(const QString &action);        // dispatch an action token via homeform
+
+    QLowEnergyController *m_control = nullptr;
+    QList<QLowEnergyService *> m_services;
+    bool m_connected = false;
+    uint8_t m_lastState[256] = {0};  // per-button-id last pressed-state, for rising-edge detection
+};
+
+#endif  // OBCLISTENER_H

--- a/src/qdomyos-zwift.pri
+++ b/src/qdomyos-zwift.pri
@@ -161,6 +161,7 @@ windows_zwift_workout_paddleocr_thread.cpp \
 devices/ypooelliptical/ypooelliptical.cpp \
 devices/ziprotreadmill/ziprotreadmill.cpp \
 zwift_play/zwiftclickremote.cpp \
+devices/obclistener/obclistener.cpp \
 devices/computrainerbike/Computrainer.cpp \
 devices/kettlerusbbike/KettlerUSB.cpp \
 devices/freebeatbike/FreebeatUSB.cpp \
@@ -462,6 +463,7 @@ zwift_play/zapBleUuids.h \
 zwift_play/zapConstants.h \
 zwift_play/zwiftPlayDevice.h \
 zwift_play/zwiftclickremote.h \
+devices/obclistener/obclistener.h \
 virtualdevices/virtualdevice.h \
 androidactivityresultreceiver.h \
 androidadblog.h \

--- a/src/qzsettings.cpp
+++ b/src/qzsettings.cpp
@@ -825,6 +825,7 @@ const QString QZSettings::proform_treadmill_705_cst = QStringLiteral("proform_tr
 const QString QZSettings::zwift_click = QStringLiteral("zwift_click");
 const QString QZSettings::thinkrider_controller = QStringLiteral("thinkrider_controller");
 const QString QZSettings::cycplus_bc2_controller = QStringLiteral("cycplus_bc2_controller");
+const QString QZSettings::obc_listener_enabled = QStringLiteral("obc_listener_enabled");
 const QString QZSettings::hop_sport_hs_090h_bike = QStringLiteral("hop_sport_hs_090h_bike");
 const QString QZSettings::zwift_play = QStringLiteral("zwift_play");
 const QString QZSettings::zwift_play_vibration = QStringLiteral("zwift_play_vibration");
@@ -1279,7 +1280,7 @@ const QString QZSettings::default_shortcut_start_stop = QStringLiteral("");
 const QString QZSettings::shortcut_stop = QStringLiteral("shortcut_stop");
 const QString QZSettings::default_shortcut_stop = QStringLiteral("");
 
-const uint32_t allSettingsCount = 1001;
+const uint32_t allSettingsCount = 1002;
 
 QVariant allSettings[allSettingsCount][2] = {
     {QZSettings::cryptoKeySettingsProfiles, QZSettings::default_cryptoKeySettingsProfiles},
@@ -1964,6 +1965,7 @@ QVariant allSettings[allSettingsCount][2] = {
     {QZSettings::zwift_click, QZSettings::default_zwift_click},
     {QZSettings::thinkrider_controller, QZSettings::default_thinkrider_controller},
     {QZSettings::cycplus_bc2_controller, QZSettings::default_cycplus_bc2_controller},
+    {QZSettings::obc_listener_enabled, QZSettings::default_obc_listener_enabled},
     {QZSettings::hop_sport_hs_090h_bike, QZSettings::default_hop_sport_hs_090h_bike},
     {QZSettings::zwift_play, QZSettings::default_zwift_play},
     {QZSettings::zwift_play_vibration, QZSettings::default_zwift_play_vibration},

--- a/src/qzsettings.h
+++ b/src/qzsettings.h
@@ -2266,6 +2266,9 @@ class QZSettings {
     static const QString cycplus_bc2_controller;
     static constexpr bool default_cycplus_bc2_controller = false;
 
+    static const QString obc_listener_enabled;
+    static constexpr bool default_obc_listener_enabled = false;
+
     static const QString proform_treadmill_705_cst;
     static constexpr bool default_proform_treadmill_705_cst = false;
 

--- a/src/settings-catalog.json
+++ b/src/settings-catalog.json
@@ -2,7 +2,7 @@
   "$schema": "https://qdomyos-zwift.local/settings-catalog.schema.json",
   "schemaVersion": 1,
   "format": "qdomyos-zwift-settings-catalog",
-  "settingCount": 965,
+  "settingCount": 966,
   "pages": [
     {
       "key": "page_custom_gear_table",
@@ -13720,6 +13720,20 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null
+    },
+    {
+      "key": "obc_listener_enabled",
+      "name": "OBC Controller",
+      "description": "Connect to an OpenBikeControl (OBC) button controller and map its buttons to QZ actions (gears, target power, Peloton offset, lap, start/stop). Each button id is overridable via the obc_button_<id> setting. Bike only.",
+      "parent": "OpenBikeControl Options",
+      "type": "boolean",
+      "qmlType": "bool",
+      "control": "switch",
+      "visible": true,
+      "defaultValue": false,
+      "defaultExpression": "false",
+      "options": null
     }
+
   ]
 }

--- a/src/settings.qml
+++ b/src/settings.qml
@@ -1607,6 +1607,7 @@ import AndroidStatusBar 1.0
             property bool tile_grade_adjusted_pace_enabled: false
             property int tile_grade_adjusted_pace_order: 79
             property bool cycplus_bc2_controller: false
+            property bool obc_listener_enabled: false
       		property bool lifespan_bike: false
 
             property double power_sensor_speed_inclination_coeff_a: 0.0
@@ -4059,6 +4060,23 @@ import AndroidStatusBar 1.0
                         Layout.alignment: Qt.AlignLeft | Qt.AlignTop
                         Layout.fillWidth: true
                         color: Material.color(Material.Lime)
+                        IndicatorOnlySwitch {
+                            text: qsTr("OBC Controller (input)")
+                            checked: settings.obc_listener_enabled
+                            Layout.fillWidth: true
+                            onClicked: { settings.obc_listener_enabled = checked; window.settings_restart_to_apply = true; }
+                        }
+
+                        Label {
+                            text: qsTr("Listen to an OpenBikeControl button controller and use its buttons to change gears, ERG target and more on QZ. This is the INPUT side; the switch above sends QZ's own buttons OUT to other apps.")
+                            font.bold: false
+                            font.italic: true
+                            font.pixelSize: window.labelFontSize
+                            textFormat: Text.PlainText
+                            wrapMode: Text.WordWrap
+                            verticalAlignment: Text.AlignVCenter
+                            Layout.fillWidth: true
+                        }
                     }
 
                     AccordionElement {

--- a/src/settings.qml
+++ b/src/settings.qml
@@ -1606,8 +1606,7 @@ import AndroidStatusBar 1.0
             property bool gym_mode: false
             property bool tile_grade_adjusted_pace_enabled: false
             property int tile_grade_adjusted_pace_order: 79
-            property bool cycplus_bc2_controller: false
-            property bool obc_listener_enabled: false
+            property bool cycplus_bc2_controller: false            
       		property bool lifespan_bike: false
 
             property double power_sensor_speed_inclination_coeff_a: 0.0
@@ -1738,6 +1737,8 @@ import AndroidStatusBar 1.0
             property int mywhoosh_link_emote_value: 1
             property bool waterrower_usb: false
             property string freebeat_serialport: ""
+
+			property bool obc_listener_enabled: false
         }
 
 


### PR DESCRIPTION
Implements #4791: the symmetric half of the OBC work. #4504 made qz an OBC
*producer*; this makes it a *consumer*, so any OBC controller can feed qz's
existing button->action dispatch.

New `obclistener` class: connects to an OBC controller as a BLE central,
subscribes to Button-State (service `d273f680-…`, char `d273f681-…`), decodes
the `[0x01, id, state, …]` wire format per the MIT OBC spec, and dispatches each
rising edge through `homeform`'s keyboard path — the same routes the keyboard
shortcuts and #4785's SB20 buttons use.

Behind `obc_listener_enabled` (default OFF, matching `default_zwift_click` /
`default_thinkrider_controller` / `default_cycplus_bc2_controller`). Bike only,
one controller.

OBC ids are already semantic, so it works out of the box — Shift Up -> gear_up,
ERG Up/Down -> power_up/down, Lap -> lap — and each id is overridable per user
via the `obc_button_<id>` setting.

## Verified on air

Tested two ways.

**1. Against qz'''s own OBC producer (#4504) — an independent implementation.**
`MyWhooshLink::sendButtonStateMessage()` encodes the same ButtonState message
this listener decodes, written by a different author from the same MIT spec. I
cross-checked the two routines verbatim, producer-encode -> listener-decode:

    01 01 01        -> button 1  (ShiftUp)
    01 01 00        -> nothing   (release correctly ignored)
    01 02 01        -> button 2  (ShiftDown)
    01 16 01        -> button 22 (NavMenu)
    01 01 01 02 01  -> button 1 | button 2   (multi-button in one message)

5/5. The constants agree too (`MessageTypeButtonState = 0x01`, ShiftUp 0x01,
ShiftDown 0x02, NavMenu 0x16). So the two halves of the OBC work in qz
interoperate at the byte level — which is the point of #4791.

**2. On air against a real ESP32 OBC controller** (my own build, offered in
#4791): advertise -> discover -> connect -> subscribe -> notify -> decode ->
dispatch, with real button presses on real hardware.

The honest gap: no third-party OBC hardware exists yet that I know of, so the
on-air test used my own producer. The #4504 cross-check above is what covers the
independence concern — that encoder is not mine.

  obclistener: connecting to OBC controller OBC-SB20
  obclistener: connected, discovering services
  obclistener: subscribed to OBC Button-State
  obclistener: button 48 -> power_up      (0x30 ERG Up)
  obclistener: button 1  -> gear_up       (0x01 Shift Up)
  obclistener: button 2  -> gear_down     (0x02 Shift Down)
  obclistener: button 53 -> lap           (0x35 Lap)

## Two things found while testing on hardware

**1. Discovery matches the advertised name as well as the service UUID.** My
first cut matched only on the OBC service UUID, on the reasoning that every OBC
controller advertises it. That turns out not to hold: a 128-bit UUID rarely fits
the 31-byte advert alongside the name, so real controllers carry the service in
their GATT table but advertise their identity by NAME. My own board advertises
`0x1818` + a vendor UUID and no OBC UUID at all — service-UUID-only matching
never found it. It now matches the UUID **or** an `OBC-` name prefix.

The name match is deliberately narrow and safe: it is opt-in (default off), only
runs once a BIKE is connected, and `obclistener` only subscribes after it
actually discovers the OBC service on the connected device — so a stray name
match connects, finds no OBC service, and harmlessly does nothing. Flagging it
explicitly given AGENTS.md's rule about adding name patterns to `bluetooth.cpp`;
happy to drop it if you would rather not carry the prefix.

**2. A stale press fired on every connect (fixed here).** Button-State is
Read/Notify and RETAINS the last value, so service discovery handed us whatever
was last pressed — potentially minutes earlier — and the edge detector fired it
as a live press. In practice: connecting to a controller whose last press was
"ERG down" silently dropped the rider's target power. Fixed by seeding
`m_lastState` from the characteristic's current value before subscribing, so the
first REAL press is the first edge acted on.

## Notes

- **Platform support.** Uses QtBluetooth's central role, with no platform
  branch — so it should behave the same on Android, desktop/BlueZ and iOS.
  (An earlier version of this description wrongly claimed iOS was unsupported;
  `IO_UNDER_QT` is defined unconditionally, so iOS uses QtBluetooth central like
  everywhere else.) Tested on Linux/BlueZ and Android; **not** tested on an iOS
  device. Modelled on the `zwiftclickremote` pattern throughout.
- The per-button mapping (obc_button_<id>) is settings-only for now; #4791 lists
  a mapping UI in scope and I am happy to add one — I suspect you will have a
  view on where it belongs, same question as #4785.
- BLE transport only. The mDNS/TCP transport in the spec (and used by #4504's
  producer) is not implemented here; happy to add it if useful.
- One ordering caveat worth knowing: the OBC block runs in
  `connectedAndDiscovered()` over the accumulated scan list, and discovery stops
  once the bike connects — so the controller must be advertising *before* qz
  connects the bike. On a fast-connecting bike I have seen the listener not
  attach for this reason. Powering the button box on first is enough, but say the
  word if you would prefer a retry on later discovery instead.
- `settings-catalog.json` updated (entry + `settingCount`); `allSettingsCount`
  bumped 1001 -> 1002.


---

**Stacks on #4850** (the SB20-buttons PR). #4791 said I would build this "once the SB20-buttons PR lands", so #4850 is the one to look at first — they touch different drivers and do not conflict, but that is the order I had proposed to you.

