### PR TITLE
Fix floating window metric settings not persisting

### DIFF
--- a/src/templateinfosenderbuilder.cpp
+++ b/src/templateinfosenderbuilder.cpp
@@ -490,21 +490,18 @@ void TemplateInfoSenderBuilder::onSetSettings(const QJsonValue &msgContent, Temp
     QJsonObject outObj;
     QSettings settings;
     for (auto &key : keys) {
+        val = obj[key];
+        valConv = val.toVariant();
         if (settings.contains(key)) {
-            val = obj[key];
-            valConv = val.toVariant();
             settingVal = settings.value(key);
-            if (valConv.type() == settingVal.type()) {
-                settings.setValue(key, valConv);
-                outObj.insert(key, val);
-            } else {
-                outObj.insert(key, QJsonValue::fromVariant(settingVal));
+            if (valConv.type() != settingVal.type() && valConv.canConvert(settingVal.type())) {
+                // QSettings backends don't always round-trip the original type (e.g. bool
+                // coming back as QString/int), so coerce instead of silently dropping the update.
+                valConv.convert(settingVal.type());
             }
-        } else {
-            val = obj[key];
-            settings.setValue(key, val.toVariant());
-            outObj.insert(key, val);
         }
+        settings.setValue(key, valConv);
+        outObj.insert(key, QJsonValue::fromVariant(valConv));
     }
     settings.sync();
     QJsonObject main;


### PR DESCRIPTION
## Summary
- A user (Kareem, via email "QZ AI App Issues") reported that the metric selections in the floating/horizontal companion window don't persist after closing and reopening the app.
- Root cause: `TemplateInfoSenderBuilder::onSetSettings` (`src/templateinfosenderbuilder.cpp`) only wrote an incoming setting to `QSettings` when its `QVariant` type exactly matched the type already stored. QSettings backends (INI on desktop, native storage on Android) don't reliably round-trip `bool`, so a previously-saved value can come back as `QString`/`int`. When that happened, the type check failed and the new value was silently discarded, with the old value echoed back as if nothing changed.
- Fix: coerce the incoming value to the stored type (`QVariant::convert`) instead of dropping it when types differ but are convertible, then always persist.

## Test plan
- [ ] Manual: toggle a metric checkbox in the floating window, close and relaunch the main app, verify the selection is retained.
- [ ] Existing behavior for keys not previously present in settings (first-time save) is unchanged.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Uk7syLLAUDYyVFnwhe9f1P)_