### PR TITLE
fix: scale FTMS speed commands for Horizon T202

### DIFF
--- a/src/devices/horizontreadmill/horizontreadmill.cpp
+++ b/src/devices/horizontreadmill/horizontreadmill.cpp
@@ -1279,10 +1279,10 @@ void horizontreadmill::forceSpeed(double requestSpeed) {
         if(BOWFLEX_T9) {
             requestSpeed *= miles_conversion;   // this treadmill wants the speed in miles, at least seems so!!
         }
-        if(TM4800 || TM6500 || T3G_ELITE || WT_TREADMILL || THERUN_T15 || MERACH_TREADMILL) {
+        if(TM4800 || TM6500 || T3G_ELITE || WT_TREADMILL || THERUN_T15 || MERACH_TREADMILL || JFTM_T202) {
             bool miles = settings.value(QZSettings::miles_unit, QZSettings::default_miles_unit).toBool();
-            if(miles) {
-                requestSpeed *= miles_conversion;   // these treadmills want the speed in miles when miles_unit is enabled
+            if(miles || JFTM_T202) {
+                requestSpeed *= miles_conversion;   // JFTM T202 expects FTMS target speed in miles
             }
         }
         uint16_t speed_int = round(requestSpeed * 100);
@@ -2656,6 +2656,7 @@ void horizontreadmill::deviceDiscovered(const QBluetoothDeviceInfo &device) {
     {
         QSettings settings;
         bluetoothDevice = device;
+        JFTM_T202 = device.name().toUpper().startsWith(QStringLiteral("JFTM T202"));
 
         if (device.name().toUpper().startsWith(QStringLiteral("MOBVOI TMP"))) {
             mobvoi_tmp_treadmill = true;

--- a/src/devices/horizontreadmill/horizontreadmill.h
+++ b/src/devices/horizontreadmill/horizontreadmill.h
@@ -121,6 +121,7 @@ class horizontreadmill : public treadmill {
     bool FIT_TM = false;
     bool T3G_PRO = false;
     bool T3G_ELITE = false;
+    bool JFTM_T202 = false;
     bool TP1 = false;
     bool T01 = false;
     bool TM4800 = false;


### PR DESCRIPTION
## Summary

- Detects `JFTM T202*` Horizon treadmill devices.
- Converts the FTMS target-speed command from km/h to mph for this model family.
- Keeps the workaround scoped to the T202 and leaves other Horizon/FTMS treadmill paths unchanged.

## Background
**mail Horizon t202 on 9/8/2026**

The supplied debug log showed the treadmill interpreting FTMS speed commands with an approximately 1.609 scaling factor:

- QZ requested `1.0`, the treadmill reported approximately `1.6`.
- QZ requested `1.4`, the treadmill reported approximately `2.2`.
- A decrease command could therefore make the treadmill speed increase.

The log also showed that the FTMS path was active (`JFTM T202-5_4DEE`, FTMS service `0x1826`, Control Point `0x2AD9`, and `horizon_treadmill_force_ftms=true`).

## Implementation

The T202 is identified from the BLE name prefix and the target speed is converted with the existing `0.621371` miles conversion before encoding `FTMS_SET_TARGET_SPEED`.

## Test plan

- [x] `git diff --check`
- [x] Build QZ library with qmake/make (`build/`)
- [x] Verify the diff is limited to `horizontreadmill.cpp` and `horizontreadmill.h`
- [ ] Validate on a physical Horizon/JFTM T202 with `+` and `-`
