### PR TITLE
Route XCX- devices to sportsplusbike

### DIFF
--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -1982,7 +1982,6 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                         (b.name().toUpper().startsWith("ROBX")) ||
                         (b.name().toUpper().startsWith("ORLAUF_ARES")) ||
                         (b.name().toUpper().startsWith("SPEEDMAGPRO")) ||                        
-                        (b.name().toUpper().startsWith("XCX-")) ||
                         (b.name().toUpper().startsWith("SMARTBIKE-")) ||
                         (b.name().toUpper().startsWith("D500V2")) ||
                         (b.name().toUpper().startsWith("FBIKE-HEAVY-PRO")) ||
@@ -2479,6 +2478,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 sportsTechRower->deviceDiscovered(b);
                 this->signalBluetoothDeviceConnected(sportsTechRower);
             } else if ((b.name().toUpper().startsWith(QStringLiteral("CARDIOFIT")) ||
+                        b.name().toUpper().startsWith(QStringLiteral("XCX-")) ||
                         ((b.name().toUpper().startsWith(QStringLiteral("HT")) && b.name().length() == 10) &&
                          ftms_bike.contains(QZSettings::default_ftms_bike)) ||
                         (b.name().toUpper().contains(QStringLiteral("CARE")) &&

--- a/tst/Devices/devicetestdataindex.cpp
+++ b/tst/Devices/devicetestdataindex.cpp
@@ -1160,7 +1160,7 @@ void DeviceTestDataIndex::Initialize() {
     // Sports Plus Bike
     RegisterNewDeviceTestData(DeviceIndex::SportsPlusBike)
         ->expectDevice<sportsplusbike>()        
-        ->acceptDeviceName("CARDIOFIT", DeviceNameComparison::StartsWithIgnoreCase);
+        ->acceptDeviceNames({"CARDIOFIT", "XCX-"}, DeviceNameComparison::StartsWithIgnoreCase);
 
     // Sports Plus Rower
     RegisterNewDeviceTestData(DeviceIndex::SportsPlusRower)


### PR DESCRIPTION
### Motivation
- Il prefisso Bluetooth `XCX-` deve essere interpretato come un dispositivo Sports Plus e instradato all'implementazione `sportsplusbike` invece che alla gestione FTMS generica per migliorare il riconoscimento di questi dispositivi.

### Description
- Spostata la corrispondenza `XCX-` nella condizione che crea `sportsplusbike` in `src/devices/bluetooth.cpp` e aggiornato il dataset di test in `tst/Devices/devicetestdataindex.cpp` per accettare i nomi che iniziano con `XCX-` oltre a `CARDIOFIT`.

### Testing
- Eseguiti controlli automatici: `git diff --check` è passato e ho verificato con `rg` che `XCX-` compare una sola volta nella logica di rilevamento in `bluetooth.cpp`, mentre la suite completa non è stata eseguita perché `qmake` non è disponibile nell'ambiente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a2ba43a5c8325b7ac101024dfe2ea)