### PR TITLE
Automatically detect ERG mode from control requests

### DIFF
--- a/src/characteristics/characteristicwriteprocessor.cpp
+++ b/src/characteristics/characteristicwriteprocessor.cpp
@@ -7,11 +7,16 @@ CharacteristicWriteProcessor::CharacteristicWriteProcessor(double bikeResistance
                                                            bluetoothdevice *bike, QObject *parent)
     : QObject(parent), bikeResistanceOffset(bikeResistanceOffset), bikeResistanceGain(bikeResistanceGain), Bike(bike) {}
 
-void CharacteristicWriteProcessor::changePower(uint16_t power) { Bike->changePower(power); }
+void CharacteristicWriteProcessor::changePower(uint16_t power) {
+    QSettings settings;
+    settings.setValue(QZSettings::zwift_erg, true);
+    Bike->changePower(power);
+}
 
 void CharacteristicWriteProcessor::changeSlope(int16_t iresistance, uint8_t crr, uint8_t cw) {
     BLUETOOTH_TYPE dt = Bike->deviceType();
     QSettings settings;
+    settings.setValue(QZSettings::zwift_erg, false);
     bool force_resistance =
         settings.value(QZSettings::virtualbike_forceresistance, QZSettings::default_virtualbike_forceresistance)
             .toBool();

--- a/src/characteristics/characteristicwriteprocessor2ad9.cpp
+++ b/src/characteristics/characteristicwriteprocessor2ad9.cpp
@@ -14,13 +14,20 @@ CharacteristicWriteProcessor2AD9::CharacteristicWriteProcessor2AD9(double bikeRe
 int CharacteristicWriteProcessor2AD9::writeProcess(quint16 uuid, const QByteArray &data, QByteArray &reply) {
     if (data.size()) {
         BLUETOOTH_TYPE dt = Bike->deviceType();
+        QSettings settings;
+        char cmd = data.at(0);
+        if (cmd == FTMS_SET_TARGET_POWER) {
+            settings.setValue(QZSettings::zwift_erg, true);
+        } else if (cmd == FTMS_SET_TARGET_INCLINATION ||
+                   cmd == FTMS_SET_TARGET_RESISTANCE_LEVEL ||
+                   cmd == FTMS_SET_INDOOR_BIKE_SIMULATION_PARAMS) {
+            settings.setValue(QZSettings::zwift_erg, false);
+        }
         if (dt == BIKE || dt == ROWING) {
-            QSettings settings;
             bool force_resistance =
                 settings.value(QZSettings::virtualbike_forceresistance, QZSettings::default_virtualbike_forceresistance)
                     .toBool();
             bool erg_mode = settings.value(QZSettings::zwift_erg, QZSettings::default_zwift_erg).toBool();
-            char cmd = data.at(0);
             emit ftmsCharacteristicChanged(QLowEnergyCharacteristic(), data);
             if (cmd == FTMS_SET_TARGET_RESISTANCE_LEVEL) {
 

--- a/src/homeform.cpp
+++ b/src/homeform.cpp
@@ -4677,6 +4677,13 @@ void homeform::LargeButton(const QString &name) {
     if (!bluetoothManager || !bluetoothManager->device())
         return;
 
+    if (name.startsWith(QStringLiteral("preset_powerzone_")) || name.contains(QStringLiteral("target_power")) ||
+        name.contains(QStringLiteral("target_zone"))) {
+        settings.setValue(QZSettings::zwift_erg, true);
+    } else if (name.contains(QStringLiteral("resistance")) || name.contains(QStringLiteral("inclination"))) {
+        settings.setValue(QZSettings::zwift_erg, false);
+    }
+
     if (bluetoothManager->device()->deviceType() == BIKE || 
         bluetoothManager->device()->deviceType() == ELLIPTICAL ||
         bluetoothManager->device()->deviceType() == ROWING) {
@@ -5155,6 +5162,11 @@ void homeform::Plus(const QString &name) {
 
     bool miles = settings.value(QZSettings::miles_unit, QZSettings::default_miles_unit).toBool();
     qDebug() << QStringLiteral("Plus") << name;
+    if (name.contains(QStringLiteral("target_power")) || name.contains(QStringLiteral("target_zone"))) {
+        settings.setValue(QZSettings::zwift_erg, true);
+    } else if (name.contains(QStringLiteral("resistance")) || name.contains(QStringLiteral("inclination"))) {
+        settings.setValue(QZSettings::zwift_erg, false);
+    }
     if (name.contains(QStringLiteral("target_speed")) || name.contains(QStringLiteral("target_pace"))) {
         if (bluetoothManager->device()) {
 
@@ -5458,6 +5470,11 @@ void homeform::Minus(const QString &name) {
     QSettings settings;
     bool miles = settings.value(QZSettings::miles_unit, QZSettings::default_miles_unit).toBool();
     qDebug() << QStringLiteral("Minus") << name;
+    if (name.contains(QStringLiteral("target_power")) || name.contains(QStringLiteral("target_zone"))) {
+        settings.setValue(QZSettings::zwift_erg, true);
+    } else if (name.contains(QStringLiteral("resistance")) || name.contains(QStringLiteral("inclination"))) {
+        settings.setValue(QZSettings::zwift_erg, false);
+    }
     if (name.contains(QStringLiteral("target_speed")) || name.contains(QStringLiteral("target_pace"))) {
         if (bluetoothManager->device()) {
 

--- a/src/trainprogram.cpp
+++ b/src/trainprogram.cpp
@@ -644,6 +644,7 @@ void trainprogram::scheduler() {
 
     QMutexLocker(&this->schedulerMutex);
     QSettings settings;
+    auto setErgMode = [&settings](bool enabled) { settings.setValue(QZSettings::zwift_erg, enabled); };
     QDateTime now = QDateTime::currentDateTime();
     qint64 msecsElapsed = lastSchedulerCall.msecsTo(now);
 
@@ -769,6 +770,7 @@ void trainprogram::scheduler() {
                                 if(zwift_api_autoinclination) {
                                     if(bluetoothManager->device()->deviceType() == TREADMILL || 
                                         (bluetoothManager->device()->deviceType() == ELLIPTICAL && ((elliptical*)bluetoothManager->device())->inclinationAvailableByHardware())) {
+                                        setErgMode(false);
                                         bluetoothManager->device()->changeInclination(grade, grade);
                                     }
                                     if (bluetoothManager->device()->deviceType() == ELLIPTICAL &&
@@ -778,6 +780,7 @@ void trainprogram::scheduler() {
                                         double bikeResistanceOffset = settings.value(QZSettings::bike_resistance_offset, bikeResistanceOffset).toInt();
                                         double bikeResistanceGain = settings.value(QZSettings::bike_resistance_gain_f, bikeResistanceGain).toDouble();
 
+                                        setErgMode(false);
                                         bluetoothManager->device()->changeResistance((resistance_t)(round(grade * bikeResistanceGain)) + bikeResistanceOffset + 1); // resistance start from 1
                                     }
                                 }
@@ -836,6 +839,7 @@ void trainprogram::scheduler() {
                                     ss[0] = ss[0].replace("l", "1");
                                     ss[0] = ss[0].replace(" ", "");
                                     if (ss[0].toInt() < 15 && ss[0].toInt() > -15) {
+                                        setErgMode(false);
                                         bluetoothManager->device()->changeInclination(ss[0].toInt(), ss[0].toInt());
                                     } else {
                                         qDebug() << "filtering" << ss[0].toInt();
@@ -941,11 +945,13 @@ void trainprogram::scheduler() {
                     inc = rows.at(0).inclination;
                 }
                 qDebug() << QStringLiteral("trainprogram change inclination") + QString::number(inc);
+                setErgMode(false);
                 emit changeInclination(inc, inc);
                 emit changeNextInclination300Meters(avgInclinationNext300Meters());
             }
             if (rows.at(0).power != -1) {
                 qDebug() << QStringLiteral("trainprogram change power") + QString::number(rows.at(0).power);
+                setErgMode(true);
                 emit changePower(rows.at(0).power);
             }
         } else if (bluetoothManager->device()->deviceType() == ROWING) {
@@ -959,15 +965,18 @@ void trainprogram::scheduler() {
             }
             if (rows.at(0).power != -1) {
                 qDebug() << QStringLiteral("trainprogram change power") + QString::number(rows.at(0).power);
+                setErgMode(true);
                 emit changePower(rows.at(0).power);
             }
             if (rows.at(0).resistance != -1) {
                 qDebug() << QStringLiteral("trainprogram change resistance") + QString::number(rows.at(0).resistance);
+                setErgMode(false);
                 emit changeResistance(rows.at(0).resistance);
             }
         } else {
             if (rows.at(0).resistance != -1) {
                 qDebug() << QStringLiteral("trainprogram change resistance") + QString::number(rows.at(0).resistance);
+                setErgMode(false);
                 emit changeResistance(rows.at(0).resistance);
             }
 
@@ -978,12 +987,14 @@ void trainprogram::scheduler() {
 
             if (rows.at(0).power != -1) {
                 qDebug() << QStringLiteral("trainprogram change power") + QString::number(rows.at(0).power);
+                setErgMode(true);
                 emit changePower(rows.at(0).power);
             }
 
             if (rows.at(0).requested_peloton_resistance != -1) {
                 qDebug() << QStringLiteral("trainprogram change requested peloton resistance") +
                                 QString::number(rows.at(0).requested_peloton_resistance);
+                setErgMode(false);
                 emit changeRequestedPelotonResistance(rows.at(0).requested_peloton_resistance);
             }
 
@@ -1018,6 +1029,7 @@ void trainprogram::scheduler() {
                         settings.value(QZSettings::bike_resistance_gain_f, QZSettings::default_bike_resistance_gain_f)
                             .toDouble();
 
+                    setErgMode(false);
                     bluetoothManager->device()->changeResistance((resistance_t)(round(inc * bikeResistanceGain)) +
                                                                  bikeResistanceOffset + 1); // resistance start from 1
                 }
@@ -1028,6 +1040,7 @@ void trainprogram::scheduler() {
                 if (bluetoothManager->device()->deviceType() == BIKE ||
                     (isElliptical && ellipticalInclinationByHardware)) {
                     qDebug() << QStringLiteral("trainprogram change inclination") + QString::number(inc);
+                    setErgMode(false);
                     emit changeInclination(inc, inc);
                     emit changeNextInclination300Meters(inclinationNext300Meters());
                 }
@@ -1058,6 +1071,7 @@ void trainprogram::scheduler() {
                          << "row" << currentStep
                          << "condition" << blockingTransitionRowDescription(row);
             }
+            setErgMode(true);
             emit changePower(row.power);
         }
     }
@@ -1199,6 +1213,7 @@ void trainprogram::scheduler() {
             if (rows.length() > currentStep && rows.at(currentStep).power != -1) {
                 qDebug() << QStringLiteral("trainprogram change power ") +
                                 QString::number(rows.at(currentStep).power);
+                setErgMode(true);
                 emit changePower(rows.at(currentStep).power);
             }
 
@@ -1219,6 +1234,7 @@ void trainprogram::scheduler() {
                         settings.value(QZSettings::bike_resistance_gain_f, QZSettings::default_bike_resistance_gain_f)
                             .toDouble();
 
+                    setErgMode(false);
                     bluetoothManager->device()->changeResistance((resistance_t)(round(inc * bikeResistanceGain)) +
                                                                  bikeResistanceOffset + 1); // resistance start from 1
                     
@@ -1228,6 +1244,7 @@ void trainprogram::scheduler() {
                     bluetoothManager->device()->setInclination(inc);
 
                 qDebug() << QStringLiteral("trainprogram change inclination due to gps") + QString::number(inc);
+                setErgMode(false);
                 emit changeInclination(inc, inc);
                 if (bluetoothManager->device()->deviceType() == TREADMILL)
                     emit changeNextInclination300Meters(avgInclinationNext300Meters());
@@ -1433,6 +1450,7 @@ void trainprogram::applyCurrentStepSettings() {
         return;
 
     QSettings settings;
+    auto setErgMode = [&settings](bool enabled) { settings.setValue(QZSettings::zwift_erg, enabled); };
     emit intervalTransitionApplied();
 
     if (bluetoothManager->device()->deviceType() == TREADMILL) {
@@ -1455,12 +1473,14 @@ void trainprogram::applyCurrentStepSettings() {
                 inc = rows.at(currentStep).inclination;
             }
             qDebug() << QStringLiteral("trainprogram change inclination") + QString::number(inc);
+            setErgMode(false);
             emit changeInclination(inc, inc);
             emit changeNextInclination300Meters(avgInclinationNext300Meters());
         }
         if (rows.at(currentStep).power != -1) {
             qDebug() << QStringLiteral("trainprogram change power ") +
                             QString::number(rows.at(currentStep).power);
+            setErgMode(true);
             emit changePower(rows.at(currentStep).power);
         }
     } else if (bluetoothManager->device()->deviceType() == ROWING) {
@@ -1483,17 +1503,20 @@ void trainprogram::applyCurrentStepSettings() {
         if (rows.at(currentStep).power != -1) {
             qDebug() << QStringLiteral("trainprogram change power ") +
                             QString::number(rows.at(currentStep).power);
+            setErgMode(true);
             emit changePower(rows.at(currentStep).power);
         }
         if (rows.at(currentStep).resistance != -1) {
             qDebug() << QStringLiteral("trainprogram change resistance ") +
                             QString::number(rows.at(currentStep).resistance);
+            setErgMode(false);
             emit changeResistance(rows.at(currentStep).resistance);
         }
     } else {
         if (rows.at(currentStep).resistance != -1) {
             qDebug() << QStringLiteral("trainprogram change resistance ") +
                             QString::number(rows.at(currentStep).resistance);
+            setErgMode(false);
             emit changeResistance(rows.at(currentStep).resistance);
         }
         if (rows.at(currentStep).cadence != -1) {
@@ -1504,11 +1527,13 @@ void trainprogram::applyCurrentStepSettings() {
         if (rows.at(currentStep).power != -1) {
             qDebug() << QStringLiteral("trainprogram change power ") +
                             QString::number(rows.at(currentStep).power);
+            setErgMode(true);
             emit changePower(rows.at(currentStep).power);
         }
         if (rows.at(currentStep).requested_peloton_resistance != -1) {
             qDebug() << QStringLiteral("trainprogram change requested peloton resistance ") +
                             QString::number(rows.at(currentStep).requested_peloton_resistance);
+            setErgMode(false);
             emit changeRequestedPelotonResistance(rows.at(currentStep).requested_peloton_resistance);
         }
         if (rows.at(currentStep).inclination != -200 &&
@@ -1537,6 +1562,7 @@ void trainprogram::applyCurrentStepSettings() {
                     settings.value(QZSettings::bike_resistance_offset, QZSettings::default_bike_resistance_offset).toInt();
                 double bikeResistanceGain =
                     settings.value(QZSettings::bike_resistance_gain_f, QZSettings::default_bike_resistance_gain_f).toDouble();
+                setErgMode(false);
                 bluetoothManager->device()->changeResistance((resistance_t)(round(inc * bikeResistanceGain)) +
                                                              bikeResistanceOffset + 1);
             }
@@ -1547,6 +1573,7 @@ void trainprogram::applyCurrentStepSettings() {
             if (bluetoothManager->device()->deviceType() == BIKE ||
                 (isElliptical && ellipticalInclinationByHardware)) {
                 qDebug() << QStringLiteral("trainprogram change inclination") + QString::number(inc);
+                setErgMode(false);
                 emit changeInclination(inc, inc);
                 emit changeNextInclination300Meters(inclinationNext300Meters());
             }

--- a/src/virtualdevices/virtualbike.cpp
+++ b/src/virtualdevices/virtualbike.cpp
@@ -1,6 +1,7 @@
 #include "virtualdevices/virtualbike.h"
 #include "devices/bike.h"
 #include "devices/echelonconnectsport/echelonconnectsport.h"
+#include "devices/ftmsbike/ftmsbike.h"
 #include <QThread>
 #include <QDataStream>
 #include <QMetaEnum>
@@ -1469,6 +1470,16 @@ void virtualbike::bikeProvider() {
             uint8_t ftms_message[255];
             int ret = h->virtualbike_getLastFTMSMessage(ftms_message);
             if (ret > 0) {
+                QSettings settings;
+                if (ftms_message[0] == FTMS_SET_TARGET_POWER) {
+                    settings.setValue(QZSettings::zwift_erg, true);
+                    erg_mode = true;
+                } else if (ftms_message[0] == FTMS_SET_TARGET_INCLINATION ||
+                           ftms_message[0] == FTMS_SET_TARGET_RESISTANCE_LEVEL ||
+                           ftms_message[0] == FTMS_SET_INDOOR_BIKE_SIMULATION_PARAMS) {
+                    settings.setValue(QZSettings::zwift_erg, false);
+                    erg_mode = false;
+                }
                 lastFTMSFrameReceived = QDateTime::currentMSecsSinceEpoch();
                 qDebug() << "FTMS rcv << " << QByteArray::fromRawData((char *)ftms_message, ret).toHex(' ');
                 emit ftmsCharacteristicChanged(QLowEnergyCharacteristic(),

--- a/src/virtualdevices/virtualrower.cpp
+++ b/src/virtualdevices/virtualrower.cpp
@@ -322,6 +322,15 @@ virtualrower::virtualrower(bluetoothdevice *t, bool noWriteResistance, bool noHe
 void virtualrower::characteristicChanged(const QLowEnergyCharacteristic &characteristic, const QByteArray &newValue) {
     QByteArray reply;
     QSettings settings;
+    if (characteristic.uuid().toUInt16() == 0x2AD9 && !newValue.isEmpty() &&
+        newValue.at(0) == FTMS_SET_TARGET_POWER) {
+        settings.setValue(QZSettings::zwift_erg, true);
+    } else if (characteristic.uuid().toUInt16() == 0x2AD9 && !newValue.isEmpty() &&
+               (newValue.at(0) == FTMS_SET_TARGET_INCLINATION ||
+                newValue.at(0) == FTMS_SET_TARGET_RESISTANCE_LEVEL ||
+                newValue.at(0) == FTMS_SET_INDOOR_BIKE_SIMULATION_PARAMS)) {
+        settings.setValue(QZSettings::zwift_erg, false);
+    }
     bool erg_mode = settings.value(QZSettings::zwift_erg, QZSettings::default_zwift_erg).toBool();
     qDebug() << QStringLiteral("characteristicChanged ") + QString::number(characteristic.uuid().toUInt16()) +
                     QStringLiteral(" ") + newValue.toHex(' ');


### PR DESCRIPTION
Closes #4882

## Summary
- Keep the existing `zwift_erg` setting and override it from incoming FTMS/Dircon control frames.
- Enable ERG for target-power commands and disable it for inclination, simulation, and resistance commands.
- Apply the same override to training-program targets and power/resistance/inclination tiles.
- Update the iOS FTMS replay path immediately when a new control frame arrives.

## Validation
- `git diff --check` passed for all PR files.
- The available Qt iOS qmake dry-run was attempted; a full build could not complete because the local CoreSimulator service is unavailable.