### PR TITLE
Send steering as a single button/state pair (fixes right paddle)

### DIFF
--- a/src/mywhooshlink.cpp
+++ b/src/mywhooshlink.cpp
@@ -444,11 +444,13 @@ void MyWhooshLink::sendAction(Action action, bool keyDown) {
     }
 }
 
-void MyWhooshLink::sendSteering(int value) {
-    QList<QPair<quint8, quint8>> actions;
-    actions.append(qMakePair(ButtonSteerLeft, static_cast<quint8>(value < 0 ? 0x01 : 0x00)));
-    actions.append(qMakePair(ButtonSteerRight, static_cast<quint8>(value > 0 ? 0x01 : 0x00)));
-    sendButtonStateMessage(actions);
+void MyWhooshLink::sendSteering(Action direction, bool keyDown) {
+    // Send a single button/state pair, exactly like the regular button-mapped
+    // path does. Packing both steer buttons into one message (SteerLeft first,
+    // SteerRight second) made right-paddle steering silently do nothing,
+    // because a right press was encoded as "SteerLeft released, SteerRight
+    // pressed" and only the leading pair took effect. See qdomyos-zwift#4717.
+    sendAction(direction, keyDown);
 }
 
 void MyWhooshLink::cycleCameraAngle() {
@@ -552,10 +554,10 @@ void MyWhooshLink::handleLeftPower(bool pressed) {
 void MyWhooshLink::handleLeftPaddle(int value) {
     if (value < 0 && !leftPaddlePressed) {
         leftPaddlePressed = true;
-        sendSteering(-1);
+        sendSteering(SteerLeft, true);
     } else if (value >= 0 && leftPaddlePressed) {
         leftPaddlePressed = false;
-        sendSteering(0);
+        sendSteering(SteerLeft, false);
     }
 }
 
@@ -586,10 +588,10 @@ void MyWhooshLink::handleRightPower(bool pressed) {
 void MyWhooshLink::handleRightPaddle(int value) {
     if (value > 0 && !rightPaddlePressed) {
         rightPaddlePressed = true;
-        sendSteering(1);
+        sendSteering(SteerRight, true);
     } else if (value <= 0 && rightPaddlePressed) {
         rightPaddlePressed = false;
-        sendSteering(0);
+        sendSteering(SteerRight, false);
     }
 }
 

--- a/src/mywhooshlink.h
+++ b/src/mywhooshlink.h
@@ -86,7 +86,7 @@ private:
     static MyWhooshLink *s_instance;
 
     void sendAction(Action action, bool keyDown = true);
-    void sendSteering(int value);
+    void sendSteering(Action direction, bool keyDown);
     void sendButtonStateMessage(const QList<QPair<quint8, quint8>> &actions);
     quint8 actionToButtonId(Action action) const;
     quint8 actionToButtonState(Action action, bool keyDown) const;


### PR DESCRIPTION
Supersedes #4869 (GitHub refused to reopen it after the branch was rewritten — that PR's original approach was wrong and caused a regression, see the analysis there).

Fixes the original report in #4717: *"Right paddle only - it doesn't steer right as expected. Only left paddle does. Assigning to buttons and restarting app then it works as expected."*

## Root cause
Paddle steering went through `sendSteering()`, which packed **both** steer buttons into a single button-state message, always with SteerLeft (`0x18`) first and SteerRight (`0x19`) second. From @sondregronas's debug log in #4717:

| input | message sent | result |
|---|---|---|
| left paddle | `01 `**`18 01`**` 19 00` | ✅ steers |
| right paddle | `01 `**`18 00`**` 19 01` | ❌ nothing |
| button-mapped (via `sendAction`) | `01 18 01` / `01 19 01` (single pair) | ✅ both directions |

If the app only acts on the **leading** button/state pair, a left press reads as "SteerLeft pressed" and works, while a right press reads as "SteerLeft **released**" — and the trailing `SteerRight` pair is ignored, so the right paddle silently does nothing.

This is the only explanation consistent with all three observed cases, in particular why assigning steering to regular buttons works in *both* directions (that path already emits a single pair).

## Fix
Route the paddles through the same single-pair path the working button mapping already uses.

## Test plan
- [x] `mywhooshlink.o` compiles cleanly
- [ ] CI build
- [ ] @sondregronas to confirm the right paddle now steers right without reassigning to buttons