### PR TITLE
Acquire mDNS multicast lock independently of ForegroundService + IP diagnostics

### DIFF
--- a/src/android/src/MulticastLockHelper.java
+++ b/src/android/src/MulticastLockHelper.java
@@ -1,0 +1,53 @@
+package org.cagnulen.qdomyoszwift;
+
+import android.content.Context;
+import android.net.wifi.WifiManager;
+
+/**
+ * Holds a WifiManager.MulticastLock so that incoming multicast packets (mDNS
+ * service discovery queries) are delivered to the app. Android drops them by
+ * default to save power, which makes QZ invisible to apps looking for it via
+ * mDNS (OpenBikeControl/MyWhoosh Link, DirCon).
+ *
+ * This is intentionally independent of ForegroundService: that service is only
+ * started when the "android notification" setting is enabled and a device is
+ * connected, while mDNS advertising starts as soon as the app launches.
+ */
+public class MulticastLockHelper {
+    private static WifiManager.MulticastLock multicastLock;
+
+    public static synchronized void acquire(Context context) {
+        if (multicastLock != null && multicastLock.isHeld()) {
+            return;
+        }
+
+        try {
+            WifiManager wifiManager =
+                (WifiManager) context.getApplicationContext().getSystemService(Context.WIFI_SERVICE);
+            if (wifiManager == null) {
+                QLog.d("MulticastLockHelper", "WifiManager unavailable; cannot acquire multicast lock");
+                return;
+            }
+
+            multicastLock = wifiManager.createMulticastLock("QZ:mdns");
+            multicastLock.setReferenceCounted(false);
+            multicastLock.acquire();
+            QLog.d("MulticastLockHelper", "Acquired multicast lock");
+        } catch (Exception e) {
+            QLog.e("MulticastLockHelper", "Failed to acquire multicast lock", e);
+        }
+    }
+
+    public static synchronized void release() {
+        try {
+            if (multicastLock != null && multicastLock.isHeld()) {
+                multicastLock.release();
+                QLog.d("MulticastLockHelper", "Released multicast lock");
+            }
+        } catch (Exception e) {
+            QLog.e("MulticastLockHelper", "Failed to release multicast lock", e);
+        } finally {
+            multicastLock = null;
+        }
+    }
+}

--- a/src/localipaddress.cpp
+++ b/src/localipaddress.cpp
@@ -116,6 +116,7 @@ QString getConnectivityManagerIp(JNIEnv *env, jobject jCtxObj) {
         env->GetMethodID(jCtxClz, "getSystemService", "(Ljava/lang/String;)Ljava/lang/Object;");
     jobject connManager = env->CallObjectMethod(jCtxObj, midGetSystemService, jstrConnService);
     if (connManager == NULL) {
+        qDebug() << "getConnectivityManagerIp: ConnectivityManager unavailable";
         env->PopLocalFrame(NULL);
         return QString();
     }
@@ -125,12 +126,14 @@ QString getConnectivityManagerIp(JNIEnv *env, jobject jCtxObj) {
     // GetMethodID throws NoSuchMethodError and returns NULL.
     jmethodID midGetActiveNetwork = env->GetMethodID(connManagerClz, "getActiveNetwork", "()Landroid/net/Network;");
     if (midGetActiveNetwork == NULL) {
+        qDebug() << "getConnectivityManagerIp: getActiveNetwork() not available (pre-API23)";
         env->ExceptionClear();
         env->PopLocalFrame(NULL);
         return QString();
     }
     jobject network = env->CallObjectMethod(connManager, midGetActiveNetwork);
     if (network == NULL) {
+        qDebug() << "getConnectivityManagerIp: no active network (device offline?)";
         env->PopLocalFrame(NULL);
         return QString();
     }
@@ -139,6 +142,7 @@ QString getConnectivityManagerIp(JNIEnv *env, jobject jCtxObj) {
         connManagerClz, "getLinkProperties", "(Landroid/net/Network;)Landroid/net/LinkProperties;");
     jobject linkProperties = env->CallObjectMethod(connManager, midGetLinkProperties, network);
     if (linkProperties == NULL) {
+        qDebug() << "getConnectivityManagerIp: no link properties for the active network";
         env->PopLocalFrame(NULL);
         return QString();
     }
@@ -147,6 +151,7 @@ QString getConnectivityManagerIp(JNIEnv *env, jobject jCtxObj) {
     jmethodID midGetLinkAddresses = env->GetMethodID(linkPropertiesClz, "getLinkAddresses", "()Ljava/util/List;");
     jobject linkAddresses = env->CallObjectMethod(linkProperties, midGetLinkAddresses);
     if (linkAddresses == NULL) {
+        qDebug() << "getConnectivityManagerIp: link addresses list is null";
         env->PopLocalFrame(NULL);
         return QString();
     }
@@ -192,6 +197,10 @@ QString getConnectivityManagerIp(JNIEnv *env, jobject jCtxObj) {
         if (!result.isEmpty()) {
             break;
         }
+    }
+
+    if (result.isEmpty()) {
+        qDebug() << "getConnectivityManagerIp: active network has no usable IPv4 address, link addresses:" << size;
     }
 
     env->PopLocalFrame(NULL);

--- a/src/mywhooshlink.cpp
+++ b/src/mywhooshlink.cpp
@@ -8,6 +8,11 @@
 #include <QNetworkDatagram>
 #include <QSysInfo>
 
+#ifdef Q_OS_ANDROID
+#include <QAndroidJniObject>
+#include <QtAndroid>
+#endif
+
 MyWhooshLink *MyWhooshLink::s_instance = nullptr;
 
 namespace {
@@ -134,6 +139,14 @@ void MyWhooshLink::start() {
         return;
     }
 
+#ifdef Q_OS_ANDROID
+    // Without a multicast lock Android silently drops the incoming mDNS queries
+    // that MyWhoosh sends to discover us.
+    QAndroidJniObject::callStaticMethod<void>("org/cagnulen/qdomyoszwift/MulticastLockHelper", "acquire",
+                                              "(Landroid/content/Context;)V",
+                                              QtAndroid::androidContext().object());
+#endif
+
     qDebug() << "MyWhooshLink(OpenBikeControl): network interfaces:";
     foreach (const QNetworkInterface &netInterface, QNetworkInterface::allInterfaces()) {
         if (netInterface.flags().testFlag(QNetworkInterface::IsUp) &&
@@ -212,6 +225,10 @@ void MyWhooshLink::stop() {
         mdnsServer->deleteLater();
         mdnsServer = nullptr;
     }
+
+#ifdef Q_OS_ANDROID
+    QAndroidJniObject::callStaticMethod<void>("org/cagnulen/qdomyoszwift/MulticastLockHelper", "release", "()V");
+#endif
 
     qDebug() << "MyWhooshLink(OpenBikeControl): stopped";
 }


### PR DESCRIPTION
Follow-up to #4864, based on the reporter's 31 July log in #4717.

## What the new log shows

The fix in #4864 is running (`getConnectivityManagerIp....` appears), but two things are still wrong:

**1. The multicast lock is never acquired.** I put it in `ForegroundService`, which only starts when `android_notification` is enabled *and* a device connects. The reporter has `android_notification=false`, so the service never runs — there are **zero** "multicast" lines in their 15k-line log. Moved into a standalone `MulticastLockHelper`, acquired from `MyWhooshLink::start()` where mDNS advertising actually begins.

**2. `getConnectivityManagerIp()` fails silently.** It has 5 early returns with no logging, so a user log can't tell us *which* step failed. Added a debug line to each.

## Note on the reporter's actual blocker

Their phone appears to have **no IPv4 address at all** right now, which no code change can fix:

| Log date | published address |
|---|---|
| 12 Jun | `192.168.1.55` |
| 23 Jul | `192.168.1.61` |
| 29 Jul | `0.0.0.0` |
| 30 Jul | `0.0.0.0` |
| 31 Jul (with #4864) | `""` |

`QNetworkInterface::allAddresses()` is empty, the legacy WifiManager JNI returns 0, and ConnectivityManager finds no usable IPv4 — while in June/July the same WifiManager call returned a real 192.168.1.x. The diagnostics above should tell us definitively on the next log.

## Test plan
- [ ] CI Android build
- [ ] Confirm "Acquired multicast lock" now appears in a debug log with `android_notification=false`