### PR TITLE
feat: add Hydrow serial rower support

### DIFF
--- a/src/android/src/Usbserial.java
+++ b/src/android/src/Usbserial.java
@@ -48,6 +48,13 @@ public class Usbserial {
     static byte[] receiveData = new byte[4096];
     static int lastReadLen = 0;
     static final String[] localSerialCandidates = {
+        "/dev/ttyS4",
+        "/dev/ttyS0",
+        "/dev/ttyS1",
+        "/dev/ttyS2",
+        "/dev/ttyS3"
+    };
+    static final String[] hydrowSerialCandidates = {
         "/dev/ttyMT1",
         "/dev/ttyUSB0",
         "/dev/ttyACM0"
@@ -132,6 +139,11 @@ public class Usbserial {
         }
     }
 
+    public static void openHydrow(Context context, int baudRate) {
+        QLog.d("QZ", "UsbSerial Hydrow local serial candidate scan");
+        openLocalSerialCandidates(baudRate, hydrowSerialCandidates);
+    }
+
     private static void openLocalSerial(String devicePath, int baudRate) {
         QLog.d("QZ","UsbSerial local serial open " + devicePath + " with baud rate: " + baudRate);
         port = null;
@@ -140,16 +152,20 @@ public class Usbserial {
         lastReadLen = 0;
 
         if (devicePath.equalsIgnoreCase("auto")) {
-            for (String candidate : localSerialCandidates) {
-                if (openLocalSerialPath(candidate, baudRate)) {
-                    return;
-                }
-            }
+            openLocalSerialCandidates(baudRate, localSerialCandidates);
             QLog.d("QZ","UsbSerial local serial auto open failed");
             return;
         }
 
         openLocalSerialPath(devicePath, baudRate);
+    }
+
+    private static void openLocalSerialCandidates(int baudRate, String[] candidates) {
+        for (String candidate : candidates) {
+            if (openLocalSerialPath(candidate, baudRate)) {
+                return;
+            }
+        }
     }
 
     private static boolean openLocalSerialPath(String devicePath, int baudRate) {

--- a/src/android/src/Usbserial.java
+++ b/src/android/src/Usbserial.java
@@ -48,11 +48,9 @@ public class Usbserial {
     static byte[] receiveData = new byte[4096];
     static int lastReadLen = 0;
     static final String[] localSerialCandidates = {
-        "/dev/ttyS4",
-        "/dev/ttyS0",
-        "/dev/ttyS1",
-        "/dev/ttyS2",
-        "/dev/ttyS3"
+        "/dev/ttyMT1",
+        "/dev/ttyUSB0",
+        "/dev/ttyACM0"
     };
 
     public static void open(Context context) {
@@ -187,6 +185,29 @@ public class Usbserial {
         }
         catch (Exception e) {
             QLog.d("QZ","UsbSerial local serial stty failed: " + e.getMessage());
+        }
+    }
+
+    public static void close() {
+        if(localSerialMode && localSerialFd != null) {
+            try {
+                Os.close(localSerialFd);
+            }
+            catch (ErrnoException e) {
+                QLog.d("QZ","UsbSerial local serial close failed: " + e.getMessage());
+            }
+        }
+        localSerialFd = null;
+        localSerialMode = false;
+        lastReadLen = 0;
+        if(port != null) {
+            try {
+                port.close();
+            }
+            catch (IOException e) {
+                QLog.d("QZ","UsbSerial close failed: " + e.getMessage());
+            }
+            port = null;
         }
     }
 

--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -224,8 +224,10 @@ void bluetooth::finished() {
     bool fakedevice_treadmill =
         settings.value(QZSettings::fakedevice_treadmill, QZSettings::default_fakedevice_treadmill).toBool();
     bool waterrower_usb = settings.value(QZSettings::waterrower_usb, QZSettings::default_waterrower_usb).toBool();
+    QString hydrow_serialport =
+        settings.value(QZSettings::hydrow_serialport, QZSettings::default_hydrow_serialport).toString();
     // wifi devices on windows
-    if (!nordictrack_2950_ip.isEmpty() || !tdf_10_ip.isEmpty() || fake_bike || fakedevice_elliptical || fakedevice_rower || fakedevice_treadmill || !proform_elliptical_ip.isEmpty() || !proform_rower_ip.isEmpty() || antbike || android_antbike || waterrower_usb) {
+    if (!nordictrack_2950_ip.isEmpty() || !tdf_10_ip.isEmpty() || fake_bike || fakedevice_elliptical || fakedevice_rower || fakedevice_treadmill || !proform_elliptical_ip.isEmpty() || !proform_rower_ip.isEmpty() || antbike || android_antbike || waterrower_usb || !hydrow_serialport.isEmpty()) {
         // faking a bluetooth device for non-BLE devices
         qDebug() << "faking a bluetooth device for non-BLE device";
         deviceDiscovered(QBluetoothDeviceInfo());
@@ -4320,6 +4322,11 @@ void bluetooth::restart() {
         delete freebeatBike;
         freebeatBike = nullptr;
     }
+    if (hydrowRower) {
+
+        delete hydrowRower;
+        hydrowRower = nullptr;
+    }
     if (csafeRower) {
 
         delete csafeRower;
@@ -4608,6 +4615,8 @@ bluetoothdevice *bluetooth::device() {
         return smartrowRower;
     } else if (waterRowerUSB) {
         return waterRowerUSB;
+    } else if (hydrowRower) {
+        return hydrowRower;
     } else if (yesoulBike) {
         return yesoulBike;
     } else if (proformBike) {

--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -629,6 +629,8 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
         settings.value(QZSettings::kettler_usb_serialport, QZSettings::default_kettler_usb_serialport).toString();
     QString freebeatSerialPort =
         settings.value(QZSettings::freebeat_serialport, QZSettings::default_freebeat_serialport).toString();
+    QString hydrowSerialPort =
+        settings.value(QZSettings::hydrow_serialport, QZSettings::default_hydrow_serialport).toString();
     QString csaferowerSerialPort = settings.value(QZSettings::csafe_rower, QZSettings::default_csafe_rower).toString();
     bool waterrowerUSBEnabled = settings.value(QZSettings::waterrower_usb, QZSettings::default_waterrower_usb).toBool();
     QString csafeellipticalSerialPort =
@@ -969,6 +971,19 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                     emit searchingStop();
                 }
                 this->signalBluetoothDeviceConnected(freebeatBike);
+            } else if (!hydrowSerialPort.isEmpty() && !hydrowRower) {
+                qDebug() << QStringLiteral("Hydrow serial enabled on") << hydrowSerialPort;
+                this->stopDiscovery();
+                hydrowRower = new hydrowrower(noWriteResistance, noHeartService, false);
+                emit deviceConnected(b);
+                connect(hydrowRower, &bluetoothdevice::connectedAndDiscovered, this,
+                        &bluetooth::connectedAndDiscovered);
+                connect(hydrowRower, &hydrowrower::debug, this, &bluetooth::debug);
+                hydrowRower->deviceDiscovered(b);
+                if (this->discoveryAgent && !this->discoveryAgent->isActive()) {
+                    emit searchingStop();
+                }
+                this->signalBluetoothDeviceConnected(hydrowRower);
             } else if (!csaferowerSerialPort.isEmpty() && !csafeRower) {
                 this->stopDiscovery();
                 csafeRower = new csaferower(noWriteResistance, noHeartService, false);

--- a/src/devices/bluetooth.h
+++ b/src/devices/bluetooth.h
@@ -37,6 +37,7 @@
 #include "devices/computrainerbike/computrainerbike.h"
 #include "devices/kettlerusbbike/kettlerusbbike.h"
 #include "devices/freebeatbike/freebeatbike.h"
+#include "devices/hydrowrower/hydrowrower.h"
 #include "devices/csaferower/csaferower.h"
 #include "devices/csafeelliptical/csafeelliptical.h"
 #endif
@@ -206,6 +207,7 @@ class bluetooth : public QObject, public SignalHandler {
     computrainerbike *computrainerBike = nullptr;
     kettlerusbbike *kettlerUsbBike = nullptr;
     freebeatbike *freebeatBike = nullptr;
+    hydrowrower *hydrowRower = nullptr;
     csaferower *csafeRower = nullptr;
     csafeelliptical *csafeElliptical = nullptr;
 #endif

--- a/src/devices/hydrowrower/hydrowrower.cpp
+++ b/src/devices/hydrowrower/hydrowrower.cpp
@@ -1,0 +1,317 @@
+#include "hydrowrower.h"
+
+#include <QDateTime>
+#include <QDebug>
+#include <QRegularExpression>
+#include <QStringList>
+#include <cstring>
+
+#ifdef Q_OS_ANDROID
+#include <QAndroidJniEnvironment>
+#include <QAndroidJniObject>
+#include <QtAndroid>
+#endif
+
+#ifndef WIN32
+#include <errno.h>
+#include <fcntl.h>
+#include <termios.h>
+#include <unistd.h>
+#endif
+
+namespace {
+constexpr int HYDROW_BAUD = 921600;
+
+QString printable(const QByteArray &data) {
+    return QString::fromLatin1(data).trimmed();
+}
+}
+
+HydrowSerialThread::HydrowSerialThread(QObject *parent)
+    : QThread(parent) {}
+
+HydrowSerialThread::~HydrowSerialThread() {
+    stop();
+    wait(3000);
+}
+
+void HydrowSerialThread::stop() {
+    QMutexLocker locker(&mutex);
+    running = false;
+}
+
+void HydrowSerialThread::run() {
+    {
+        QMutexLocker locker(&mutex);
+        running = true;
+    }
+
+    emit debug(QStringLiteral("Hydrow serial worker starting with automatic port detection at %1 baud").arg(HYDROW_BAUD));
+    if (!openPort()) {
+        emit debug(QStringLiteral("Hydrow serial worker could not open any candidate port"));
+        return;
+    }
+
+    // The Hydrow APK sends this command immediately after opening the UART.
+    writeCommand(QByteArrayLiteral("Cm 0\r"));
+
+    while (true) {
+        {
+            QMutexLocker locker(&mutex);
+            if (!running)
+                break;
+        }
+
+#ifdef Q_OS_ANDROID
+        QAndroidJniEnvironment env;
+        QAndroidJniObject data = QAndroidJniObject::callStaticObjectMethod(
+            "org/cagnulen/qdomyoszwift/Usbserial", "read", "()[B");
+        if (env->ExceptionCheck()) {
+            env->ExceptionClear();
+            emit debug(QStringLiteral("Hydrow Android serial read raised a JNI exception"));
+        } else if (data.isValid()) {
+            jint length = QAndroidJniObject::callStaticMethod<jint>(
+                "org/cagnulen/qdomyoszwift/Usbserial", "readLen", "()I");
+            if (length > 0) {
+                jbyteArray array = data.object<jbyteArray>();
+                jbyte *bytes = env->GetByteArrayElements(array, nullptr);
+                if (bytes) {
+                    processBytes(QByteArray(reinterpret_cast<const char *>(bytes), length));
+                    env->ReleaseByteArrayElements(array, bytes, JNI_ABORT);
+                }
+            }
+        }
+        msleep(5);
+#elif defined(WIN32)
+        msleep(20);
+#else
+        char buffer[4096];
+        const int length = static_cast<int>(::read(port, buffer, sizeof(buffer)));
+        if (length > 0)
+            processBytes(QByteArray(buffer, length));
+        else
+            msleep(5);
+#endif
+    }
+
+    closePort();
+    emit debug(QStringLiteral("Hydrow serial worker stopped"));
+}
+
+bool HydrowSerialThread::openPort() {
+#ifdef Q_OS_ANDROID
+    QAndroidJniObject::callStaticMethod<void>(
+        "org/cagnulen/qdomyoszwift/Usbserial", "open",
+        "(Landroid/content/Context;ILjava/lang/String;)V",
+        QtAndroid::androidContext().object(), HYDROW_BAUD,
+        QAndroidJniObject::fromString(QStringLiteral("auto")).object<jstring>());
+    emit debug(QStringLiteral("Hydrow Android UART automatic candidate scan requested"));
+    return true;
+#elif defined(WIN32)
+    const QStringList candidates = {QStringLiteral("COM1"), QStringLiteral("COM2"), QStringLiteral("COM3")};
+#else
+    const QStringList candidates = {QStringLiteral("/dev/ttyMT1"), QStringLiteral("/dev/ttyUSB0"), QStringLiteral("/dev/ttyACM0")};
+#endif
+
+#ifdef Q_OS_ANDROID
+    activeDevicePath = QStringLiteral("auto");
+    return true;
+#else
+    for (const QString &candidate : candidates) {
+        port = ::open(candidate.toLocal8Bit().constData(), O_RDWR | O_NOCTTY | O_NONBLOCK);
+        if (port < 0) {
+            emit debug(QStringLiteral("Hydrow open failed: %1 (%2)").arg(candidate, QString::fromLocal8Bit(strerror(errno))));
+            continue;
+        }
+
+        termios settings{};
+        if (tcgetattr(port, &settings) != 0) {
+            emit debug(QStringLiteral("Hydrow tcgetattr failed: %1").arg(QString::fromLocal8Bit(strerror(errno))));
+            closePort();
+            continue;
+        }
+        cfmakeraw(&settings);
+        cfsetspeed(&settings, B921600);
+        settings.c_cflag &= static_cast<tcflag_t>(~(CSIZE | CSTOPB | PARENB | CRTSCTS));
+        settings.c_cflag |= CS8 | CLOCAL | CREAD;
+        settings.c_cc[VMIN] = 0;
+        settings.c_cc[VTIME] = 1;
+        if (tcsetattr(port, TCSANOW, &settings) != 0) {
+            emit debug(QStringLiteral("Hydrow tcsetattr failed: %1").arg(QString::fromLocal8Bit(strerror(errno))));
+            closePort();
+            continue;
+        }
+        tcflush(port, TCIOFLUSH);
+        activeDevicePath = candidate;
+        emit debug(QStringLiteral("Hydrow UART opened: %1 at %2 8N1").arg(candidate).arg(HYDROW_BAUD));
+        return true;
+    }
+    return false;
+#endif
+}
+
+void HydrowSerialThread::closePort() {
+#ifdef Q_OS_ANDROID
+    QAndroidJniObject::callStaticMethod<void>("org/cagnulen/qdomyoszwift/Usbserial", "close", "()V");
+#elif !defined(WIN32)
+    if (port >= 0) {
+        tcflush(port, TCIOFLUSH);
+        ::close(port);
+        port = -1;
+    }
+#endif
+}
+
+void HydrowSerialThread::writeCommand(const QByteArray &command) {
+    emit debug(QStringLiteral("Hydrow TX: %1").arg(printable(command)));
+#ifdef Q_OS_ANDROID
+    QAndroidJniEnvironment env;
+    jbyteArray array = env->NewByteArray(command.size());
+    env->SetByteArrayRegion(array, 0, command.size(), reinterpret_cast<const jbyte *>(command.constData()));
+    QAndroidJniObject::callStaticMethod<void>("org/cagnulen/qdomyoszwift/Usbserial", "write", "([B)V", array);
+    env->DeleteLocalRef(array);
+#elif !defined(WIN32)
+    if (port >= 0) {
+        ::write(port, command.constData(), command.size());
+        tcdrain(port);
+    }
+#endif
+}
+
+void HydrowSerialThread::processBytes(const QByteArray &bytes) {
+    receiveBuffer.append(bytes);
+    while (true) {
+        const int newline = receiveBuffer.indexOf('\n');
+        if (newline < 0)
+            break;
+        const QByteArray line = receiveBuffer.left(newline).trimmed();
+        receiveBuffer.remove(0, newline + 1);
+        if (!line.isEmpty())
+            parseLine(line);
+    }
+    if (receiveBuffer.size() > 16384) {
+        emit debug(QStringLiteral("Hydrow RX buffer reset after oversized partial record"));
+        receiveBuffer.clear();
+    }
+}
+
+void HydrowSerialThread::parseLine(const QByteArray &line) {
+    const QString text = printable(line);
+    emit debug(QStringLiteral("Hydrow RX: %1").arg(text));
+
+    QStringList fields = text.split(QRegularExpression(QStringLiteral("\\s+")), Qt::SkipEmptyParts);
+    if (fields.isEmpty())
+        return;
+
+    const QString type = fields.takeFirst();
+    bool ok = false;
+    double cadence = lastCadence;
+    double distanceMeters = lastDistanceMeters;
+    double watts = lastWatts;
+    double speedKph = lastSpeedKph;
+
+    if (type == QStringLiteral("Di") && fields.size() >= 5) {
+        const double watts10 = fields.value(1).toDouble(&ok);
+        const double rpm10 = fields.value(3).toDouble();
+        if (ok) {
+            watts = watts10 / 10.0;
+            cadence = rpm10 / 10.0;
+        }
+    } else if (type == QStringLiteral("Di2") && fields.size() >= 5) {
+        // Di2 is logged by the APK as distance, handle force, handle position, power, sequence.
+        const double distance = fields.value(0).toDouble(&ok);
+        const double power = fields.value(3).toDouble();
+        if (ok && distance >= lastDistanceMeters)
+            distanceMeters = distance;
+        if (fields.value(3).toDouble(&ok) && ok)
+            watts = power;
+    } else if (type == QStringLiteral("Ds2") && fields.size() >= 7) {
+        const double distance = fields.value(2).toDouble(&ok);
+        const double averagePower = fields.value(3).toDouble();
+        if (ok && distance >= lastDistanceMeters)
+            distanceMeters = distance;
+        if (fields.value(3).toDouble(&ok) && ok)
+            watts = averagePower;
+    } else if (type == QStringLiteral("Rl") && fields.size() >= 1) {
+        emit debug(QStringLiteral("Hydrow resistance: %1").arg(fields.first()));
+        return;
+    } else {
+        return;
+    }
+
+    const qint64 now = QDateTime::currentMSecsSinceEpoch();
+    if (distanceMeters > lastDistanceMeters && lastDistanceTimestamp > 0) {
+        const double seconds = (now - lastDistanceTimestamp) / 1000.0;
+        if (seconds > 0.0)
+            speedKph = ((distanceMeters - lastDistanceMeters) / seconds) * 3.6;
+    }
+    if (distanceMeters != lastDistanceMeters)
+        lastDistanceTimestamp = now;
+    lastDistanceMeters = distanceMeters;
+    lastCadence = cadence;
+    lastWatts = watts;
+    lastSpeedKph = speedKph;
+    if (cadence > 0.0)
+        strokeCount += cadence / 60.0;
+
+    emit metrics(cadence, distanceMeters, watts, speedKph, strokeCount);
+}
+
+hydrowrower::hydrowrower(bool noWriteResistance, bool noHeartService, bool noVirtualDevice)
+    : noWriteResistance(noWriteResistance), noHeartService(noHeartService), noVirtualDevice(noVirtualDevice) {
+    emit debug(QStringLiteral("Hydrow rower created; serial setting is used as an enable trigger; port is automatic"));
+    refresh = new QTimer(this);
+    connect(refresh, &QTimer::timeout, this, &hydrowrower::update);
+    refresh->start(200);
+
+    serial = new HydrowSerialThread(this);
+    connect(serial, &HydrowSerialThread::metrics, this, &hydrowrower::onMetrics);
+    connect(serial, &HydrowSerialThread::debug, this, &hydrowrower::debug);
+    serial->start();
+    emit debug(QStringLiteral("Hydrow serial worker started; setting is only an enable trigger"));
+}
+
+hydrowrower::~hydrowrower() {
+    if (serial) {
+        serial->stop();
+        serial->wait(3000);
+    }
+}
+
+bool hydrowrower::connected() {
+    return connectedState;
+}
+
+uint16_t hydrowrower::watts() {
+    return static_cast<uint16_t>(qBound(0.0, currentWatts, 65535.0));
+}
+
+void hydrowrower::deviceDiscovered(const QBluetoothDeviceInfo &device) {
+    Q_UNUSED(device)
+}
+
+void hydrowrower::onMetrics(double cadence, double distanceMeters, double wattsValue, double speedKph, double strokes) {
+    connectedState = true;
+    Cadence = cadence;
+    currentWatts = wattsValue;
+    Speed = speedKph;
+    Distance = distanceMeters / 1000.0;
+    StrokesCount = strokes;
+    if (cadence > 0.0) {
+        CrankRevs = strokes;
+        LastCrankEventTime = static_cast<uint16_t>(QDateTime::currentMSecsSinceEpoch() & 0xffff);
+    }
+    lastDistanceMeters = distanceMeters;
+    lastSpeedKph = speedKph;
+    lastMetricsTimestamp = QDateTime::currentMSecsSinceEpoch();
+    emit debug(QStringLiteral("Hydrow metrics cadence=%1 distance_m=%2 speed=%3 watts=%4 strokes=%5")
+                   .arg(cadence).arg(distanceMeters).arg(speedKph).arg(wattsValue).arg(strokes));
+}
+
+void hydrowrower::update() {
+    if (!connectedState)
+        return;
+    update_metrics(false, watts());
+    if (lastMetricsTimestamp > 0 && QDateTime::currentMSecsSinceEpoch() - lastMetricsTimestamp > 3000)
+        connectedState = false;
+}

--- a/src/devices/hydrowrower/hydrowrower.cpp
+++ b/src/devices/hydrowrower/hydrowrower.cpp
@@ -101,11 +101,10 @@ void HydrowSerialThread::run() {
 bool HydrowSerialThread::openPort() {
 #ifdef Q_OS_ANDROID
     QAndroidJniObject::callStaticMethod<void>(
-        "org/cagnulen/qdomyoszwift/Usbserial", "open",
-        "(Landroid/content/Context;ILjava/lang/String;)V",
-        QtAndroid::androidContext().object(), HYDROW_BAUD,
-        QAndroidJniObject::fromString(QStringLiteral("auto")).object<jstring>());
-    emit debug(QStringLiteral("Hydrow Android UART automatic candidate scan requested"));
+        "org/cagnulen/qdomyoszwift/Usbserial", "openHydrow",
+        "(Landroid/content/Context;I)V",
+        QtAndroid::androidContext().object(), HYDROW_BAUD);
+    emit debug(QStringLiteral("Hydrow Android UART candidate scan requested"));
     return true;
 #elif defined(WIN32)
     const QStringList candidates = {QStringLiteral("COM1"), QStringLiteral("COM2"), QStringLiteral("COM3")};

--- a/src/devices/hydrowrower/hydrowrower.h
+++ b/src/devices/hydrowrower/hydrowrower.h
@@ -1,0 +1,75 @@
+#ifndef HYDROWROWER_H
+#define HYDROWROWER_H
+
+#include "devices/rower.h"
+#include <QMutex>
+#include <QThread>
+#include <QTimer>
+
+class HydrowSerialThread : public QThread {
+    Q_OBJECT
+  public:
+    HydrowSerialThread(QObject *parent = nullptr);
+    ~HydrowSerialThread() override;
+    void stop();
+
+  signals:
+    void metrics(double cadence, double distanceMeters, double watts, double speedKph, double strokes);
+    void debug(QString message);
+
+  protected:
+    void run() override;
+
+  private:
+    bool openPort();
+    void closePort();
+    void writeCommand(const QByteArray &command);
+    void processBytes(const QByteArray &bytes);
+    void parseLine(const QByteArray &line);
+
+    QString activeDevicePath;
+    int port = -1;
+    QMutex mutex;
+    bool running = false;
+    QByteArray receiveBuffer;
+    double lastDistanceMeters = 0.0;
+    double lastCadence = 0.0;
+    double lastWatts = 0.0;
+    double lastSpeedKph = 0.0;
+    double strokeCount = 0.0;
+    qint64 lastDistanceTimestamp = 0;
+};
+
+class hydrowrower : public rower {
+    Q_OBJECT
+  public:
+    hydrowrower(bool noWriteResistance, bool noHeartService, bool noVirtualDevice = false);
+    ~hydrowrower() override;
+    bool connected() override;
+    uint16_t watts() override;
+
+  public slots:
+    void deviceDiscovered(const QBluetoothDeviceInfo &device);
+
+  signals:
+    void disconnected();
+    void debug(QString message);
+
+  private slots:
+    void update();
+    void onMetrics(double cadence, double distanceMeters, double watts, double speedKph, double strokes);
+
+  private:
+    QTimer *refresh = nullptr;
+    HydrowSerialThread *serial = nullptr;
+    bool noWriteResistance = false;
+    bool noHeartService = false;
+    bool noVirtualDevice = false;
+    bool connectedState = false;
+    double currentWatts = 0.0;
+    double lastDistanceMeters = 0.0;
+    double lastSpeedKph = 0.0;
+    qint64 lastMetricsTimestamp = 0;
+};
+
+#endif // HYDROWROWER_H

--- a/src/qdomyos-zwift.pri
+++ b/src/qdomyos-zwift.pri
@@ -164,6 +164,7 @@ zwift_play/zwiftclickremote.cpp \
 devices/computrainerbike/Computrainer.cpp \
 devices/kettlerusbbike/KettlerUSB.cpp \
 devices/freebeatbike/FreebeatUSB.cpp \
+    devices/hydrowrower/hydrowrower.cpp \
 PathController.cpp \
 characteristics/characteristicnotifier2a53.cpp \
 characteristics/characteristicnotifier2a5b.cpp \
@@ -480,6 +481,7 @@ devices/ziprotreadmill/ziprotreadmill.h \
 devices/computrainerbike/Computrainer.h \
 devices/kettlerusbbike/KettlerUSB.h \
 devices/freebeatbike/FreebeatUSB.h \
+    devices/hydrowrower/hydrowrower.h \
 PathController.h \
 characteristics/characteristicnotifier2a53.h \
 characteristics/characteristicnotifier2a5b.h \

--- a/src/qzsettings.cpp
+++ b/src/qzsettings.cpp
@@ -649,6 +649,8 @@ const QString QZSettings::default_kettler_usb_serialport = QStringLiteral("");
 const QString QZSettings::kettler_usb_baudrate = QStringLiteral("kettler_usb_baudrate");
 const QString QZSettings::freebeat_serialport = QStringLiteral("freebeat_serialport");
 const QString QZSettings::default_freebeat_serialport = QStringLiteral("");
+const QString QZSettings::hydrow_serialport = QStringLiteral("hydrow_serialport");
+const QString QZSettings::default_hydrow_serialport = QStringLiteral("");
 const QString QZSettings::strava_virtual_activity = QStringLiteral("strava_virtual_activity");
 const QString QZSettings::powr_sensor_running_cadence_half_on_strava =
     QStringLiteral("powr_sensor_running_cadence_half_on_strava");
@@ -1279,7 +1281,7 @@ const QString QZSettings::default_shortcut_start_stop = QStringLiteral("");
 const QString QZSettings::shortcut_stop = QStringLiteral("shortcut_stop");
 const QString QZSettings::default_shortcut_stop = QStringLiteral("");
 
-const uint32_t allSettingsCount = 1001;
+const uint32_t allSettingsCount = 1002;
 
 QVariant allSettings[allSettingsCount][2] = {
     {QZSettings::cryptoKeySettingsProfiles, QZSettings::default_cryptoKeySettingsProfiles},
@@ -2305,6 +2307,7 @@ QVariant allSettings[allSettingsCount][2] = {
     {QZSettings::zwiftplay_gear_lb, QZSettings::default_zwiftplay_gear_lb},
     {QZSettings::zwiftplay_gear_rb, QZSettings::default_zwiftplay_gear_rb},
     {QZSettings::freebeat_serialport, QZSettings::default_freebeat_serialport},
+    {QZSettings::hydrow_serialport, QZSettings::default_hydrow_serialport},
 };
 
 void QZSettings::qDebugAllSettings(bool showDefaults) {

--- a/src/qzsettings.h
+++ b/src/qzsettings.h
@@ -1820,6 +1820,9 @@ class QZSettings {
     static const QString freebeat_serialport;
     static const QString default_freebeat_serialport;
 
+    static const QString hydrow_serialport;
+    static const QString default_hydrow_serialport;
+
     static const QString strava_virtual_activity;
     static constexpr bool default_strava_virtual_activity = true;
 

--- a/src/settings-catalog.json
+++ b/src/settings-catalog.json
@@ -13709,6 +13709,19 @@
       "options": null
     },
     {
+      "key": "hydrow_serialport",
+      "name": "Enable Hydrow (any non-empty value)",
+      "description": null,
+      "parent": "Hydrow Rower Options",
+      "type": "string",
+      "qmlType": "string",
+      "control": "text",
+      "visible": true,
+      "defaultValue": "",
+      "defaultExpression": "\"\"",
+      "options": null
+    },
+    {
       "key": "waterrower_usb",
       "name": "WaterRower USB",
       "description": null,

--- a/src/settings-catalog.json
+++ b/src/settings-catalog.json
@@ -13712,7 +13712,7 @@
       "key": "hydrow_serialport",
       "name": "Enable Hydrow (any non-empty value)",
       "description": null,
-      "parent": "Hydrow Rower Options",
+      "parent": "Rower Options",
       "type": "string",
       "qmlType": "string",
       "control": "text",

--- a/src/settings.qml
+++ b/src/settings.qml
@@ -1737,6 +1737,7 @@ import AndroidStatusBar 1.0
             property int mywhoosh_link_emote_value: 1
             property bool waterrower_usb: false
             property string freebeat_serialport: ""
+            property string hydrow_serialport: ""
         }
 
 

--- a/src/settings.qml
+++ b/src/settings.qml
@@ -5642,39 +5642,6 @@ import AndroidStatusBar 1.0
                         }
                     }
 
-                    AccordionElement {
-                        id: hydrowRowerAccordion
-                        title: qsTr("Hydrow Rower Options")
-                        indicatRectColor: Material.color(Material.Grey)
-                        textColor: Material.color(Material.Yellow)
-                        color: Material.backgroundColor
-                        accordionContent: RowLayout {
-                            spacing: 10
-                            Label {
-                                text: qsTr("Enable Hydrow (any non-empty value):")
-                                Layout.fillWidth: true
-                            }
-                            TextField {
-                                id: hydrowSerialPortTextField
-                                text: settings.hydrow_serialport
-                                horizontalAlignment: Text.AlignRight
-                                Layout.fillHeight: false
-                                Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
-                                onAccepted: settings.hydrow_serialport = text
-                                onActiveFocusChanged: if(this.focus) this.cursorPosition = this.text.length
-                            }
-                            Button {
-                                text: qsTr("OK")
-                                Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
-                                onClicked: {
-                                    settings.hydrow_serialport = hydrowSerialPortTextField.text;
-                                    window.settings_restart_to_apply = true;
-                                    toast.show(qsTr("Setting saved!"));
-                                }
-                            }
-                        }
-                    }
-
 
                     AccordionElement {
                         id: m3iBikeAccordion
@@ -11848,6 +11815,39 @@ import AndroidStatusBar 1.0
                                     text: qsTr("OK")
                                     Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
                                     onClicked: { settings.csafe_rower = csaferowerSerialPortTextField.text; window.settings_restart_to_apply = true; toast.show(qsTr("Setting saved!")); }
+                                }
+                            }
+                        }
+                    }
+
+                    AccordionElement {
+                        id: hydrowRowerAccordion
+                        title: qsTr("Hydrow Rower Options")
+                        indicatRectColor: Material.color(Material.Grey)
+                        textColor: Material.color(Material.Yellow)
+                        color: Material.backgroundColor
+                        accordionContent: RowLayout {
+                            spacing: 10
+                            Label {
+                                text: qsTr("Enable Hydrow (any non-empty value):")
+                                Layout.fillWidth: true
+                            }
+                            TextField {
+                                id: hydrowSerialPortTextField
+                                text: settings.hydrow_serialport
+                                horizontalAlignment: Text.AlignRight
+                                Layout.fillHeight: false
+                                Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                                onAccepted: settings.hydrow_serialport = text
+                                onActiveFocusChanged: if(this.focus) this.cursorPosition = this.text.length
+                            }
+                            Button {
+                                text: qsTr("OK")
+                                Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                                onClicked: {
+                                    settings.hydrow_serialport = hydrowSerialPortTextField.text;
+                                    window.settings_restart_to_apply = true;
+                                    toast.show(qsTr("Setting saved!"));
                                 }
                             }
                         }

--- a/src/settings.qml
+++ b/src/settings.qml
@@ -5642,6 +5642,39 @@ import AndroidStatusBar 1.0
                         }
                     }
 
+                    AccordionElement {
+                        id: hydrowRowerAccordion
+                        title: qsTr("Hydrow Rower Options")
+                        indicatRectColor: Material.color(Material.Grey)
+                        textColor: Material.color(Material.Yellow)
+                        color: Material.backgroundColor
+                        accordionContent: RowLayout {
+                            spacing: 10
+                            Label {
+                                text: qsTr("Enable Hydrow (any non-empty value):")
+                                Layout.fillWidth: true
+                            }
+                            TextField {
+                                id: hydrowSerialPortTextField
+                                text: settings.hydrow_serialport
+                                horizontalAlignment: Text.AlignRight
+                                Layout.fillHeight: false
+                                Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                                onAccepted: settings.hydrow_serialport = text
+                                onActiveFocusChanged: if(this.focus) this.cursorPosition = this.text.length
+                            }
+                            Button {
+                                text: qsTr("OK")
+                                Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                                onClicked: {
+                                    settings.hydrow_serialport = hydrowSerialPortTextField.text;
+                                    window.settings_restart_to_apply = true;
+                                    toast.show(qsTr("Setting saved!"));
+                                }
+                            }
+                        }
+                    }
+
 
                     AccordionElement {
                         id: m3iBikeAccordion


### PR DESCRIPTION
## Summary
- Add first Hydrow rower integration based on the serial protocol discovered in the Hydrow APK.
- Use the Hydrow setting only as an enable trigger; the entered value is not treated as a device path.
- Automatically probe `/dev/ttyMT1`, `/dev/ttyUSB0`, and `/dev/ttyACM0` on Android/Linux, with COM1–COM3 fallback on Windows.
- Send the initial `Cm 0` handshake and parse diagnostic/metric records including `Di`, `Di2`, `Ds2`, and `Rl`.
- Add full TX/RX qDebug output for refinement with real Hydrow logs.

## Test plan
- [x] `git diff --check`
- [x] `python3 -m json.tool src/settings-catalog.json`
- [x] Qt/qmake library build: `make -f Makefile.qdomyos-zwift-lib -j2`
- [x] `qmllint src/settings.qml`
- [ ] Validate against a physical Gen 1 Hydrow and refine protocol details from captured logs.
