### PR TITLE
feat: add CARE bike support setting

### DIFF
--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -649,6 +649,8 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
     bool sole_inclination =
         settings.value(QZSettings::sole_treadmill_inclination, QZSettings::default_sole_treadmill_inclination).toBool();
     QString ftms_rower = settings.value(QZSettings::ftms_rower, QZSettings::default_ftms_rower).toString();
+    bool careBikeEnableSupport =
+        settings.value(QZSettings::care_bike_enable_support, QZSettings::default_care_bike_enable_support).toBool();
     QString ftms_bike = settings.value(QZSettings::ftms_bike, QZSettings::default_ftms_bike).toString();
     QString ftms_treadmill = settings.value(QZSettings::ftms_treadmill, QZSettings::default_ftms_treadmill).toString();
     QString ftms_elliptical = settings.value(QZSettings::ftms_elliptical, QZSettings::default_ftms_elliptical).toString();
@@ -2482,7 +2484,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                         ((b.name().toUpper().startsWith(QStringLiteral("HT")) && b.name().length() == 10) &&
                          ftms_bike.contains(QZSettings::default_ftms_bike)) ||
                         (b.name().toUpper().contains(QStringLiteral("CARE")) &&
-                         b.name().length() == 11)) // CARE9040177 - Carefitness CV-351
+                         (b.name().length() == 11 || careBikeEnableSupport))) // CARE9040177 - Carefitness CV-351
                        && !sportsPlusBike && filter) {
                 this->setLastBluetoothDevice(b);
                 this->stopDiscovery();
@@ -2498,7 +2500,8 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 // SLOT(inclinationChanged(double)));
                 sportsPlusBike->deviceDiscovered(b);
                 this->signalBluetoothDeviceConnected(sportsPlusBike);
-            } else if (((b.name().toUpper().contains(QStringLiteral("CARE")) && b.name().length() >= 12) ||  // CARE968300122, CARE10692135
+            } else if (((b.name().toUpper().contains(QStringLiteral("CARE")) && b.name().length() >= 12 &&
+                        !careBikeEnableSupport) ||  // CARE968300122, CARE10692135
                        (b.name().toUpper().startsWith(QStringLiteral("VMAX"))))
                        && !sportsPlusRower && filter) {
                 this->setLastBluetoothDevice(b);

--- a/src/qzsettings.cpp
+++ b/src/qzsettings.cpp
@@ -1120,6 +1120,8 @@ const QString QZSettings::applewatch_as_treadmill_speed = QStringLiteral("applew
 const QString QZSettings::horizon_treadmill_omega_z = QStringLiteral("horizon_treadmill_omega_z");
 const QString QZSettings::nordictrack_elliptical_s700 = QStringLiteral("nordictrack_elliptical_s700");
 
+const QString QZSettings::care_bike_enable_support = QStringLiteral("care_bike_enable_support");
+
 // Zwift Play/Ride per-button gear mapping
 const QString QZSettings::zwiftplay_gear_ls1 = QStringLiteral("zwiftplay_gear_ls1");
 const QString QZSettings::zwiftplay_gear_ls2 = QStringLiteral("zwiftplay_gear_ls2");
@@ -1280,7 +1282,7 @@ const QString QZSettings::default_shortcut_start_stop = QStringLiteral("");
 const QString QZSettings::shortcut_stop = QStringLiteral("shortcut_stop");
 const QString QZSettings::default_shortcut_stop = QStringLiteral("");
 
-const uint32_t allSettingsCount = 1002;
+const uint32_t allSettingsCount = 1003;
 
 QVariant allSettings[allSettingsCount][2] = {
     {QZSettings::cryptoKeySettingsProfiles, QZSettings::default_cryptoKeySettingsProfiles},
@@ -2307,6 +2309,7 @@ QVariant allSettings[allSettingsCount][2] = {
     {QZSettings::zwiftplay_gear_lb, QZSettings::default_zwiftplay_gear_lb},
     {QZSettings::zwiftplay_gear_rb, QZSettings::default_zwiftplay_gear_rb},
     {QZSettings::freebeat_serialport, QZSettings::default_freebeat_serialport},
+    {QZSettings::care_bike_enable_support, QZSettings::default_care_bike_enable_support},
 };
 
 void QZSettings::qDebugAllSettings(bool showDefaults) {

--- a/src/qzsettings.h
+++ b/src/qzsettings.h
@@ -3294,6 +3294,9 @@ class QZSettings {
      */
     static const QString nordictrack_elliptical_s700;
     static constexpr bool default_nordictrack_elliptical_s700 = false;
+
+    static const QString care_bike_enable_support;
+    static constexpr bool default_care_bike_enable_support = false;
     
     /**
      * @brief Per-button gear mapping for Zwift Play/Ride controllers.

--- a/src/settings-catalog.json
+++ b/src/settings-catalog.json
@@ -2,7 +2,7 @@
   "$schema": "https://qdomyos-zwift.local/settings-catalog.schema.json",
   "schemaVersion": 1,
   "format": "qdomyos-zwift-settings-catalog",
-  "settingCount": 966,
+  "settingCount": 967,
   "pages": [
     {
       "key": "page_custom_gear_table",
@@ -13726,6 +13726,19 @@
       "name": "WaterRower USB",
       "description": null,
       "parent": "Rower Options",
+      "type": "boolean",
+      "qmlType": "bool",
+      "control": "switch",
+      "visible": true,
+      "defaultValue": false,
+      "defaultExpression": "false",
+      "options": null
+    },
+    {
+      "key": "care_bike_enable_support",
+      "name": "Enable Support",
+      "description": "Treat CARE devices as bikes instead of rowers. Default is off.",
+      "parent": "Care Bike Options",
       "type": "boolean",
       "qmlType": "bool",
       "control": "switch",

--- a/src/settings.qml
+++ b/src/settings.qml
@@ -1738,6 +1738,7 @@ import AndroidStatusBar 1.0
             property bool waterrower_usb: false
             property string freebeat_serialport: ""
             property bool nordictrack_elliptical_s700: false
+            property bool care_bike_enable_support: false
         }
 
 
@@ -4490,6 +4491,20 @@ import AndroidStatusBar 1.0
                         Layout.fillWidth: true
                         color: Material.color(Material.Lime)
                     }                    
+
+                    AccordionElement {
+                        id: careBikeAccordion
+                        title: qsTr("Care Bike Options")
+                        indicatRectColor: Material.color(Material.Grey)
+                        textColor: Material.color(Material.Yellow)
+                        color: Material.backgroundColor
+                        accordionContent: IndicatorOnlySwitch {
+                            text: qsTr("Enable Support")
+                            checked: settings.care_bike_enable_support
+                            Layout.fillWidth: true
+                            onClicked: { settings.care_bike_enable_support = checked; window.settings_restart_to_apply = true; }
+                        }
+                    }
 
                     NewPageElement {
                         title: qsTr("Wahoo Options")

--- a/tst/Devices/deviceindex.cpp
+++ b/tst/Devices/deviceindex.cpp
@@ -136,6 +136,7 @@ DEFINE_DEVICE(SoleF80Treadmill2, "Sole F80 Treadmill 2");
 DEFINE_DEVICE(SoleF85Treadmill, "Sole F85 Treadmill");
 DEFINE_DEVICE(SpiritTreadmill, "Spirit Treadmill");
 DEFINE_DEVICE(SportsPlusBike, "Sports Plus Bike");
+DEFINE_DEVICE(CareBike_EnableSupport, "Care Bike (Enable Support)");
 DEFINE_DEVICE(SportsPlusRower, "Sports Plus Rower");
 DEFINE_DEVICE(SportsTechBike, "Sports Tech Bike");
 DEFINE_DEVICE(StagesBike_Assioma_PowerSensorDisabled, "Stages Bike (Assioma / Power Sensor disabled)");

--- a/tst/Devices/deviceindex.h
+++ b/tst/Devices/deviceindex.h
@@ -141,6 +141,7 @@ public:
     DEFINE_DEVICE(SoleF85Treadmill, "Sole F85 Treadmill");
     DEFINE_DEVICE(SpiritTreadmill, "Spirit Treadmill");
     DEFINE_DEVICE(SportsPlusBike, "Sports Plus Bike");
+    DEFINE_DEVICE(CareBike_EnableSupport, "Care Bike (Enable Support)");
     DEFINE_DEVICE(SportsPlusRower, "Sports Plus Rower");
     DEFINE_DEVICE(SportsTechBike, "Sports Tech Bike");
     DEFINE_DEVICE(StagesBike_Assioma_PowerSensorDisabled, "Stages Bike (Assioma / Power Sensor disabled)");

--- a/tst/Devices/devicetestdataindex.cpp
+++ b/tst/Devices/devicetestdataindex.cpp
@@ -1162,6 +1162,12 @@ void DeviceTestDataIndex::Initialize() {
         ->expectDevice<sportsplusbike>()        
         ->acceptDeviceName("CARDIOFIT", DeviceNameComparison::StartsWithIgnoreCase);
 
+    // Care Bike with support enabled
+    RegisterNewDeviceTestData(DeviceIndex::CareBike_EnableSupport)
+        ->expectDevice<sportsplusbike>()
+        ->acceptDeviceName("CARE10692135", DeviceNameComparison::IgnoreCase)
+        ->configureSettingsWith(QZSettings::care_bike_enable_support);
+
     // Sports Plus Rower
     RegisterNewDeviceTestData(DeviceIndex::SportsPlusRower)
         ->expectDevice<sportsplusrower>()


### PR DESCRIPTION
## Summary

- Add a new **Care Bike Options → Enable Support** setting.
- When enabled, CARE devices are handled as Sports Plus bikes instead of rowers.
- Keep the existing CARE-as-rower behavior unchanged when the setting is disabled.
- Add detection coverage for `CARE10692135` with support enabled.
- Reference: @xavrozno

## Screenshot

![Care bike support setting](https://github.com/cagnulein/qdomyos-zwift/blob/feat/care-bike-support/docs-care-bike-screenshot.png?raw=true)

## Test plan

- `git diff --check`
- Settings catalog and `allSettingsCount` consistency checks
- QMake configuration completed
- Full build attempted; blocked by the repository SMTP submodule/Qt moc linking setup in the environment. See commit validation notes.
