### PR TITLE
fix: parse 19-byte PASYOU bike packets

### DIFF
--- a/src/devices/trxappgateusbbike/trxappgateusbbike.cpp
+++ b/src/devices/trxappgateusbbike/trxappgateusbbike.cpp
@@ -237,7 +237,7 @@ void trxappgateusbbike::characteristicChanged(const QLowEnergyCharacteristic &ch
     lastPacket = newValue;
     if ((newValue.length() != 21 && (bike_type != JLL_IC400 && bike_type != ASVIVA && bike_type != FYTTER_RI08 &&
                                      bike_type != TUNTURI && bike_type != TUNTURI_2 && bike_type != TOORX_SRX_500 &&
-                                     bike_type != FAL_SPORTS && bike_type != HAMMER_SPEED_BIKE_S)) ||
+                                     bike_type != FAL_SPORTS && bike_type != PASYOU && bike_type != HAMMER_SPEED_BIKE_S)) ||
         (newValue.length() != 19 && (bike_type == JLL_IC400 || bike_type == ASVIVA || bike_type == FYTTER_RI08 ||
                                      bike_type == PASYOU || bike_type == HAMMER_SPEED_BIKE_S)) ||
         (newValue.length() != 20 && newValue.length() != 21 &&


### PR DESCRIPTION
## Summary

- Allow PASYOU 19-byte packets through the AppGate USB bike parser length guard.
- Fix missing speed, cadence, resistance, and power parsing for PASYOU-0526.

## Evidence

Discussion #4866 shows repeated 19-byte PASYOU packets received by
`trxappgateusbbike::characteristicChanged()`, followed by an immediate return
from the packet-length validation.

## Test plan

- Compiled `trxappgateusbbike.cpp` successfully.
- Verified `git diff --check`.
- Full build remains blocked by the pre-existing missing
  `smtpclient/src/SmtpMime` dependency.

Refs #4866
