### PR TITLE
Recognize X100 bikes as VirtuFit Etappe 2.0i

### DIFF
--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -2928,6 +2928,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 snodeBike->deviceDiscovered(b);
                 this->signalBluetoothDeviceConnected(snodeBike);
             } else if (((b.name().startsWith(QStringLiteral("FS-")) && fitplus_bike) ||
+                        b.name().startsWith(QStringLiteral("X100-")) ||
                         (b.name().toUpper().startsWith("H9110 OSAKA")) ||
                         b.name().startsWith(QStringLiteral("MRK-"))) &&
                        !fitPlusBike && !ftmsBike && !ftmsRower && !snodeBike && !horizonTreadmill && !trxappgateusbRower && filter) {

--- a/src/devices/fitplusbike/fitplusbike.cpp
+++ b/src/devices/fitplusbike/fitplusbike.cpp
@@ -88,7 +88,8 @@ void fitplusbike::writeCharacteristic(uint8_t *data, uint8_t data_len, const QSt
 
 void fitplusbike::forceResistance(resistance_t requestResistance) {
     QSettings settings;
-    bool virtufit_etappe = settings.value(QZSettings::virtufit_etappe, QZSettings::default_virtufit_etappe).toBool();
+    bool virtufit_etappe = virtufitEtappe ||
+                           settings.value(QZSettings::virtufit_etappe, QZSettings::default_virtufit_etappe).toBool();
     bool sportstech_sx600 = settings.value(QZSettings::sportstech_sx600, QZSettings::default_sportstech_sx600).toBool();
     requestResistanceCompleted = false;
     if (virtufit_etappe || merach_MRK || H9110_OSAKA) {
@@ -304,8 +305,8 @@ void fitplusbike::update() {
                gattNotify1Characteristic.isValid() && initDone) {
         QSettings settings;
         update_metrics(false, watts());
-        bool virtufit_etappe =
-            settings.value(QZSettings::virtufit_etappe, QZSettings::default_virtufit_etappe).toBool();
+        bool virtufit_etappe = virtufitEtappe ||
+                               settings.value(QZSettings::virtufit_etappe, QZSettings::default_virtufit_etappe).toBool();
         bool sportstech_sx600 =
             settings.value(QZSettings::sportstech_sx600, QZSettings::default_sportstech_sx600).toBool();
 
@@ -413,7 +414,8 @@ void fitplusbike::characteristicChanged(const QLowEnergyCharacteristic &characte
 
     lastPacket = newValue;
 
-    bool virtufit_etappe = settings.value(QZSettings::virtufit_etappe, QZSettings::default_virtufit_etappe).toBool();
+    bool virtufit_etappe = virtufitEtappe ||
+                           settings.value(QZSettings::virtufit_etappe, QZSettings::default_virtufit_etappe).toBool();
     bool sportstech_sx600 = settings.value(QZSettings::sportstech_sx600, QZSettings::default_sportstech_sx600).toBool();
 
     if (sportstech_sx600 && characteristic.uuid() == QBluetoothUuid((quint16)0x2AD2)) {
@@ -752,7 +754,8 @@ double fitplusbike::bikeResistanceToPeloton(double resistance) {
 void fitplusbike::btinit() {
 
     QSettings settings;
-    bool virtufit_etappe = settings.value(QZSettings::virtufit_etappe, QZSettings::default_virtufit_etappe).toBool();
+    bool virtufit_etappe = virtufitEtappe ||
+                           settings.value(QZSettings::virtufit_etappe, QZSettings::default_virtufit_etappe).toBool();
     bool sportstech_sx600 = settings.value(QZSettings::sportstech_sx600, QZSettings::default_sportstech_sx600).toBool();
 
     if (merach_MRK) {
@@ -1014,6 +1017,9 @@ void fitplusbike::deviceDiscovered(const QBluetoothDeviceInfo &device) {
         if (device.name().startsWith(QStringLiteral("MRK-"))) {
             qDebug() << QStringLiteral("merach_MRK workaround enabled!");
             merach_MRK = true;
+        } else if (device.name().startsWith(QStringLiteral("X100-"))) {
+            qDebug() << QStringLiteral("VirtuFit Etappe 2.0i workaround enabled!");
+            virtufitEtappe = true;
         } else if (device.name().toUpper().startsWith("H9110 OSAKA")) {
             qDebug() << QStringLiteral("H9110 OSAKA workaround enabled!");
             max_resistance = 32;
@@ -1080,7 +1086,8 @@ void fitplusbike::controllerStateChanged(QLowEnergyController::ControllerState s
 
 uint16_t fitplusbike::wattsFromResistance(double resistance) {
     QSettings settings;
-    bool virtufit_etappe = settings.value(QZSettings::virtufit_etappe, QZSettings::default_virtufit_etappe).toBool();
+    bool virtufit_etappe = virtufitEtappe ||
+                           settings.value(QZSettings::virtufit_etappe, QZSettings::default_virtufit_etappe).toBool();
 
     // https://github.com/cagnulein/qdomyos-zwift/issues/62#issuecomment-736913564
     /*if(currentCadence().value() < 90)

--- a/src/devices/fitplusbike/fitplusbike.h
+++ b/src/devices/fitplusbike/fitplusbike.h
@@ -80,6 +80,7 @@ class fitplusbike : public bike {
 
     bool merach_MRK = false;
     bool H9110_OSAKA = false;
+    bool virtufitEtappe = false;
 
 #ifdef Q_OS_IOS
     lockscreen *h = 0;

--- a/tst/Devices/deviceindex.cpp
+++ b/tst/Devices/deviceindex.cpp
@@ -77,6 +77,7 @@ DEFINE_DEVICE(FakeRower, "Fake Rower");
 DEFINE_DEVICE(FakeTreadmill, "Fake Treadmill");
 DEFINE_DEVICE(FitPlusBike_MRK_NoSettings, "FitPlus Bike (MRK, no settings)");
 DEFINE_DEVICE(FitPlusF5, "FitPlus F5");
+DEFINE_DEVICE(FitPlusVirtufitEtappeX100, "FitPlus VirtuFit Etappe 2.0i (X100)");
 DEFINE_DEVICE(FitShowBF, "FitShow BF");
 DEFINE_DEVICE(FitShowFS, "FitShow FS");
 DEFINE_DEVICE(FitShowTR510T, "FitShow TR510-T");

--- a/tst/Devices/deviceindex.h
+++ b/tst/Devices/deviceindex.h
@@ -82,6 +82,7 @@ public:
     DEFINE_DEVICE(FakeTreadmill, "Fake Treadmill");
     DEFINE_DEVICE(FitPlusBike_MRK_NoSettings, "FitPlus Bike (MRK, no settings)");
     DEFINE_DEVICE(FitPlusF5, "FitPlus F5");
+    DEFINE_DEVICE(FitPlusVirtufitEtappeX100, "FitPlus VirtuFit Etappe 2.0i (X100)");
     DEFINE_DEVICE(FitShowBF, "FitShow BF");
     DEFINE_DEVICE(FitShowFS, "FitShow FS");
     DEFINE_DEVICE(FitShowTR510T, "FitShow TR510-T");

--- a/tst/Devices/devicetestdataindex.cpp
+++ b/tst/Devices/devicetestdataindex.cpp
@@ -387,6 +387,11 @@ void DeviceTestDataIndex::Initialize() {
         ->acceptDeviceName("FS-", DeviceNameComparison::StartsWith)
         ->configureSettingsWith( QZSettings::fitplus_bike);
 
+    // VirtuFit Etappe 2.0i
+    RegisterNewDeviceTestData(DeviceIndex::FitPlusVirtufitEtappeX100)
+        ->expectDevice<fitplusbike>()
+        ->acceptDeviceName("X100-", DeviceNameComparison::StartsWith);
+
 
     // FitPlus MRK
     RegisterNewDeviceTestData(DeviceIndex::FitPlusBike_MRK_NoSettings)


### PR DESCRIPTION
### Motivation

- Map physical devices advertising with the `X100-` Bluetooth name to the existing VirtuFit Etappe 2.0i behavior so X100 bikes behave like the VirtuFit Etappe device without requiring manual setting changes.

### Description

- Treat devices whose Bluetooth name starts with `X100-` as `fitplusbike` in the central discovery logic by adding the `X100-` prefix check to `bluetooth::deviceDiscovered` (`src/devices/bluetooth.cpp`).
- Add an instance flag `virtufitEtappe` to `fitplusbike` (`src/devices/fitplusbike/fitplusbike.h`).
- Enable VirtuFit Etappe behavior automatically for X100 devices by setting `virtufitEtappe = true` when the device is discovered and OR-ing that flag with the existing `virtufit_etappe` QSettings checks across `fitplusbike` code paths (`src/devices/fitplusbike/fitplusbike.cpp`).
- Add a test/devicedata entry so the device-discovery test index contains a case for the `X100-` prefix (`tst/Devices/devicetestdataindex.cpp`) and register a device index value (`tst/Devices/deviceindex.h` / `tst/Devices/deviceindex.cpp`).

### Testing

- Ran `git diff --check` to validate the patch formatting and it passed.
- Verified the new detection pattern and behavior gates via ripgrep searches for `X100-` and `virtufit_etappe` and found the expected edits in `src/devices/bluetooth.cpp` and `src/devices/fitplusbike/fitplusbike.cpp` respectively.
- Committed the changes (`Add X100 VirtuFit Etappe bike detection`) successfully; no CI tests were executed in this environment.
- Attempted `qmake -v` to run the Qt build/test suite but `qmake` is not available in the environment so the full test suite could not be run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a2184f41083258fc143dc0c7cd3b8)