### PR TITLE
Fix Android IP detection and multicast for OpenBikeControl (MyWhoosh Link)

### DIFF
--- a/src/android/AndroidManifest.xml
+++ b/src/android/AndroidManifest.xml
@@ -165,6 +165,7 @@
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT"/>
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
+    <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE"/>
 	 <uses-permission android:name="com.android.vending.BILLING"/>
 	 <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
 	 <uses-permission android:name="com.google.android.things.permission.USE_PERIPHERAL_IO" />

--- a/src/android/AndroidManifest.xml
+++ b/src/android/AndroidManifest.xml
@@ -165,6 +165,7 @@
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT"/>
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE"/>
 	 <uses-permission android:name="com.android.vending.BILLING"/>
 	 <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />

--- a/src/android/src/ForegroundService.java
+++ b/src/android/src/ForegroundService.java
@@ -6,6 +6,7 @@ import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.app.Service;
 import android.content.Intent;
+import android.net.wifi.WifiManager;
 import android.os.Build;
 import android.os.IBinder;
 import androidx.core.app.NotificationCompat;
@@ -16,13 +17,50 @@ public class ForegroundService extends Service {
 	 public static final String CHANNEL_ID = "ForegroundServiceChannel";
          private static final String EXTRA_FOREGROUND_SERVICE_TYPE = "FOREGROUND_SERVICE_TYPE";
          private static final int FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE = 0x10;
+         private WifiManager.MulticastLock multicastLock;
+
+         private void acquireMulticastLock() {
+             if (multicastLock != null && multicastLock.isHeld()) {
+                 return;
+             }
+
+             try {
+                 WifiManager wifiManager = (WifiManager) getApplicationContext().getSystemService(WIFI_SERVICE);
+                 if (wifiManager == null) {
+                     QLog.d("ForegroundService", "WifiManager unavailable; cannot acquire multicast lock");
+                     return;
+                 }
+
+                 multicastLock = wifiManager.createMulticastLock("QZ:ForegroundService");
+                 multicastLock.setReferenceCounted(false);
+                 multicastLock.acquire();
+                 QLog.d("ForegroundService", "Acquired multicast lock");
+             } catch (Exception e) {
+                 QLog.e("ForegroundService", "Failed to acquire multicast lock", e);
+             }
+         }
+
+         private void releaseMulticastLock() {
+             try {
+                 if (multicastLock != null && multicastLock.isHeld()) {
+                     multicastLock.release();
+                     QLog.d("ForegroundService", "Released multicast lock");
+                 }
+             } catch (Exception e) {
+                 QLog.e("ForegroundService", "Failed to release multicast lock", e);
+             } finally {
+                 multicastLock = null;
+             }
+         }
 
 	 @Override
 	 public void onCreate() {
 		  super.onCreate();
+                  acquireMulticastLock();
 		}
 	 @Override
 	 public int onStartCommand(Intent intent, int flags, int startId) {
+		  acquireMulticastLock();
 		  String input = intent.getStringExtra("inputExtra");
 		  createNotificationChannel();
                   Intent notificationIntent = new Intent();
@@ -52,6 +90,7 @@ public class ForegroundService extends Service {
 		}
 	 @Override
 	 public void onDestroy() {
+                  releaseMulticastLock();
 		  super.onDestroy();
 		}
 

--- a/src/localipaddress.cpp
+++ b/src/localipaddress.cpp
@@ -91,45 +91,119 @@ int getIpAddress(JNIEnv *env, jobject wifiInfoObj) {
     jmethodID mid = env->GetMethodID(jclz, "getIpAddress", "()I");
     return env->CallIntMethod(wifiInfoObj, mid);
 }
+
+/*
+ * Get the device's own IPv4 address via ConnectivityManager.getLinkProperties()
+ * on the active network. Unlike QNetworkInterface (which reads netlink route
+ * sockets and is blocked by SELinux for untrusted apps on modern Android) and
+ * the deprecated WifiManager.getConnectionInfo().getIpAddress() (which returns
+ * 0 on Android 10+ without extra permissions), this goes through the regular
+ * ConnectivityManager system service and is not subject to either restriction.
+ */
+QString getConnectivityManagerIp(JNIEnv *env, jobject jCtxObj) {
+    qDebug() << "getConnectivityManagerIp....";
+
+    jclass jCtxClz = env->FindClass("android/content/Context");
+    jfieldID fidConnService = env->GetStaticFieldID(jCtxClz, "CONNECTIVITY_SERVICE", "Ljava/lang/String;");
+    jstring jstrConnService = (jstring)env->GetStaticObjectField(jCtxClz, fidConnService);
+    jmethodID midGetSystemService =
+        env->GetMethodID(jCtxClz, "getSystemService", "(Ljava/lang/String;)Ljava/lang/Object;");
+    jobject connManager = env->CallObjectMethod(jCtxObj, midGetSystemService, jstrConnService);
+    env->DeleteLocalRef(jCtxClz);
+    env->DeleteLocalRef(jstrConnService);
+    if (connManager == NULL) {
+        return QString();
+    }
+
+    jclass connManagerClz = env->GetObjectClass(connManager);
+    // getActiveNetwork() is only available on API 23+; on older devices this
+    // GetMethodID throws NoSuchMethodError and returns NULL.
+    jmethodID midGetActiveNetwork = env->GetMethodID(connManagerClz, "getActiveNetwork", "()Landroid/net/Network;");
+    if (midGetActiveNetwork == NULL) {
+        env->ExceptionClear();
+        env->DeleteLocalRef(connManagerClz);
+        env->DeleteLocalRef(connManager);
+        return QString();
+    }
+    jobject network = env->CallObjectMethod(connManager, midGetActiveNetwork);
+    env->DeleteLocalRef(connManager);
+    if (network == NULL) {
+        env->DeleteLocalRef(connManagerClz);
+        return QString();
+    }
+
+    jmethodID midGetLinkProperties = env->GetMethodID(
+        connManagerClz, "getLinkProperties", "(Landroid/net/Network;)Landroid/net/LinkProperties;");
+    jobject linkProperties = env->CallObjectMethod(connManager, midGetLinkProperties, network);
+    env->DeleteLocalRef(connManagerClz);
+    env->DeleteLocalRef(network);
+    if (linkProperties == NULL) {
+        return QString();
+    }
+
+    jclass linkPropertiesClz = env->GetObjectClass(linkProperties);
+    jmethodID midGetLinkAddresses = env->GetMethodID(linkPropertiesClz, "getLinkAddresses", "()Ljava/util/List;");
+    jobject linkAddresses = env->CallObjectMethod(linkProperties, midGetLinkAddresses);
+    env->DeleteLocalRef(linkPropertiesClz);
+    env->DeleteLocalRef(linkProperties);
+    if (linkAddresses == NULL) {
+        return QString();
+    }
+
+    jclass listClz = env->GetObjectClass(linkAddresses);
+    jmethodID midSize = env->GetMethodID(listClz, "size", "()I");
+    jmethodID midGet = env->GetMethodID(listClz, "get", "(I)Ljava/lang/Object;");
+    const jint size = env->CallIntMethod(linkAddresses, midSize);
+
+    jclass linkAddressClz = env->FindClass("android/net/LinkAddress");
+    jmethodID midGetAddress = env->GetMethodID(linkAddressClz, "getAddress", "()Ljava/net/InetAddress;");
+    jclass inet4Clz = env->FindClass("java/net/Inet4Address");
+
+    QString result;
+    for (jint i = 0; i < size; ++i) {
+        jobject linkAddress = env->CallObjectMethod(linkAddresses, midGet, i);
+        if (linkAddress == NULL) {
+            continue;
+        }
+        jobject inetAddress = env->CallObjectMethod(linkAddress, midGetAddress);
+        env->DeleteLocalRef(linkAddress);
+        if (inetAddress == NULL) {
+            continue;
+        }
+        if (!env->IsInstanceOf(inetAddress, inet4Clz)) {
+            env->DeleteLocalRef(inetAddress);
+            continue;
+        }
+
+        jclass inetAddressClz = env->GetObjectClass(inetAddress);
+        jmethodID midIsLoopback = env->GetMethodID(inetAddressClz, "isLoopbackAddress", "()Z");
+        const bool isLoopback = env->CallBooleanMethod(inetAddress, midIsLoopback);
+        if (!isLoopback) {
+            jmethodID midGetHostAddress = env->GetMethodID(inetAddressClz, "getHostAddress", "()Ljava/lang/String;");
+            jstring jHostAddress = (jstring)env->CallObjectMethod(inetAddress, midGetHostAddress);
+            const char *hostAddressChars = env->GetStringUTFChars(jHostAddress, NULL);
+            result = QString::fromUtf8(hostAddressChars);
+            env->ReleaseStringUTFChars(jHostAddress, hostAddressChars);
+            env->DeleteLocalRef(jHostAddress);
+        }
+        env->DeleteLocalRef(inetAddressClz);
+        env->DeleteLocalRef(inetAddress);
+        if (!result.isEmpty()) {
+            break;
+        }
+    }
+
+    env->DeleteLocalRef(linkAddressClz);
+    env->DeleteLocalRef(inet4Clz);
+    env->DeleteLocalRef(listClz);
+    env->DeleteLocalRef(linkAddresses);
+    return result;
+}
 #endif
 
 static bool isValidUsableIPv4(const QHostAddress &address) {
     return address.protocol() == QAbstractSocket::IPv4Protocol && !address.isLoopback() &&
            !address.isNull() && address != QHostAddress::AnyIPv4;
-}
-
-static QHostAddress findLocalInterfaceIPv4() {
-    const auto interfaces = QNetworkInterface::allInterfaces();
-    QHostAddress fallbackAddress;
-
-    for (const QNetworkInterface &networkInterface : interfaces) {
-        const auto flags = networkInterface.flags();
-        const bool interfaceIsUsable =
-            flags.testFlag(QNetworkInterface::IsUp) && flags.testFlag(QNetworkInterface::IsRunning) &&
-            !flags.testFlag(QNetworkInterface::IsLoopBack);
-        if (!interfaceIsUsable) {
-            continue;
-        }
-
-        const auto entries = networkInterface.addressEntries();
-        for (const QNetworkAddressEntry &entry : entries) {
-            const QHostAddress address = entry.ip();
-            if (!isValidUsableIPv4(address)) {
-                continue;
-            }
-
-            // Android Wi-Fi interfaces are usually wlan*. Prefer them when available.
-            if (networkInterface.name().startsWith("wlan", Qt::CaseInsensitive)) {
-                return address;
-            }
-
-            if (fallbackAddress.isNull()) {
-                fallbackAddress = address;
-            }
-        }
-    }
-
-    return fallbackAddress;
 }
 
 QHostAddress localipaddress::getIP(const QHostAddress &srcAddress) {
@@ -154,13 +228,20 @@ QHostAddress localipaddress::getIP(const QHostAddress &srcAddress) {
         }
     }
 #ifdef Q_OS_ANDROID
-    QHostAddress interfaceIp = findLocalInterfaceIPv4();
-    if (!interfaceIp.isNull()) {
-        qDebug() << "getIP from interface scan" << interfaceIp;
-        return interfaceIp;
+    QAndroidJniEnvironment env;
+
+    const QString connectivityIp = getConnectivityManagerIp(env, QtAndroid::androidContext().object());
+    if (env->ExceptionCheck()) {
+        // getActiveNetwork()/getLinkProperties() require API 23+; ignore on older devices.
+        env->ExceptionClear();
+    } else if (!connectivityIp.isEmpty()) {
+        QHostAddress connectivityAddress(connectivityIp);
+        if (isValidUsableIPv4(connectivityAddress)) {
+            qDebug() << "getIP from ConnectivityManager" << connectivityAddress;
+            return connectivityAddress;
+        }
     }
 
-    QAndroidJniEnvironment env;
     jobject wifiManagerObj = getWifiManagerObj(env, QtAndroid::androidContext().object());
     jobject wifiInfoObj = getWifiInfoObj(env, wifiManagerObj);
     int ip = getIpAddress(env, wifiInfoObj);

--- a/src/localipaddress.cpp
+++ b/src/localipaddress.cpp
@@ -103,15 +103,20 @@ int getIpAddress(JNIEnv *env, jobject wifiInfoObj) {
 QString getConnectivityManagerIp(JNIEnv *env, jobject jCtxObj) {
     qDebug() << "getConnectivityManagerIp....";
 
+    // Reserve enough local reference slots for this whole call, regardless of
+    // the caller thread's default JNI local reference frame capacity.
+    if (env->PushLocalFrame(32) < 0) {
+        return QString();
+    }
+
     jclass jCtxClz = env->FindClass("android/content/Context");
     jfieldID fidConnService = env->GetStaticFieldID(jCtxClz, "CONNECTIVITY_SERVICE", "Ljava/lang/String;");
     jstring jstrConnService = (jstring)env->GetStaticObjectField(jCtxClz, fidConnService);
     jmethodID midGetSystemService =
         env->GetMethodID(jCtxClz, "getSystemService", "(Ljava/lang/String;)Ljava/lang/Object;");
     jobject connManager = env->CallObjectMethod(jCtxObj, midGetSystemService, jstrConnService);
-    env->DeleteLocalRef(jCtxClz);
-    env->DeleteLocalRef(jstrConnService);
     if (connManager == NULL) {
+        env->PopLocalFrame(NULL);
         return QString();
     }
 
@@ -121,32 +126,28 @@ QString getConnectivityManagerIp(JNIEnv *env, jobject jCtxObj) {
     jmethodID midGetActiveNetwork = env->GetMethodID(connManagerClz, "getActiveNetwork", "()Landroid/net/Network;");
     if (midGetActiveNetwork == NULL) {
         env->ExceptionClear();
-        env->DeleteLocalRef(connManagerClz);
-        env->DeleteLocalRef(connManager);
+        env->PopLocalFrame(NULL);
         return QString();
     }
     jobject network = env->CallObjectMethod(connManager, midGetActiveNetwork);
-    env->DeleteLocalRef(connManager);
     if (network == NULL) {
-        env->DeleteLocalRef(connManagerClz);
+        env->PopLocalFrame(NULL);
         return QString();
     }
 
     jmethodID midGetLinkProperties = env->GetMethodID(
         connManagerClz, "getLinkProperties", "(Landroid/net/Network;)Landroid/net/LinkProperties;");
     jobject linkProperties = env->CallObjectMethod(connManager, midGetLinkProperties, network);
-    env->DeleteLocalRef(connManagerClz);
-    env->DeleteLocalRef(network);
     if (linkProperties == NULL) {
+        env->PopLocalFrame(NULL);
         return QString();
     }
 
     jclass linkPropertiesClz = env->GetObjectClass(linkProperties);
     jmethodID midGetLinkAddresses = env->GetMethodID(linkPropertiesClz, "getLinkAddresses", "()Ljava/util/List;");
     jobject linkAddresses = env->CallObjectMethod(linkProperties, midGetLinkAddresses);
-    env->DeleteLocalRef(linkPropertiesClz);
-    env->DeleteLocalRef(linkProperties);
     if (linkAddresses == NULL) {
+        env->PopLocalFrame(NULL);
         return QString();
     }
 
@@ -193,10 +194,7 @@ QString getConnectivityManagerIp(JNIEnv *env, jobject jCtxObj) {
         }
     }
 
-    env->DeleteLocalRef(linkAddressClz);
-    env->DeleteLocalRef(inet4Clz);
-    env->DeleteLocalRef(listClz);
-    env->DeleteLocalRef(linkAddresses);
+    env->PopLocalFrame(NULL);
     return result;
 }
 #endif


### PR DESCRIPTION
## Summary
- OpenBikeControl (MyWhoosh Link) TCP server never got any client connections on Android — root cause: `localipaddress::getIP()` only used the deprecated `WifiManager.getConnectionInfo().getIpAddress()` API, which returns 0 on modern Android, so mDNS advertised `0.0.0.0` as the service address. Added a `QNetworkInterface`-based fallback (preferring `wlan*`) and stricter validation of the JNI-derived address.
- Android silently drops incoming WiFi multicast packets (including mDNS queries) unless the app holds a `WifiManager.MulticastLock`. Added `CHANGE_WIFI_MULTICAST_STATE` permission and acquire/release the lock in `ForegroundService`.
- Ports forward two commits from the abandoned branch `android-ipaddress-not-valid` (closed PR #4357, never merged, no review comments, all CI green at the time).

Relates to #4717 (Zwift Click steering via MyWhoosh not working — button routing was already fixed in 592c28e9, but messages never reach MyWhoosh because no TCP client ever connects).

## Test plan
- [ ] CI Android build
- [ ] Install built APK on a real Android device with MyWhoosh Link + Zwift Click steering enabled, confirm a TCP client connects and steering commands reach MyWhoosh