### PR TITLE
fix: prevent stale DirCon callback crash after disconnect

### DIFF
--- a/src/devices/dircon/dirconprocessor.cpp
+++ b/src/devices/dircon/dirconprocessor.cpp
@@ -280,48 +280,60 @@ bool DirconProcessor::sendCharacteristicNotification(quint16 uuid, const QByteAr
 }
 
 void DirconProcessor::tcpDataAvailable() {
-    QTcpSocket *socket = qobject_cast<QTcpSocket *>(sender());
-    DirconProcessorClient *client = clientsMap.value(socket);
+    QObject *source = sender();
+    if (!source)
+        return;
+
+    // A queued readyRead callback can arrive after tcpDisconnected() removed
+    // the socket from clientsMap() and scheduled it for deletion. Do not use
+    // qobject_cast() or dereference the socket until it is known to be active.
+    QTcpSocket *socket = static_cast<QTcpSocket *>(source);
+    auto clientIt = clientsMap.constFind(socket);
+    if (clientIt == clientsMap.constEnd() || !clientIt.value()) {
+        qDebug() << "Ignoring stale Dircon data callback for" << serverName;
+        return;
+    }
+
+    DirconProcessorClient *client = clientIt.value();
     QByteArray data = socket->readAll();
     qDebug() << "Data available for uuid " << serverName << ":" << data.toHex();
-    if (client) {
-        int buflimit, rembuf;
-        client->buffer.append(data);
-        while (1) {
-            DirconPacket pkt;
-            buflimit = pkt.parse(client->buffer, client->seq);
-            qDebug() << "Pkt for uuid" << serverName << "parsed rv=" << buflimit << " ->" << pkt;
-            if (buflimit > 0) {
-                rembuf = buflimit;
-                if (pkt.isRequest)
-                    client->seq = pkt.SequenceNumber;
-                else if (pkt.Identifier != DPKT_MSGID_UNSOLICITED_CHARACTERISTIC_NOTIFICATION)
-                    client->seq += 1;
-            } else if (buflimit < DPKT_PARSE_ERROR) {
-                rembuf = -buflimit - DPKT_PARSE_ERROR;
-                qDebug() << "Unexpected packet" << client->buffer.mid(0, rembuf).toHex();
-            } else
-                rembuf = -1;
-            if (rembuf >= 0)
-                client->buffer = client->buffer.mid(rembuf);
-            if (buflimit > 0) {
-                DirconPacket resp = processPacket(client, pkt);
-                qDebug() << "Sending resp for uuid" << serverName << ":" << resp;
-                if (resp.Identifier != DPKT_MSGID_ERROR) {
-                    QByteArray byteout = resp.encode(pkt.SequenceNumber);
-                    if (byteout.size() && client && client->sock)
-                        client->sock->write(byteout);
-                }
-            } else if (rembuf >= 0) {
-                DirconPacket resp;
-                resp.isRequest = false;
-                resp.ResponseCode = DPKT_RESPCODE_UNEXPECTED_ERROR;
-                resp.Identifier = pkt.Identifier;
+
+    int buflimit, rembuf;
+    client->buffer.append(data);
+    while (1) {
+        DirconPacket pkt;
+        buflimit = pkt.parse(client->buffer, client->seq);
+        qDebug() << "Pkt for uuid" << serverName << "parsed rv=" << buflimit << " ->" << pkt;
+        if (buflimit > 0) {
+            rembuf = buflimit;
+            if (pkt.isRequest)
+                client->seq = pkt.SequenceNumber;
+            else if (pkt.Identifier != DPKT_MSGID_UNSOLICITED_CHARACTERISTIC_NOTIFICATION)
+                client->seq += 1;
+        } else if (buflimit < DPKT_PARSE_ERROR) {
+            rembuf = -buflimit - DPKT_PARSE_ERROR;
+            qDebug() << "Unexpected packet" << client->buffer.mid(0, rembuf).toHex();
+        } else
+            rembuf = -1;
+        if (rembuf >= 0)
+            client->buffer = client->buffer.mid(rembuf);
+        if (buflimit > 0) {
+            DirconPacket resp = processPacket(client, pkt);
+            qDebug() << "Sending resp for uuid" << serverName << ":" << resp;
+            if (resp.Identifier != DPKT_MSGID_ERROR) {
                 QByteArray byteout = resp.encode(pkt.SequenceNumber);
                 if (byteout.size() && client && client->sock)
                     client->sock->write(byteout);
-            } else
-                break;
-        }
+            }
+        } else if (rembuf >= 0) {
+            DirconPacket resp;
+            resp.isRequest = false;
+            resp.ResponseCode = DPKT_RESPCODE_UNEXPECTED_ERROR;
+            resp.Identifier = pkt.Identifier;
+            QByteArray byteout = resp.encode(pkt.SequenceNumber);
+            if (byteout.size() && client && client->sock)
+                client->sock->write(byteout);
+        } else
+            break;
     }
 }

--- a/tst/ToolTests/dircontestsuite.cpp
+++ b/tst/ToolTests/dircontestsuite.cpp
@@ -1,0 +1,75 @@
+#include "dircontestsuite.h"
+
+#include "../../src/devices/dircon/dirconpacket.h"
+#include "../../src/devices/dircon/dirconprocessor.h"
+
+#include <QCoreApplication>
+#include <QEventLoop>
+#include <QHostAddress>
+#include <QElapsedTimer>
+#include <QTcpServer>
+#include <QTcpSocket>
+
+namespace {
+
+void processEventsFor(int milliseconds) {
+    QElapsedTimer timer;
+    timer.start();
+    while (timer.elapsed() < milliseconds)
+        QCoreApplication::processEvents(QEventLoop::AllEvents, 1);
+}
+
+} // namespace
+
+TEST_F(DirconTestSuite, IncompleteFrameReturnsWaitWithoutReadingPayload) {
+    QByteArray frame;
+    frame.append(char(1));
+    frame.append(char(DPKT_MSGID_READ_CHARACTERISTIC));
+    frame.append(char(1));
+    frame.append(char(DPKT_RESPCODE_SUCCESS_REQUEST));
+    frame.append(char(0));
+    frame.append(char(16));
+    frame.append(char(0));
+
+    DirconPacket packet;
+    EXPECT_EQ(packet.parse(frame, 0), DPKT_PARSE_WAIT);
+}
+
+TEST_F(DirconTestSuite, QueuedDataCallbackAfterDisconnectIsSafe) {
+    QList<DirconProcessorService *> services;
+    DirconProcessor processor(services, QStringLiteral("test-dircon"), 0, QStringLiteral("test"),
+                              QStringLiteral("00:00:00:00:00:00"));
+    ASSERT_TRUE(processor.init());
+    auto *server = processor.findChild<QTcpServer *>();
+    ASSERT_NE(server, nullptr);
+    ASSERT_TRUE(server->isListening());
+
+    QByteArray frame;
+    frame.append(char(1));
+    frame.append(char(DPKT_MSGID_READ_CHARACTERISTIC));
+    frame.append(char(1));
+    frame.append(char(DPKT_RESPCODE_SUCCESS_REQUEST));
+    frame.append(char(0));
+    frame.append(char(16));
+    frame.append(char(0));
+
+    QTcpSocket clientSocket;
+    clientSocket.connectToHost(QHostAddress::LocalHost, server->serverPort());
+    ASSERT_TRUE(clientSocket.waitForConnected(1000));
+    processEventsFor(1); // Let tcpNewConnection() create the server-side client.
+
+    const auto serverSockets = server->findChildren<QTcpSocket *>();
+    ASSERT_EQ(serverSockets.size(), 1);
+    QTcpSocket *serverSocket = serverSockets.first();
+
+    // tcpDisconnected() is already connected directly by tcpNewConnection().
+    // This second connection queues the same data callback after the direct
+    // disconnect handler has removed the client and scheduled the socket for
+    // deletion. It models a stale callback delivered during Zwift shutdown.
+    ASSERT_TRUE(QObject::connect(serverSocket, SIGNAL(disconnected()), &processor,
+                                 SLOT(tcpDataAvailable()), Qt::QueuedConnection));
+
+    ASSERT_EQ(clientSocket.write(frame), frame.size());
+    clientSocket.abort();
+    processEventsFor(20);
+}

--- a/tst/ToolTests/dircontestsuite.h
+++ b/tst/ToolTests/dircontestsuite.h
@@ -1,0 +1,9 @@
+#ifndef DIRCONTESTSUITE_H
+#define DIRCONTESTSUITE_H
+
+#include "gtest/gtest.h"
+
+class DirconTestSuite : public testing::Test {
+};
+
+#endif // DIRCONTESTSUITE_H

--- a/tst/qdomyos-zwift-tests.pro
+++ b/tst/qdomyos-zwift-tests.pro
@@ -23,6 +23,7 @@ SOURCES += \
         GarminConnect/garminconnecttestsuite.cpp \
         TrainingProgram/trainprogramtestsuite.cpp \
         ToolTests/qfittestsuite.cpp \
+        ToolTests/dircontestsuite.cpp \
         ToolTests/testsettingstestsuite.cpp \
         ToolTests/testtrainingloadtestsuite.cpp \
         ToolTests/zwiftworkouttestsuite.cpp \
@@ -69,6 +70,7 @@ HEADERS += \
     GarminConnect/garminconnecttestsuite.h \
     TrainingProgram/trainprogramtestsuite.h \
     ToolTests/qfittestsuite.h \
+    ToolTests/dircontestsuite.h \
     ToolTests/testsettingstestsuite.h \
     ToolTests/testtrainingloadtestsuite.h \
     ToolTests/zwiftworkouttestsuite.h \


### PR DESCRIPTION
## Summary
- Guard DirCon TCP data handling against callbacks arriving after a peer disconnects.
- Add regression coverage for an incomplete frame followed by a queued callback after disconnect.

## Reference
Addresses an iOS crash observed during DirCon peer shutdown, where a queued socket callback could run after the client had been removed from the active connection map.

## Test plan
- `qmake qdomyos-zwift.pro -o Makefile && make -j2`
- `cd tst && ./qdomyos-zwift-tests --gtest_filter='DirconTestSuite.*' --gtest_color=no`

## Notes
- No behavior changes for active DirCon connections.
- Stale callbacks are ignored before socket reads or packet parsing.