### PR TITLE
fix: require iOS 15 for App Store updates

### DIFF
--- a/build-qdomyos-zwift-Qt_5_15_2_for_iOS-Debug/qdomyoszwift.xcodeproj/project.pbxproj
+++ b/build-qdomyos-zwift-Qt_5_15_2_for_iOS-Debug/qdomyoszwift.xcodeproj/project.pbxproj
@@ -4730,6 +4730,7 @@
 					../../Qt/5.15.2/ios/include/QtCore/5.15.2/QtCore/,
 					../../Qt/5.15.2/ios/include/QtSql,
 				);
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LIBRARY_SEARCH_PATHS = (
 					/Users/cagnulein/Qt/5.15.2/ios/plugins/platforms,
 					/System/Library/Frameworks/,
@@ -4933,6 +4934,7 @@
 					../../Qt/5.15.2/ios/include/QtCore/5.15.2/QtCore/,
 					../../Qt/5.15.2/ios/include/QtSql,
 				);
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LIBRARY_SEARCH_PATHS = (
 					/Users/cagnulein/Qt/5.15.2/ios/plugins/platforms,
 					/System/Library/Frameworks/,


### PR DESCRIPTION
## Summary
- Set the iOS deployment target to iOS 15 for the main app Debug and Release configurations.
- Keep the existing watchOS deployment target unchanged at watchOS 5.0.

## Context
Apple will require App Store app updates to support iOS 15 or later starting in spring 2027. This PR intentionally contains only the iOS 15 requirement and does not include the watchOS changes from #4708.

## Test plan
- [x] Verified the diff contains only the two iOS deployment-target changes.
- [x] Verified `git diff --check`.
- [ ] Build and archive on macOS/Xcode.