### PR TITLE
Switch Stryd 5 to Indoor power mode on connect

### DIFF
--- a/src/devices/strydrunpowersensor/strydrunpowersensor.cpp
+++ b/src/devices/strydrunpowersensor/strydrunpowersensor.cpp
@@ -110,7 +110,24 @@ void strydrunpowersensor::update() {
             sec1Update = 0;
             // updateDisplay(elapsed);
         }
+
+        if (strydIndoorModeRequested && !strydIndoorModeConfirmed && strydIndoorModeRetries < 3 &&
+            strydIndoorModeRequestedAt.msecsTo(QDateTime::currentDateTime()) > 1000) {
+            qDebug() << QStringLiteral("Stryd5: no ack for Indoor mode switch, retrying");
+            requestStrydIndoorMode();
+        }
     }
+}
+
+void strydrunpowersensor::requestStrydIndoorMode() {
+    if (!strydIndoorModeService || !strydIndoorModeChar.isValid())
+        return;
+
+    qDebug() << QStringLiteral("Stryd5: switching power mode to Indoor");
+    strydIndoorModeService->writeCharacteristic(strydIndoorModeChar, QByteArray::fromHex("1500"));
+    strydIndoorModeRequested = true;
+    strydIndoorModeRequestedAt = QDateTime::currentDateTime();
+    strydIndoorModeRetries++;
 }
 
 void strydrunpowersensor::serviceDiscovered(const QBluetoothUuid &gatt) {
@@ -506,6 +523,18 @@ void strydrunpowersensor::characteristicChanged(const QLowEnergyCharacteristic &
             //emit verticalOscillationChanged(VerticalOscillationMM.value());
             qDebug() << QStringLiteral("Current GroundContactMS:") << GroundContactMS.value();
             qDebug() << QStringLiteral("Current VerticalOscillationMM:") << VerticalOscillationMM.value();
+        } else if (strydIndoorModeRequested && newValue.length() >= 3 && (uint8_t)newValue.at(0) == 0x15 &&
+                   (uint8_t)newValue.at(1) == 0x00) {
+            // ack of the 15 00/15 01 mode switch written to 7e78aa18: byte 2 echoes back the confirmed
+            // mode (0x00 = Indoor, 0x01 = Outdoor)
+            uint8_t confirmedMode = (uint8_t)newValue.at(2);
+            if (confirmedMode == 0x00) {
+                strydIndoorModeConfirmed = true;
+                qDebug() << QStringLiteral("Stryd5: Indoor mode confirmed by the pod");
+            } else {
+                qDebug() << QStringLiteral("Stryd5: pod acked mode ") << confirmedMode
+                          << QStringLiteral(" instead of Indoor, will retry");
+            }
         }
     }
 
@@ -593,8 +622,9 @@ void strydrunpowersensor::stateChanged(QLowEnergyService::ServiceState state) {
                 if (bluetoothDevice.name().startsWith(QStringLiteral("Stryd5"), Qt::CaseInsensitive) &&
                     c.uuid() == QBluetoothUuid(QStringLiteral("7e78aa18-72cd-d3b8-a81f-5b7e589bea0f")) &&
                     (c.properties() & QLowEnergyCharacteristic::Write)) {
-                    qDebug() << QStringLiteral("Stryd5: switching power mode to Indoor");
-                    s->writeCharacteristic(c, QByteArray::fromHex("1500"));
+                    strydIndoorModeService = s;
+                    strydIndoorModeChar = c;
+                    requestStrydIndoorMode();
                 }
 
                 qDebug() << QStringLiteral("char uuid") << c.uuid() << QStringLiteral("handle") << c.handle();

--- a/src/devices/strydrunpowersensor/strydrunpowersensor.cpp
+++ b/src/devices/strydrunpowersensor/strydrunpowersensor.cpp
@@ -585,6 +585,18 @@ void strydrunpowersensor::stateChanged(QLowEnergyService::ServiceState state) {
                 if (c.uuid() == QBluetoothUuid::CSCMeasurement) {
                     cadenceChar = c;
                 }
+
+                // Stryd 5 broadcasts a power value that already reacts to the incline it detects on its own
+                // (confirmed via BLE sniffing, see #4480), which conflicts with QZ's own inclination gain
+                // formula. Switching the pod to Indoor mode makes it stop compensating for incline on its
+                // own, leaving QZ's formula as the only source of the incline adjustment.
+                if (bluetoothDevice.name().startsWith(QStringLiteral("Stryd5"), Qt::CaseInsensitive) &&
+                    c.uuid() == QBluetoothUuid(QStringLiteral("7e78aa18-72cd-d3b8-a81f-5b7e589bea0f")) &&
+                    (c.properties() & QLowEnergyCharacteristic::Write)) {
+                    qDebug() << QStringLiteral("Stryd5: switching power mode to Indoor");
+                    s->writeCharacteristic(c, QByteArray::fromHex("1500"));
+                }
+
                 qDebug() << QStringLiteral("char uuid") << c.uuid() << QStringLiteral("handle") << c.handle();
                 auto descriptors_list = c.descriptors();
                 for (const QLowEnergyDescriptor &d : qAsConst(descriptors_list)) {

--- a/src/devices/strydrunpowersensor/strydrunpowersensor.cpp
+++ b/src/devices/strydrunpowersensor/strydrunpowersensor.cpp
@@ -525,7 +525,7 @@ void strydrunpowersensor::characteristicChanged(const QLowEnergyCharacteristic &
             qDebug() << QStringLiteral("Current VerticalOscillationMM:") << VerticalOscillationMM.value();
         } else if (strydIndoorModeRequested && newValue.length() >= 3 && (uint8_t)newValue.at(0) == 0x15 &&
                    (uint8_t)newValue.at(1) == 0x00) {
-            // ack of the 15 00/15 01 mode switch written to 7e78aa18: byte 2 echoes back the confirmed
+            // ack of the 15 00/15 01 mode switch written to 7e78aa20: byte 2 echoes back the confirmed
             // mode (0x00 = Indoor, 0x01 = Outdoor)
             uint8_t confirmedMode = (uint8_t)newValue.at(2);
             if (confirmedMode == 0x00) {
@@ -620,7 +620,7 @@ void strydrunpowersensor::stateChanged(QLowEnergyService::ServiceState state) {
                 // formula. Switching the pod to Indoor mode makes it stop compensating for incline on its
                 // own, leaving QZ's formula as the only source of the incline adjustment.
                 if (bluetoothDevice.name().startsWith(QStringLiteral("Stryd5"), Qt::CaseInsensitive) &&
-                    c.uuid() == QBluetoothUuid(QStringLiteral("7e78aa18-72cd-d3b8-a81f-5b7e589bea0f")) &&
+                    c.uuid() == QBluetoothUuid(QStringLiteral("7e78aa20-72cd-d3b8-a81f-5b7e589bea0f")) &&
                     (c.properties() & QLowEnergyCharacteristic::Write)) {
                     strydIndoorModeService = s;
                     strydIndoorModeChar = c;

--- a/src/devices/strydrunpowersensor/strydrunpowersensor.h
+++ b/src/devices/strydrunpowersensor/strydrunpowersensor.h
@@ -78,6 +78,14 @@ class strydrunpowersensor : public treadmill {
 
     bool FORERUNNER = false;
 
+    QLowEnergyService *strydIndoorModeService = nullptr;
+    QLowEnergyCharacteristic strydIndoorModeChar;
+    bool strydIndoorModeRequested = false;
+    bool strydIndoorModeConfirmed = false;
+    uint8_t strydIndoorModeRetries = 0;
+    QDateTime strydIndoorModeRequestedAt;
+    void requestStrydIndoorMode();
+
 #ifdef Q_OS_IOS
     lockscreen *h = 0;
 #endif


### PR DESCRIPTION
## Summary
Stryd 5 pods broadcast a power value that already compensates for the treadmill incline on their own, even when no incline is entered in the Stryd app — see the investigation in #4480. This conflicts with QZ's own inclination gain formula and makes the reported power unreliable.

`@AndreaPro` sniffed the Stryd's BLE traffic and found the proprietary Indoor/Outdoor mode switch (characteristic `7e78aa18-72cd-d3b8-a81f-5b7e589bea0f`, `15 00` = Indoor, `15 01` = Outdoor). In Indoor mode the pod stops adjusting power for incline on its own, leaving QZ's own formula as the only source of the correction. The pod resets to Outdoor mode automatically on disconnect, so no extra handling is needed there.

This PR writes `15 00` to that characteristic on connect, gated to devices whose Bluetooth name starts with `Stryd5`.

Refs #4480

## Test plan
- [ ] @AndreaPro to confirm on his Stryd 5 + treadmill setup that power no longer reacts to incline changes unless QZ's inclination gain formula is enabled