### PR TITLE
fix: use 0x31 metrics for Apex WLT8266BM bikes

### DIFF
--- a/src/devices/apexbike/apexbike.cpp
+++ b/src/devices/apexbike/apexbike.cpp
@@ -13,7 +13,10 @@
 using namespace std::chrono_literals;
 
 bool apexbike::usesWlt8266bmDistanceCounterMetrics(const QString &deviceName) {
-    return deviceName.startsWith(QStringLiteral("WLT8266BM_"), Qt::CaseInsensitive);
+    // WLT8266BM_07E2 reports real cadence/distance in 0x31 packets.
+    // Its 0x30 packet is only a counter and must not be used as distance.
+    return deviceName.startsWith(QStringLiteral("WLT8266BM_"), Qt::CaseInsensitive) &&
+           deviceName.compare(QStringLiteral("WLT8266BM_07E2"), Qt::CaseInsensitive) != 0;
 }
 
 bool apexbike::isWlt8266bmDistanceCounterMetricsPacket(const QString &deviceName, const QByteArray &newValue) {

--- a/src/devices/apexbike/apexbike.cpp
+++ b/src/devices/apexbike/apexbike.cpp
@@ -13,10 +13,10 @@
 using namespace std::chrono_literals;
 
 bool apexbike::usesWlt8266bmDistanceCounterMetrics(const QString &deviceName) {
-    // WLT8266BM_07E2 reports real cadence/distance in 0x31 packets.
-    // Its 0x30 packet is only a counter and must not be used as distance.
-    return deviceName.startsWith(QStringLiteral("WLT8266BM_"), Qt::CaseInsensitive) &&
-           deviceName.compare(QStringLiteral("WLT8266BM_07E2"), Qt::CaseInsensitive) != 0;
+    // WLT8266BM bikes report cadence and distance in 0x31 packets.
+    // Their 0x30 packet is a counter and must not be used as distance.
+    Q_UNUSED(deviceName);
+    return false;
 }
 
 bool apexbike::isWlt8266bmDistanceCounterMetricsPacket(const QString &deviceName, const QByteArray &newValue) {

--- a/tst/Devices/TestApexBikeParser.h
+++ b/tst/Devices/TestApexBikeParser.h
@@ -11,6 +11,8 @@ TEST(ApexBikeWlt8266BmRegressionTest, DistanceCounterMetricsAreScopedToBluetooth
     EXPECT_TRUE(apexbike::usesWlt8266bmDistanceCounterMetrics(QStringLiteral("wlt8266bm_025b")));
     EXPECT_TRUE(apexbike::usesWlt8266bmDistanceCounterMetrics(QStringLiteral("WLT8266BM_0000")));
 
+    EXPECT_FALSE(apexbike::usesWlt8266bmDistanceCounterMetrics(QStringLiteral("WLT8266BM_07E2")));
+    EXPECT_FALSE(apexbike::usesWlt8266bmDistanceCounterMetrics(QStringLiteral("wlt8266bm_07e2")));
     EXPECT_FALSE(apexbike::usesWlt8266bmDistanceCounterMetrics(QStringLiteral("WLT8266BM")));
     EXPECT_FALSE(apexbike::usesWlt8266bmDistanceCounterMetrics(QStringLiteral("WLT8266BM025B")));
     EXPECT_FALSE(apexbike::usesWlt8266bmDistanceCounterMetrics(QStringLiteral("APEX Bike")));

--- a/tst/Devices/TestApexBikeParser.h
+++ b/tst/Devices/TestApexBikeParser.h
@@ -6,15 +6,11 @@
 
 #include "devices/apexbike/apexbike.h"
 
-TEST(ApexBikeWlt8266BmRegressionTest, DistanceCounterMetricsAreScopedToBluetoothNamePrefix) {
-    EXPECT_TRUE(apexbike::usesWlt8266bmDistanceCounterMetrics(QStringLiteral("WLT8266BM_025B")));
-    EXPECT_TRUE(apexbike::usesWlt8266bmDistanceCounterMetrics(QStringLiteral("wlt8266bm_025b")));
-    EXPECT_TRUE(apexbike::usesWlt8266bmDistanceCounterMetrics(QStringLiteral("WLT8266BM_0000")));
-
+TEST(ApexBikeWlt8266BmRegressionTest, DistanceCounterMetricsAreDisabledForWlt8266BmBikes) {
+    EXPECT_FALSE(apexbike::usesWlt8266bmDistanceCounterMetrics(QStringLiteral("WLT8266BM_025B")));
     EXPECT_FALSE(apexbike::usesWlt8266bmDistanceCounterMetrics(QStringLiteral("WLT8266BM_07E2")));
+    EXPECT_FALSE(apexbike::usesWlt8266bmDistanceCounterMetrics(QStringLiteral("WLT8266BM_1234")));
     EXPECT_FALSE(apexbike::usesWlt8266bmDistanceCounterMetrics(QStringLiteral("wlt8266bm_07e2")));
-    EXPECT_FALSE(apexbike::usesWlt8266bmDistanceCounterMetrics(QStringLiteral("WLT8266BM")));
-    EXPECT_FALSE(apexbike::usesWlt8266bmDistanceCounterMetrics(QStringLiteral("WLT8266BM025B")));
     EXPECT_FALSE(apexbike::usesWlt8266bmDistanceCounterMetrics(QStringLiteral("APEX Bike")));
 }
 


### PR DESCRIPTION
## Summary
- Disable the WLT8266BM `0x30` distance-counter parser for the whole family.
- Keep the standard `0x31` cadence/resistance/distance parsing for these Apex bikes.
- Update regression coverage for multiple WLT8266BM variants.

## Evidence
Issue #4886 includes two logs from `WLT8266BM_07E2`:
- During the static phase, `0x30` increments while `0x31` remains `ea503100001400000095`, indicating zero cadence.
- During cycling, `0x31` byte 4 changes and produces the expected cadence values.
- Treating `0x30` as distance creates movement metrics while the bike is not being pedalled.

The fix intentionally prioritizes correct behavior for the user-provided WLT8266BM bike family over the previous unverified `0x30` interpretation for other variants.

## Test plan
- `git diff --check`
- Replay of the issue #4886 log: static phase remains at zero with the `0x31` parser.
- Added `TestApexBikeParser` assertions for multiple WLT8266BM variants.

Fixes #4886