### PR TITLE
Debug: 0.01 km/h raw FTMS speed step on Horizon treadmill (not for merge)

### DIFF
--- a/src/devices/horizontreadmill/horizontreadmill.cpp
+++ b/src/devices/horizontreadmill/horizontreadmill.cpp
@@ -974,26 +974,13 @@ void horizontreadmill::update() {
             requestSpeed = -1;
         
         if (requestSpeed != -1) {
-            if (qEnvironmentVariableIsSet("QZ_DEBUG_SPEED_001_STEP")) {
-                // DEBUG ONLY: skip the .1 rounding and the minStepSpeed threshold so a raw
-                // 0.01 km/h delta actually reaches forceSpeed()/FTMS instead of being filtered out.
-                if (requestSpeed >= 0 && requestSpeed <= 22 && requestSpeed != currentSpeed().value()) {
-                    qDebug() << "[QZ_DEBUG_SPEED_001_STEP]" << QDateTime::currentDateTime().toString(Qt::ISODateWithMs)
-                             << "forcing raw requestSpeed=" << requestSpeed
-                             << "currentSpeed=" << currentSpeed().value();
-                    forceSpeed(requestSpeed);
-                }
-            } else {
-                bool minSpeed =
-                    fabs(requestSpeed - float_one_point_round(currentSpeed().value())) >= (minStepSpeed() - 0.09);
-                bool forceSpeedNeed = checkIfForceSpeedNeeding(requestSpeed);
-                qDebug() << "requestSpeed=" << requestSpeed << minSpeed << forceSpeedNeed
-                         << float_one_point_round(currentSpeed().value());
-                if (float_one_point_round(requestSpeed) != float_one_point_round(currentSpeed().value()) && minSpeed && requestSpeed >= 0 && requestSpeed <= 22 &&
-                    forceSpeedNeed) {
-                    emit debug(QStringLiteral("writing speed ") + QString::number(requestSpeed));
-                    forceSpeed(float_one_point_round(requestSpeed));
-                }
+            // DEBUG BUILD: always skip the .1 rounding and the minStepSpeed threshold so a raw
+            // 0.01 km/h delta actually reaches forceSpeed()/FTMS instead of being filtered out.
+            if (requestSpeed >= 0 && requestSpeed <= 22 && requestSpeed != currentSpeed().value()) {
+                qDebug() << "[QZ_DEBUG_SPEED_001_STEP]" << QDateTime::currentDateTime().toString(Qt::ISODateWithMs)
+                         << "forcing raw requestSpeed=" << requestSpeed
+                         << "currentSpeed=" << currentSpeed().value();
+                forceSpeed(requestSpeed);
             }
             requestSpeed = -1;
         }
@@ -1248,13 +1235,11 @@ void horizontreadmill::forceSpeed(double requestSpeed) {
             write[12] = datas[2];
             write[13] = datas[3];
 
-            if (qEnvironmentVariableIsSet("QZ_DEBUG_SPEED_001_STEP")) {
-                qDebug() << "[QZ_DEBUG_SPEED_001_STEP]" << QDateTime::currentDateTime().toString(Qt::ISODateWithMs)
-                         << "raw Horizon custom-protocol bytes="
-                         << QByteArray((const char *)write, sizeof(write)).toHex(' ')
-                         << "requestSpeed=" << requestSpeed
-                         << "(note: this protocol only has 0.1 km/h resolution, a 0.01 step won't change the bytes)";
-            }
+            qDebug() << "[QZ_DEBUG_SPEED_001_STEP]" << QDateTime::currentDateTime().toString(Qt::ISODateWithMs)
+                     << "raw Horizon custom-protocol bytes="
+                     << QByteArray((const char *)write, sizeof(write)).toHex(' ')
+                     << "requestSpeed=" << requestSpeed
+                     << "(note: this protocol only has 0.1 km/h resolution, a 0.01 step won't change the bytes)";
 
             writeCharacteristic(gattCustomService, gattWriteCharCustomService, write, sizeof(write),
                                 QStringLiteral("forceSpeed"), false, true);
@@ -1280,13 +1265,11 @@ void horizontreadmill::forceSpeed(double requestSpeed) {
             initData02_paragon[11] = datas[1];
             initData02_paragon[12] = datas[2];
 
-            if (qEnvironmentVariableIsSet("QZ_DEBUG_SPEED_001_STEP")) {
-                qDebug() << "[QZ_DEBUG_SPEED_001_STEP]" << QDateTime::currentDateTime().toString(Qt::ISODateWithMs)
-                         << "raw Horizon Paragon-X custom-protocol bytes="
-                         << QByteArray((const char *)initData02_paragon, sizeof(initData02_paragon)).toHex(' ')
-                         << "requestSpeed=" << requestSpeed
-                         << "(note: this protocol only has 0.1 km/h resolution, a 0.01 step won't change the bytes)";
-            }
+            qDebug() << "[QZ_DEBUG_SPEED_001_STEP]" << QDateTime::currentDateTime().toString(Qt::ISODateWithMs)
+                     << "raw Horizon Paragon-X custom-protocol bytes="
+                     << QByteArray((const char *)initData02_paragon, sizeof(initData02_paragon)).toHex(' ')
+                     << "requestSpeed=" << requestSpeed
+                     << "(note: this protocol only has 0.1 km/h resolution, a 0.01 step won't change the bytes)";
 
             writeCharacteristic(gattCustomService, gattWriteCharCustomService, initData02_paragon,
                                 sizeof(initData02_paragon), QStringLiteral("forceSpeed"), false, false);
@@ -1316,12 +1299,10 @@ void horizontreadmill::forceSpeed(double requestSpeed) {
         writeS[1] = speed_int & 0xFF;
         writeS[2] = speed_int >> 8;
 
-        if (qEnvironmentVariableIsSet("QZ_DEBUG_SPEED_001_STEP")) {
-            qDebug() << "[QZ_DEBUG_SPEED_001_STEP]" << QDateTime::currentDateTime().toString(Qt::ISODateWithMs)
-                     << "raw FTMS SetTargetSpeed bytes="
-                     << QByteArray((const char *)writeS, sizeof(writeS)).toHex(' ')
-                     << "requestSpeed=" << requestSpeed;
-        }
+        qDebug() << "[QZ_DEBUG_SPEED_001_STEP]" << QDateTime::currentDateTime().toString(Qt::ISODateWithMs)
+                 << "raw FTMS SetTargetSpeed bytes="
+                 << QByteArray((const char *)writeS, sizeof(writeS)).toHex(' ')
+                 << "requestSpeed=" << requestSpeed;
 
         writeCharacteristic(gattFTMSService, gattWriteCharControlPointId, writeS, sizeof(writeS),
                             QStringLiteral("forceSpeed"), false, false);

--- a/src/devices/horizontreadmill/horizontreadmill.cpp
+++ b/src/devices/horizontreadmill/horizontreadmill.cpp
@@ -974,15 +974,26 @@ void horizontreadmill::update() {
             requestSpeed = -1;
         
         if (requestSpeed != -1) {
-            bool minSpeed =
-                fabs(requestSpeed - float_one_point_round(currentSpeed().value())) >= (minStepSpeed() - 0.09);
-            bool forceSpeedNeed = checkIfForceSpeedNeeding(requestSpeed);
-            qDebug() << "requestSpeed=" << requestSpeed << minSpeed << forceSpeedNeed
-                     << float_one_point_round(currentSpeed().value());
-            if (float_one_point_round(requestSpeed) != float_one_point_round(currentSpeed().value()) && minSpeed && requestSpeed >= 0 && requestSpeed <= 22 &&
-                forceSpeedNeed) {
-                emit debug(QStringLiteral("writing speed ") + QString::number(requestSpeed));
-                forceSpeed(float_one_point_round(requestSpeed));
+            if (qEnvironmentVariableIsSet("QZ_DEBUG_SPEED_001_STEP")) {
+                // DEBUG ONLY: skip the .1 rounding and the minStepSpeed threshold so a raw
+                // 0.01 km/h delta actually reaches forceSpeed()/FTMS instead of being filtered out.
+                if (requestSpeed >= 0 && requestSpeed <= 22 && requestSpeed != currentSpeed().value()) {
+                    qDebug() << "[QZ_DEBUG_SPEED_001_STEP]" << QDateTime::currentDateTime().toString(Qt::ISODateWithMs)
+                             << "forcing raw requestSpeed=" << requestSpeed
+                             << "currentSpeed=" << currentSpeed().value();
+                    forceSpeed(requestSpeed);
+                }
+            } else {
+                bool minSpeed =
+                    fabs(requestSpeed - float_one_point_round(currentSpeed().value())) >= (minStepSpeed() - 0.09);
+                bool forceSpeedNeed = checkIfForceSpeedNeeding(requestSpeed);
+                qDebug() << "requestSpeed=" << requestSpeed << minSpeed << forceSpeedNeed
+                         << float_one_point_round(currentSpeed().value());
+                if (float_one_point_round(requestSpeed) != float_one_point_round(currentSpeed().value()) && minSpeed && requestSpeed >= 0 && requestSpeed <= 22 &&
+                    forceSpeedNeed) {
+                    emit debug(QStringLiteral("writing speed ") + QString::number(requestSpeed));
+                    forceSpeed(float_one_point_round(requestSpeed));
+                }
             }
             requestSpeed = -1;
         }
@@ -1237,6 +1248,14 @@ void horizontreadmill::forceSpeed(double requestSpeed) {
             write[12] = datas[2];
             write[13] = datas[3];
 
+            if (qEnvironmentVariableIsSet("QZ_DEBUG_SPEED_001_STEP")) {
+                qDebug() << "[QZ_DEBUG_SPEED_001_STEP]" << QDateTime::currentDateTime().toString(Qt::ISODateWithMs)
+                         << "raw Horizon custom-protocol bytes="
+                         << QByteArray((const char *)write, sizeof(write)).toHex(' ')
+                         << "requestSpeed=" << requestSpeed
+                         << "(note: this protocol only has 0.1 km/h resolution, a 0.01 step won't change the bytes)";
+            }
+
             writeCharacteristic(gattCustomService, gattWriteCharCustomService, write, sizeof(write),
                                 QStringLiteral("forceSpeed"), false, true);
         } else {
@@ -1260,6 +1279,14 @@ void horizontreadmill::forceSpeed(double requestSpeed) {
             initData02_paragon[10] = datas[0];
             initData02_paragon[11] = datas[1];
             initData02_paragon[12] = datas[2];
+
+            if (qEnvironmentVariableIsSet("QZ_DEBUG_SPEED_001_STEP")) {
+                qDebug() << "[QZ_DEBUG_SPEED_001_STEP]" << QDateTime::currentDateTime().toString(Qt::ISODateWithMs)
+                         << "raw Horizon Paragon-X custom-protocol bytes="
+                         << QByteArray((const char *)initData02_paragon, sizeof(initData02_paragon)).toHex(' ')
+                         << "requestSpeed=" << requestSpeed
+                         << "(note: this protocol only has 0.1 km/h resolution, a 0.01 step won't change the bytes)";
+            }
 
             writeCharacteristic(gattCustomService, gattWriteCharCustomService, initData02_paragon,
                                 sizeof(initData02_paragon), QStringLiteral("forceSpeed"), false, false);
@@ -1288,6 +1315,13 @@ void horizontreadmill::forceSpeed(double requestSpeed) {
         uint16_t speed_int = round(requestSpeed * 100);
         writeS[1] = speed_int & 0xFF;
         writeS[2] = speed_int >> 8;
+
+        if (qEnvironmentVariableIsSet("QZ_DEBUG_SPEED_001_STEP")) {
+            qDebug() << "[QZ_DEBUG_SPEED_001_STEP]" << QDateTime::currentDateTime().toString(Qt::ISODateWithMs)
+                     << "raw FTMS SetTargetSpeed bytes="
+                     << QByteArray((const char *)writeS, sizeof(writeS)).toHex(' ')
+                     << "requestSpeed=" << requestSpeed;
+        }
 
         writeCharacteristic(gattFTMSService, gattWriteCharControlPointId, writeS, sizeof(writeS),
                             QStringLiteral("forceSpeed"), false, false);

--- a/src/homeform.cpp
+++ b/src/homeform.cpp
@@ -25,6 +25,7 @@
 #include <QByteArray>
 #include <QClipboard>
 #include <QCryptographicHash>
+#include <QDateTime>
 #include <QDesktopServices>
 #include <QDir>
 #include <QDirIterator>
@@ -5222,20 +5223,28 @@ void homeform::Plus(const QString &name) {
                 speed = targetspeed;
             if (requestedspeed != -1)
                 speed = requestedspeed;
-            double minStepSpeed = ((treadmill *)bluetoothManager->device())->minStepSpeed();
-            double step =
-                settings.value(QZSettings::treadmill_step_speed, QZSettings::default_treadmill_step_speed).toDouble();
-            if (!miles)
-                step = ((double)qRound(step * 10.0)) / 10.0;
-            if (step > minStepSpeed)
-                minStepSpeed = step;
-            int rest = 0;
-            if (!miles)
-                rest = (minStepSpeed * 10.0) - (((int)(speed * 10.0)) % (uint8_t)(minStepSpeed * 10.0));
-            if (rest == 5 || rest == 0)
-                speed = speed + minStepSpeed;
-            else
-                speed = speed + (((double)rest) / 10.0);
+            if (qEnvironmentVariableIsSet("QZ_DEBUG_SPEED_001_STEP")) {
+                // DEBUG ONLY: forces a raw 0.01 km/h increment per tap to probe how the
+                // treadmill firmware reacts to the smallest possible FTMS set-speed step.
+                speed = speed + 0.01;
+                qDebug() << "[QZ_DEBUG_SPEED_001_STEP]" << QDateTime::currentDateTime().toString(Qt::ISODateWithMs)
+                         << "plus tapped, requesting speed =" << speed;
+            } else {
+                double minStepSpeed = ((treadmill *)bluetoothManager->device())->minStepSpeed();
+                double step =
+                    settings.value(QZSettings::treadmill_step_speed, QZSettings::default_treadmill_step_speed).toDouble();
+                if (!miles)
+                    step = ((double)qRound(step * 10.0)) / 10.0;
+                if (step > minStepSpeed)
+                    minStepSpeed = step;
+                int rest = 0;
+                if (!miles)
+                    rest = (minStepSpeed * 10.0) - (((int)(speed * 10.0)) % (uint8_t)(minStepSpeed * 10.0));
+                if (rest == 5 || rest == 0)
+                    speed = speed + minStepSpeed;
+                else
+                    speed = speed + (((double)rest) / 10.0);
+            }
 
             ((treadmill *)bluetoothManager->device())->changeSpeed(speed);
         }

--- a/src/homeform.cpp
+++ b/src/homeform.cpp
@@ -5223,28 +5223,11 @@ void homeform::Plus(const QString &name) {
                 speed = targetspeed;
             if (requestedspeed != -1)
                 speed = requestedspeed;
-            if (qEnvironmentVariableIsSet("QZ_DEBUG_SPEED_001_STEP")) {
-                // DEBUG ONLY: forces a raw 0.01 km/h increment per tap to probe how the
-                // treadmill firmware reacts to the smallest possible FTMS set-speed step.
-                speed = speed + 0.01;
-                qDebug() << "[QZ_DEBUG_SPEED_001_STEP]" << QDateTime::currentDateTime().toString(Qt::ISODateWithMs)
-                         << "plus tapped, requesting speed =" << speed;
-            } else {
-                double minStepSpeed = ((treadmill *)bluetoothManager->device())->minStepSpeed();
-                double step =
-                    settings.value(QZSettings::treadmill_step_speed, QZSettings::default_treadmill_step_speed).toDouble();
-                if (!miles)
-                    step = ((double)qRound(step * 10.0)) / 10.0;
-                if (step > minStepSpeed)
-                    minStepSpeed = step;
-                int rest = 0;
-                if (!miles)
-                    rest = (minStepSpeed * 10.0) - (((int)(speed * 10.0)) % (uint8_t)(minStepSpeed * 10.0));
-                if (rest == 5 || rest == 0)
-                    speed = speed + minStepSpeed;
-                else
-                    speed = speed + (((double)rest) / 10.0);
-            }
+            // DEBUG BUILD: always forces a raw 0.01 km/h increment per tap to probe how the
+            // treadmill firmware reacts to the smallest possible FTMS set-speed step.
+            speed = speed + 0.01;
+            qDebug() << "[QZ_DEBUG_SPEED_001_STEP]" << QDateTime::currentDateTime().toString(Qt::ISODateWithMs)
+                     << "plus tapped, requesting speed =" << speed;
 
             ((treadmill *)bluetoothManager->device())->changeSpeed(speed);
         }


### PR DESCRIPTION
## Context
Related to the Gmail thread "Issue with controlling treadmill" — the user reports issues controlling their Horizon treadmill's speed.

This is a **diagnostic build, not intended to be merged**. Its only purpose is to probe how the treadmill firmware reacts to the smallest possible speed step, so we can correlate each button press with the treadmill's observed behavior and narrow down the control bug.

## What it does
This build is always in debug mode (no configuration or env var needed — just install and use):
- Each tap on the home form's speed **+** button requests `currentSpeed + 0.01` instead of the normal step (0.5/1.0 km/h).
- In `horizontreadmill.cpp`, bypasses the 1-decimal rounding and `minStepSpeed` threshold that would otherwise silently discard such a tiny delta before it reaches `forceSpeed()`.
- Logs every outgoing BLE write with a timestamp and the raw hex bytes (`qDebug`), for both the standard FTMS branch and the two Horizon proprietary-protocol branches, so the exact command sent can be matched against what's observed on the treadmill console.
- Note: the Horizon proprietary protocol (`gattCustomService`) only has 0.1 km/h resolution, so a 0.01 step won't change the bytes on that branch — the log makes this explicit. The test is meaningful only if this specific unit uses the FTMS branch (`gattFTMSService`).

## How to test
1. Build the Android debug APK via the `android-build` job in the `CI` GitHub Action (runs automatically on this PR, artifact name `fdroid-android-trial`), or build locally.
2. Install the APK and launch the app — no setup needed, the debug behavior is always on in this build.
3. Connect to the Horizon treadmill, tap the speed **+** button repeatedly, and note down what the treadmill actually does after each tap.
4. Pull the debug log (`adb logcat` on Android) and match each `[QZ_DEBUG_SPEED_001_STEP]` line (timestamp + raw bytes) to the corresponding observed treadmill reaction.

## Test plan
- [x] `homeform.o` and `horizontreadmill.o` compile cleanly (verified locally)
- [ ] Manual test against a real Horizon treadmill to confirm raw bytes are actually sent and observe firmware reaction