### PR TITLE
Fix MOK Fitness S10 Ultra resistance control (use 0xFFF2 instead of FTMS control point)

### DIFF
--- a/src/devices/ftmsbike/ftmsbike.cpp
+++ b/src/devices/ftmsbike/ftmsbike.cpp
@@ -304,6 +304,31 @@ void ftmsbike::forceResistance(resistance_t requestResistance) {
     }
     enableManualResistancePowerAdjustment(requestResistance);
 
+    if (MOK_FITNESS) {
+        // The MOK Fitness S10 Ultra NAKs the FTMS control point (0x2AD9) for resistance changes.
+        // Its own app changes resistance with a single write to 0xFFF2: AF 05 04 <level> AA.
+        if (requestResistance < 0) {
+            qDebug() << "Negative resistance detected:" << requestResistance << "using fallback value 1";
+            requestResistance = 1;
+        }
+        if (max_resistance > 0 && requestResistance > max_resistance) {
+            qDebug() << "Resistance" << requestResistance << "exceeds max_resistance" << max_resistance << "- clamping";
+            requestResistance = max_resistance;
+        }
+
+        Resistance = requestResistance;
+
+        if (gattMokFitnessService && gattWriteCharMokFitnessId.isValid()) {
+            uint8_t write[] = {0xAF, 0x05, 0x04, (uint8_t)requestResistance, 0xAA};
+            enqueueWrite(gattMokFitnessService, gattWriteCharMokFitnessId, write, sizeof(write),
+                        QStringLiteral("forceResistance MOK ") + QString::number(requestResistance), false, false,
+                        gattWriteCharMokFitnessId.properties() & QLowEnergyCharacteristic::WriteNoResponse);
+        } else {
+            qDebug() << QStringLiteral("MOK Fitness resistance characteristic (0xFFF2) not found");
+        }
+        return;
+    }
+
     QSettings settings;
     bool ergModeNotSupported = (requestPower > 0 && !ergModeSupported);
     if (!settings.value(QZSettings::ss2k_peloton, QZSettings::default_ss2k_peloton).toBool() &&
@@ -1719,6 +1744,16 @@ void ftmsbike::stateChanged(QLowEnergyService::ServiceState state) {
                     qDebug() << QStringLiteral("Zwift Play service and Control Point found");
                     zwiftPlayWriteChar = c;
                     zwiftPlayService = s;
+                }
+
+                QBluetoothUuid _mokFitnessWriteCharId((quint16)0xFFF2);
+                if (MOK_FITNESS &&
+                    (c.properties() & QLowEnergyCharacteristic::Write ||
+                     c.properties() & QLowEnergyCharacteristic::WriteNoResponse) &&
+                    c.uuid() == _mokFitnessWriteCharId) {
+                    qDebug() << QStringLiteral("MOK Fitness resistance control characteristic found");
+                    gattWriteCharMokFitnessId = c;
+                    gattMokFitnessService = s;
                 }
             }
         }

--- a/src/devices/ftmsbike/ftmsbike.h
+++ b/src/devices/ftmsbike/ftmsbike.h
@@ -131,6 +131,11 @@ class ftmsbike : public bike {
     QLowEnergyCharacteristic zwiftPlayWriteChar;
     QLowEnergyService *zwiftPlayService = nullptr;
 
+    // MOK Fitness bikes don't use the FTMS control point (0x2AD9) to change resistance,
+    // they need a raw command written to a proprietary characteristic (0xFFF2) instead.
+    QLowEnergyCharacteristic gattWriteCharMokFitnessId;
+    QLowEnergyService *gattMokFitnessService = nullptr;
+
     uint8_t sec1Update = 0;
     QByteArray lastPacket;
     QByteArray lastPacketFromFTMS;


### PR DESCRIPTION
## Summary
- Fixes #4844: auto-resistance still didn't work on the MOK Fitness S10 Ultra after the earlier power-table fix (#4845), because the bike NAKs `FTMS_SET_TARGET_RESISTANCE_LEVEL` sent over the standard FTMS control point (`0x2AD9`).
- Per the reporter's investigation (BLE packet capture of the official MOK Fitness app + confirmation via NRF Connect, see [comment](https://github.com/cagnulein/qdomyos-zwift/issues/4844#issuecomment-5082063080)), the bike expects resistance changes as a single raw write to a proprietary characteristic (`0xFFF2`) with the format `AF 05 04 <level> AA`, no handshake required.
- `ftmsbike::forceResistance()` now detects `MOK_FITNESS` and writes that raw command directly to `0xFFF2` instead of going through the FTMS control point; the characteristic/service are discovered and cached during `stateChanged()` alongside the existing FTMS/Zwift Play discovery.

## Test plan
- [x] Reporter to confirm auto-resistance now follows target resistance (e.g. incline changes in MyWhoosh) on the MOK Fitness S10 Ultra
- No local build environment available in this session (Qt not installed); changes reviewed by hand against the existing `forceResistance`/service-discovery patterns used for similar non-FTMS-control-point bikes (e.g. `SL010`, `SPORT01`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01KE6aPX5BNWZd4DQsqdAUwX)_