### PR TITLE
docs: add a Stages SB20 section to 22_devices_detail.md

### DIFF
--- a/docs/22_devices_detail.md
+++ b/docs/22_devices_detail.md
@@ -11,3 +11,40 @@ The [cardio belt provided](https://www.sports-tech.uk.com/chest-strap-sportstech
 The cardio captors are reported to not be accurate.
 #### Resistance 
 The resistance is adjusted after a few seconds delay (time for the engine to adapt magnetic resistance).
+
+## Stages
+
+### SB20
+
+The SB20 advertises as `Stages Bike <NNNN>` and is handled by the **`ftmsbike`** driver — no
+dedicated device class. It has **no display of its own**, so initial pairing/setup is done in the
+Stages Cycling app.
+
+#### Power and cadence
+Both come from the standard FTMS **Indoor Bike Data** characteristic (`0x2AD2`). The bike sets
+flags `0x00c5` — instantaneous cadence, instantaneous power and average power.
+
+#### Auto resistance (ERG)
+Fully supported over standard FTMS, and reliable in regular use — including QZ-managed **Peloton
+Power Zone** workouts, where QZ drives the target watts for the whole session.
+
+QZ takes control and sets a target, and the bike honours it:
+
+```
+0x2AD9 <- 00        Request Control     -> 80 00 01        (success)
+0x2AD9 <- 07        Start/Resume        -> 80 07 01        (success)
+0x2AD9 <- 05 XX XX  Set Target Power    -> 80 05 01 XX XX  (success)
+```
+
+#### Rare issue: telemetry drops to zero
+Uncommon — power and cadence are reliable in normal use. Documented because the symptom looks like
+a QZ bug when it is not.
+
+The bike can occasionally end up publishing a **stripped** Indoor Bike Data frame — flags `0x0011`, distance
+only, no power or cadence — while the Cycling Speed and Cadence characteristic stops updating.
+QZ then correctly shows 0 W and 0 rpm, because that is genuinely all the bike is sending.
+
+A power-cycle of the bike restores the full `0x00c5` frame. The trigger is not confirmed; a
+plausible cause is another consumer holding an FTMS **control** connection (for example a head unit
+or watch paired to the bike *as a trainer* rather than as sensors). If QZ shows no power while you
+are clearly pedalling, power-cycle the bike and check what else is connected to it.


### PR DESCRIPTION
The SB20 is a common bike with no entry in the device docs. Everything here is
from measurement on a real SB20 or from regular day-to-day use.

- Driver: advertises `Stages Bike <NNNN>`, handled by `ftmsbike`. No display of
  its own, so setup happens in the Stages app.
- Power/cadence: standard FTMS Indoor Bike Data (0x2AD2), flags `0x00c5`. Worth
  noting bit 0 of those flags means instantaneous speed is NOT present, so the
  speed QZ shows is derived rather than reported by the bike.
- Auto resistance: fully supported over FTMS and reliable in regular use,
  including QZ-managed Peloton Power Zone workouts. Documented with the actual
  control-point exchange and its success responses.
- Rare issue: the bike can end up publishing a stripped Indoor Bike Data frame
  (flags `0x0011`, distance only) with CSC stopped, so QZ correctly shows 0 W /
  0 rpm because that is genuinely all the bike is sending. A power-cycle
  restores it. Included because the symptom reads as a QZ bug when it is not.
  The trigger is NOT confirmed — a plausible cause is another consumer holding
  an FTMS *control* connection (a head unit or watch paired as a trainer rather
  than as sensors) — so it is written as a possibility, not a diagnosis.

Also relevant to the Equipment Compatibility wiki page, whose Stages row
currently reads `Stages | ? | Yes | Yes | Yes | Yes | ? | No`. Two corrections
worth making there: the model is the **SB20**, and **Auto Resistance is Yes**,
not No — ERG works and is relied on daily. HRM is still genuinely unknown to me,
so I would leave that as `?` rather than guess.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

