### PR TITLE
Add xcxbike: proprietary FFF0/FFF6 telemetry bike and detection before FTMS

### DIFF
--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -4346,6 +4346,11 @@ void bluetooth::restart() {
         delete ftmsBike;
         ftmsBike = nullptr;
     }
+    if (xcxBike) {
+
+        delete xcxBike;
+        xcxBike = nullptr;
+    }
     if (wahooKickrSnapBike) {
 
         delete wahooKickrSnapBike;
@@ -4661,6 +4666,8 @@ bluetoothdevice *bluetooth::device() {
         return snodeBike;
     } else if (ftmsBike) {
         return ftmsBike;
+    } else if (xcxBike) {
+        return xcxBike;
     } else if (wahooKickrSnapBike) {
         return wahooKickrSnapBike;
     } else if (technogymBike) {

--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -1851,6 +1851,16 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 // connect(tacxneo2Bike, SIGNAL(inclinationChanged(double)), this, SLOT(inclinationChanged(double)));
                 tacxneo2Bike->deviceDiscovered(b);
                 this->signalBluetoothDeviceConnected(tacxneo2Bike);
+            } else if (b.name().toUpper().startsWith(QStringLiteral("XCX-")) && !xcxBike && filter) {
+                // XCX exposes FTMS, CSC and Cycling Power services, but its working telemetry is
+                // proprietary FFF6. This name-specific branch must remain before generic FTMS.
+                this->setLastBluetoothDevice(b);
+                this->stopDiscovery();
+                xcxBike = new xcxbike(noWriteResistance, noHeartService, bikeResistanceOffset, bikeResistanceGain);
+                emit deviceConnected(b);
+                connect(xcxBike, &bluetoothdevice::connectedAndDiscovered, this, &bluetooth::connectedAndDiscovered);
+                xcxBike->deviceDiscovered(b);
+                this->signalBluetoothDeviceConnected(xcxBike);
             } else if (((b.name().toUpper().startsWith("INDOORCYCLE")) ||
                         ((b.name().toUpper().startsWith("MAGNUS ")) && !deviceHasService(b, QBluetoothUuid((quint16)0x1826)))) &&
                        !cycleopsphantomBike && filter) {
@@ -1982,7 +1992,6 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                         (b.name().toUpper().startsWith("ROBX")) ||
                         (b.name().toUpper().startsWith("ORLAUF_ARES")) ||
                         (b.name().toUpper().startsWith("SPEEDMAGPRO")) ||                        
-                        (b.name().toUpper().startsWith("XCX-")) ||
                         (b.name().toUpper().startsWith("SMARTBIKE-")) ||
                         (b.name().toUpper().startsWith("D500V2")) ||
                         (b.name().toUpper().startsWith("FBIKE-HEAVY-PRO")) ||

--- a/src/devices/bluetooth.h
+++ b/src/devices/bluetooth.h
@@ -156,6 +156,7 @@
 #include "devices/ultrasportbike/ultrasportbike.h"
 #include "devices/wahookickrheadwind/wahookickrheadwind.h"
 #include "devices/wahookickrsnapbike/wahookickrsnapbike.h"
+#include "devices/xcxbike/xcxbike.h"
 #include "devices/yesoulbike/yesoulbike.h"
 #include "devices/ypooelliptical/ypooelliptical.h"
 #include "devices/ziprotreadmill/ziprotreadmill.h"
@@ -309,6 +310,7 @@ class bluetooth : public QObject, public SignalHandler {
     stagesbike *powerBike = nullptr;
     ultrasportbike *ultraSportBike = nullptr;
     wahookickrsnapbike *wahooKickrSnapBike = nullptr;
+    xcxbike *xcxBike = nullptr;
     ypooelliptical *ypooElliptical = nullptr;
     ziprotreadmill *ziproTreadmill = nullptr;
     kineticinroadbike *kineticInroadBike = nullptr;

--- a/src/devices/xcxbike/xcxbike.cpp
+++ b/src/devices/xcxbike/xcxbike.cpp
@@ -1,0 +1,219 @@
+#include "xcxbike.h"
+
+#ifdef Q_OS_ANDROID
+#include "keepawakehelper.h"
+#endif
+#include "qzsettings.h"
+#include "virtualdevices/virtualbike.h"
+
+#include <QDebug>
+#include <QSettings>
+
+#include <chrono>
+#include <cmath>
+
+using namespace std::chrono_literals;
+
+#ifdef Q_OS_IOS
+extern quint8 QZ_EnableDiscoveryCharsAndDescripttors;
+#endif
+
+namespace {
+const QBluetoothUuid fff0Uuid(QStringLiteral("0000fff0-0000-1000-8000-00805f9b34fb"));
+const QBluetoothUuid fff5Uuid(QStringLiteral("0000fff5-0000-1000-8000-00805f9b34fb"));
+const QBluetoothUuid fff6Uuid(QStringLiteral("0000fff6-0000-1000-8000-00805f9b34fb"));
+
+quint8 byteAt(const QByteArray &packet, int offset) { return static_cast<quint8>(packet.at(offset)); }
+
+quint16 le16(const QByteArray &packet, int offset) {
+    return static_cast<quint16>(byteAt(packet, offset)) | (static_cast<quint16>(byteAt(packet, offset + 1)) << 8);
+}
+
+quint32 le24(const QByteArray &packet, int offset) {
+    return static_cast<quint32>(byteAt(packet, offset)) | (static_cast<quint32>(byteAt(packet, offset + 1)) << 8) |
+           (static_cast<quint32>(byteAt(packet, offset + 2)) << 16);
+}
+} // namespace
+
+xcxbike::xcxbike(bool noWriteResistance, bool noHeartService, int8_t bikeResistanceOffset, double bikeResistanceGain)
+    : noWriteResistance(noWriteResistance), noHeartService(noHeartService), bikeResistanceOffset(bikeResistanceOffset),
+      bikeResistanceGain(bikeResistanceGain) {
+#ifdef Q_OS_IOS
+    QZ_EnableDiscoveryCharsAndDescripttors = true;
+#endif
+    m_watt.setType(metric::METRIC_WATT, deviceType());
+    Speed.setType(metric::METRIC_SPEED);
+    connect(&refresh, &QTimer::timeout, this, &xcxbike::update);
+    refresh.start(300ms);
+}
+
+bool xcxbike::parseTelemetry(const QByteArray &packet, XcxTelemetry *telemetry) {
+    if (!telemetry || packet.size() != 20 || byteAt(packet, 0) != 0xfa || byteAt(packet, 1) != 0x05)
+        return false;
+
+    telemetry->state1 = byteAt(packet, 2);
+    telemetry->state2 = byteAt(packet, 3);
+    telemetry->timer = le16(packet, 4);
+    telemetry->speedKph = le16(packet, 6) / 10.0;
+    telemetry->distanceRaw = le24(packet, 8);
+    telemetry->energy = le16(packet, 11);
+    telemetry->cadence = le16(packet, 13);
+    telemetry->unknown15 = le16(packet, 15);
+    // The capture only proves that byte 17 contains power up to 255 W. A new capture is required
+    // before treating any other byte as a high byte for larger power values.
+    telemetry->power = byteAt(packet, 17);
+    telemetry->resistance = le16(packet, 18);
+    return true;
+}
+
+void xcxbike::update() {
+    if (m_control && m_control->state() == QLowEnergyController::UnconnectedState)
+        emit disconnected();
+    if (notificationEnabled)
+        update_metrics(false, watts());
+
+    // This protocol is telemetry-only: no FFF5 command format was present in the capture.
+    requestResistance = -1;
+    if (requestStart != -1) {
+        requestStart = -1;
+        emit bikeStarted();
+    }
+    requestStop = -1;
+}
+
+void xcxbike::characteristicChanged(const QLowEnergyCharacteristic &characteristic, const QByteArray &value) {
+    if (characteristic.uuid() != fff6Uuid)
+        return;
+
+    XcxTelemetry telemetry;
+    if (!parseTelemetry(value, &telemetry)) {
+        qDebug() << QStringLiteral("XCX unexpected FFF6 packet") << value.size() << value.toHex(' ');
+        return;
+    }
+
+    qDebug() << QStringLiteral("XCX << raw:") << value.toHex(' ') << QStringLiteral("state1:") << telemetry.state1
+             << QStringLiteral("state2:") << telemetry.state2 << QStringLiteral("timer:") << telemetry.timer
+             << QStringLiteral("speed:") << telemetry.speedKph << QStringLiteral("distanceRaw:")
+             << telemetry.distanceRaw << QStringLiteral("energy:") << telemetry.energy << QStringLiteral("cadence:")
+             << telemetry.cadence << QStringLiteral("unknown15:") << telemetry.unknown15 << QStringLiteral("power:")
+             << telemetry.power << QStringLiteral("resistance:") << telemetry.resistance;
+
+    if (!receivedState || telemetry.state1 != lastState1 || telemetry.state2 != lastState2) {
+        qDebug() << QStringLiteral("XCX state changed") << lastState1 << lastState2 << QStringLiteral("->")
+                 << telemetry.state1 << telemetry.state2;
+        lastState1 = telemetry.state1;
+        lastState2 = telemetry.state2;
+        receivedState = true;
+    }
+
+    const QDateTime now = QDateTime::currentDateTime();
+    const qint64 elapsedMs = lastTelemetryTime.isValid() ? lastTelemetryTime.msecsTo(now) : 0;
+    Speed = telemetry.speedKph;
+    Cadence = telemetry.cadence;
+    m_watt = telemetry.power;
+    Resistance = telemetry.resistance;
+    KCal = telemetry.energy;
+    // The proprietary counter advances plausibly in 0.1 km units. It must not be interpreted as
+    // metres like the device's broken FTMS mirror does.
+    Distance = telemetry.distanceRaw / 10.0;
+
+    if (elapsedMs > 0 && elapsedMs < 10000 && telemetry.cadence > 0) {
+        partialCrankRevolution += telemetry.cadence * (elapsedMs / 60000.0);
+        const quint32 completedRevolutions = static_cast<quint32>(std::floor(partialCrankRevolution));
+        if (completedRevolutions) {
+            CrankRevs += completedRevolutions;
+            LastCrankEventTime += static_cast<quint16>(completedRevolutions * 1024.0 * 60.0 / telemetry.cadence);
+            partialCrankRevolution -= completedRevolutions;
+        }
+    }
+    lastTelemetryTime = now;
+
+#ifdef Q_OS_ANDROID
+    QSettings settings;
+    if (settings.value(QZSettings::ant_heart, QZSettings::default_ant_heart).toBool())
+        Heart = static_cast<uint8_t>(KeepAwakeHelper::heart());
+    else
+#endif
+        update_hr_from_external();
+}
+
+void xcxbike::serviceStateChanged(QLowEnergyService::ServiceState state) {
+    qDebug() << QStringLiteral("XCX FFF0 service state") << state;
+    if (state != QLowEnergyService::ServiceDiscovered)
+        return;
+
+    fff5WriteCharacteristic = fff0Service->characteristic(fff5Uuid);
+    fff6NotifyCharacteristic = fff0Service->characteristic(fff6Uuid);
+    if (!fff6NotifyCharacteristic.isValid()) {
+        qDebug() << QStringLiteral("XCX FFF6 notification characteristic not found");
+        return;
+    }
+    qDebug() << QStringLiteral("XCX FFF5 present for future protocol research:") << fff5WriteCharacteristic.isValid();
+    connect(fff0Service, &QLowEnergyService::characteristicChanged, this, &xcxbike::characteristicChanged);
+    connect(fff0Service, &QLowEnergyService::descriptorWritten, this, &xcxbike::descriptorWritten);
+    createVirtualBike();
+
+    const QLowEnergyDescriptor cccd =
+        fff6NotifyCharacteristic.descriptor(QBluetoothUuid::ClientCharacteristicConfiguration);
+    if (!cccd.isValid()) {
+        qDebug() << QStringLiteral("XCX FFF6 CCCD not found");
+        return;
+    }
+    fff0Service->writeDescriptor(cccd, QByteArray::fromHex("0100"));
+}
+
+void xcxbike::descriptorWritten(const QLowEnergyDescriptor &descriptor, const QByteArray &value) {
+    qDebug() << QStringLiteral("XCX descriptor written") << descriptor.uuid() << value.toHex(' ');
+    if (descriptor.uuid() == QBluetoothUuid::ClientCharacteristicConfiguration &&
+        value == QByteArray::fromHex("0100")) {
+        notificationEnabled = true;
+        emit connectedAndDiscovered();
+    }
+}
+
+void xcxbike::createVirtualBike() {
+    if (hasVirtualDevice())
+        return;
+    QSettings settings;
+    if (settings.value(QZSettings::virtual_device_enabled, QZSettings::default_virtual_device_enabled).toBool()) {
+        auto *virtualBike =
+            new virtualbike(this, noWriteResistance, noHeartService, bikeResistanceOffset, bikeResistanceGain);
+        connect(virtualBike, &virtualbike::changeInclination, this, &xcxbike::changeInclination);
+        setVirtualDevice(virtualBike, VIRTUAL_DEVICE_MODE::PRIMARY);
+    }
+}
+
+void xcxbike::serviceScanDone() {
+    fff0Service = m_control->createServiceObject(fff0Uuid, this);
+    if (!fff0Service) {
+        qDebug() << QStringLiteral("XCX proprietary FFF0 service not found");
+        return;
+    }
+    connect(fff0Service, &QLowEnergyService::stateChanged, this, &xcxbike::serviceStateChanged);
+    fff0Service->discoverDetails();
+}
+
+void xcxbike::deviceDiscovered(const QBluetoothDeviceInfo &device) {
+    bluetoothDevice = device;
+    m_control = QLowEnergyController::createCentral(bluetoothDevice, this);
+    connect(m_control, &QLowEnergyController::discoveryFinished, this, &xcxbike::serviceScanDone);
+    connect(m_control, &QLowEnergyController::stateChanged, this, &xcxbike::controllerStateChanged);
+    connect(m_control, &QLowEnergyController::connected, this, [this]() { m_control->discoverServices(); });
+    connect(m_control, &QLowEnergyController::disconnected, this, &xcxbike::disconnected);
+    m_control->connectToDevice();
+}
+
+void xcxbike::controllerStateChanged(QLowEnergyController::ControllerState state) {
+    qDebug() << QStringLiteral("XCX controller state") << state;
+    if (state == QLowEnergyController::UnconnectedState && m_control) {
+        notificationEnabled = false;
+        lastTelemetryTime = QDateTime();
+        m_control->connectToDevice();
+    }
+}
+
+bool xcxbike::connected() {
+    return m_control && m_control->state() == QLowEnergyController::DiscoveredState && notificationEnabled;
+}
+
+uint16_t xcxbike::watts() { return Cadence.value() == 0 ? 0 : static_cast<uint16_t>(m_watt.value()); }

--- a/src/devices/xcxbike/xcxbike.h
+++ b/src/devices/xcxbike/xcxbike.h
@@ -1,0 +1,76 @@
+#ifndef XCXBIKE_H
+#define XCXBIKE_H
+
+#include "devices/bike.h"
+
+#include <QBluetoothDeviceInfo>
+#include <QByteArray>
+#include <QDateTime>
+#include <QLowEnergyCharacteristic>
+#include <QLowEnergyController>
+#include <QLowEnergyService>
+#include <QTimer>
+
+struct XcxTelemetry {
+    XcxTelemetry(quint8 state1 = 0, quint8 state2 = 0, quint16 timer = 0, double speedKph = 0, quint32 distanceRaw = 0,
+                 quint16 energy = 0, quint16 cadence = 0, quint16 unknown15 = 0, quint16 power = 0,
+                 quint16 resistance = 0)
+        : state1(state1), state2(state2), timer(timer), speedKph(speedKph), distanceRaw(distanceRaw), energy(energy),
+          cadence(cadence), unknown15(unknown15), power(power), resistance(resistance) {}
+
+    quint8 state1 = 0;
+    quint8 state2 = 0;
+    quint16 timer = 0;
+    double speedKph = 0;
+    quint32 distanceRaw = 0;
+    quint16 energy = 0;
+    quint16 cadence = 0;
+    quint16 unknown15 = 0;
+    quint16 power = 0;
+    quint16 resistance = 0;
+};
+
+class xcxbike : public bike {
+    Q_OBJECT
+
+  public:
+    xcxbike(bool noWriteResistance, bool noHeartService, int8_t bikeResistanceOffset, double bikeResistanceGain);
+
+    static bool parseTelemetry(const QByteArray &packet, XcxTelemetry *telemetry);
+    bool connected() override;
+
+  public slots:
+    void deviceDiscovered(const QBluetoothDeviceInfo &device);
+
+  signals:
+    void disconnected();
+
+  private slots:
+    void characteristicChanged(const QLowEnergyCharacteristic &characteristic, const QByteArray &value);
+    void descriptorWritten(const QLowEnergyDescriptor &descriptor, const QByteArray &value);
+    void serviceScanDone();
+    void serviceStateChanged(QLowEnergyService::ServiceState state);
+    void controllerStateChanged(QLowEnergyController::ControllerState state);
+    void update();
+
+  private:
+    void createVirtualBike();
+    uint16_t watts() override;
+
+    QTimer refresh;
+    QLowEnergyService *fff0Service = nullptr;
+    QLowEnergyCharacteristic fff5WriteCharacteristic;
+    QLowEnergyCharacteristic fff6NotifyCharacteristic;
+    bool noWriteResistance;
+    bool noHeartService;
+    int8_t bikeResistanceOffset;
+    double bikeResistanceGain;
+    bool notificationEnabled = false;
+    quint8 lastState1 = 0;
+    quint8 lastState2 = 0;
+    bool receivedState = false;
+    QDateTime lastTelemetryTime;
+    double partialCrankRevolution = 0;
+};
+
+#endif // XCXBIKE_H

--- a/src/qdomyos-zwift.pri
+++ b/src/qdomyos-zwift.pri
@@ -339,6 +339,7 @@ devices/treadmill.cpp \
 devices/truetreadmill/truetreadmill.cpp \
 devices/trxappgateusbbike/trxappgateusbbike.cpp \
 devices/ultrasportbike/ultrasportbike.cpp \
+devices/xcxbike/xcxbike.cpp \
 virtualdevices/virtualrower.cpp \
 devices/wahookickrsnapbike/wahookickrsnapbike.cpp \
 devices/yesoulbike/yesoulbike.cpp \
@@ -875,6 +876,7 @@ devices/truetreadmill/truetreadmill.h \
 devices/trxappgateusbbike/trxappgateusbbike.h \
 devices/trxappgateusbtreadmill/trxappgateusbtreadmill.h \
 devices/ultrasportbike/ultrasportbike.h \
+devices/xcxbike/xcxbike.h \
 virtualdevices/virtualbike.h \
 virtualdevices/virtualrower.h \
 virtualdevices/virtualtreadmill.h \

--- a/tst/Devices/TestXcxBikeParser.cpp
+++ b/tst/Devices/TestXcxBikeParser.cpp
@@ -1,0 +1,45 @@
+#include "TestXcxBikeParser.h"
+
+TEST_P(XcxBikeParserTest, DecodesCapturedFff6Telemetry) {
+  XcxTelemetry actual;
+  ASSERT_TRUE(xcxbike::parseTelemetry(std::get<0>(GetParam()), &actual));
+  const XcxTelemetry &expected = std::get<1>(GetParam());
+  EXPECT_EQ(expected.state1, actual.state1);
+  EXPECT_EQ(expected.state2, actual.state2);
+  EXPECT_EQ(expected.timer, actual.timer);
+  EXPECT_DOUBLE_EQ(expected.speedKph, actual.speedKph);
+  EXPECT_EQ(expected.distanceRaw, actual.distanceRaw);
+  EXPECT_EQ(expected.energy, actual.energy);
+  EXPECT_EQ(expected.cadence, actual.cadence);
+  EXPECT_EQ(expected.unknown15, actual.unknown15);
+  EXPECT_EQ(expected.power, actual.power);
+  EXPECT_EQ(expected.resistance, actual.resistance);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    CapturedPackets, XcxBikeParserTest,
+    testing::Values(
+        std::make_tuple(
+            QByteArray::fromHex("fa0504003b00780000000001002e0000006e3c00"),
+            XcxTelemetry{4, 0, 59, 12.0, 0, 1, 46, 0, 110, 60}),
+        std::make_tuple(
+            QByteArray::fromHex("fa05040021009300010000200038000100823c00"),
+            XcxTelemetry{4, 0, 33, 14.7, 1, 32, 56, 1, 130, 60}),
+        std::make_tuple(
+            QByteArray::fromHex("fa0504000100d6000200004f0051000200b43c00"),
+            XcxTelemetry{4, 0, 1, 21.4, 2, 79, 81, 2, 180, 60}),
+        std::make_tuple(
+            QByteArray::fromHex("fa05000100002800050000a50010000500323c00"),
+            XcxTelemetry{0, 1, 0, 4.0, 5, 165, 16, 5, 50, 60})));
+
+TEST(XcxBikeParserRejectionTest, RejectsWrongLengthAndHeaders) {
+  XcxTelemetry telemetry;
+  EXPECT_FALSE(
+      xcxbike::parseTelemetry(QByteArray::fromHex("fa05"), &telemetry));
+  EXPECT_FALSE(xcxbike::parseTelemetry(
+      QByteArray::fromHex("fb0504003b00780000000001002e0000006e3c00"),
+      &telemetry));
+  EXPECT_FALSE(xcxbike::parseTelemetry(
+      QByteArray::fromHex("fa0604003b00780000000001002e0000006e3c00"),
+      &telemetry));
+}

--- a/tst/Devices/TestXcxBikeParser.h
+++ b/tst/Devices/TestXcxBikeParser.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include "devices/xcxbike/xcxbike.h"
+
+class XcxBikeParserTest
+    : public testing::TestWithParam<std::tuple<QByteArray, XcxTelemetry>> {};

--- a/tst/Devices/deviceindex.cpp
+++ b/tst/Devices/deviceindex.cpp
@@ -157,6 +157,7 @@ DEFINE_DEVICE(TrueTreadmill, "True Treadmill");
 DEFINE_DEVICE(TrueTreadmill2, "True Treadmill 2");
 DEFINE_DEVICE(TrxAppGateUSBElliptical, "TrxAppGateUSB Elliptical");
 DEFINE_DEVICE(UltrasportBike, "Ultrasport Bike");
+DEFINE_DEVICE(XcxBike, "XCX Bike");
 DEFINE_DEVICE(WahooKickrSnapBike_KICKRCORE, "Wahoo KICKR CORE");
 DEFINE_DEVICE(WahooKickrSarisTrainer, "Wahoo Kickr Saris Trainer");
 DEFINE_DEVICE(WahooKickrSnapBike, "Wahoo Kickr Snap Bike");

--- a/tst/Devices/deviceindex.h
+++ b/tst/Devices/deviceindex.h
@@ -162,6 +162,7 @@ public:
     DEFINE_DEVICE(TrueTreadmill2, "True Treadmill 2");
     DEFINE_DEVICE(TrxAppGateUSBElliptical, "TrxAppGateUSB Elliptical");
     DEFINE_DEVICE(UltrasportBike, "Ultrasport Bike");
+    DEFINE_DEVICE(XcxBike, "XCX Bike");
     DEFINE_DEVICE(WahooKickrSnapBike_KICKRCORE, "Wahoo KICKR CORE");
     DEFINE_DEVICE(WahooKickrSarisTrainer, "Wahoo Kickr Saris Trainer");
     DEFINE_DEVICE(WahooKickrSnapBike, "Wahoo Kickr Snap Bike");
@@ -181,4 +182,3 @@ public:
 
 
 };
-

--- a/tst/Devices/devicetestdataindex.cpp
+++ b/tst/Devices/devicetestdataindex.cpp
@@ -1459,6 +1459,12 @@ void DeviceTestDataIndex::Initialize() {
         ->expectDevice<ultrasportbike>()
         ->acceptDeviceName("X-BIKE", DeviceNameComparison::StartsWithIgnoreCase);
 
+    // XCX Bike (proprietary FFF6 telemetry; explicitly not generic FTMS)
+    RegisterNewDeviceTestData(DeviceIndex::XcxBike)
+        ->expectDevice<xcxbike>()
+        ->acceptDeviceName("XCX-001048", DeviceNameComparison::StartsWithIgnoreCase)
+        ->excluding<ftmsbike>();
+
 
     // Wahoo KICKR CORE
     RegisterNewDeviceTestData(DeviceIndex::WahooKickrSnapBike_KICKRCORE)

--- a/tst/qdomyos-zwift-tests.pro
+++ b/tst/qdomyos-zwift-tests.pro
@@ -33,6 +33,7 @@ SOURCES += \
         Devices/TestApexBikeParser.cpp \
         Devices/TestKeepBikeParser.cpp \
         Devices/TestNordictrackEllipticalS700Parser.cpp \
+        Devices/TestXcxBikeParser.cpp \
         main.cpp
 
 # Avoid the "File too big" error building in Windows. This has happened when a template class is used with Google Test / typed tests
@@ -65,6 +66,7 @@ HEADERS += \
     Devices/TestApexBikeParser.h \
     Devices/TestKeepBikeParser.h \
     Devices/TestNordictrackEllipticalS700Parser.h \
+    Devices/TestXcxBikeParser.h \
     Devices/TestOctaneTreadmillZR8.h \
     Devices/TestSunnyfitStepper.h \
     Erg/ergtabletestsuite.h \


### PR DESCRIPTION
### Motivation

- Some XCX-branded bikes (observed `XCX-001048`) expose a broken FTMS implementation while providing correct telemetry on a proprietary `FFF0/FFF6` channel, so they must not be handled via generic FTMS. 
- Implement a dedicated, read-only bike class to consume the proven 20-byte `FA 05` FFF6 packets and expose speed, cadence, watts, energy, resistance and distance without inventing control commands. 
- Ensure name-based detection for `XCX-` takes precedence over service-based FTMS detection so these peripherals are instantiated as the custom class rather than `ftmsbike`.

### Description

- Added a new device implementation `xcxbike` with header and source: `src/devices/xcxbike/xcxbike.h` and `src/devices/xcxbike/xcxbike.cpp`, including an internal `XcxTelemetry` struct and a safe `parseTelemetry()` parser that validates packet length and header bytes and decodes fields using little-endian helpers. 
- Service/characteristic handling discovers `0000FFF0-0000-1000-8000-00805F9B34FB` and locates `FFF5` (write) and `FFF6` (notify) by UUID; it enables notifications on `FFF6` by writing the CCCD `01 00` and does not send any writes to `FFF5`. 
- Parsing rules implemented exactly as specified: `speed = LE16(bytes 6..7) / 10.0`, `cadence = LE16(bytes 13..14)`, `power = byte 17` (low byte only, documented), `distanceRaw = LE24(bytes 8..10)` and code uses `distance = distanceRaw / 10.0` (km) rather than the firmware's FTMS metres interpretation. 
- Detection/factory change: inserted a `XCX-` name branch in `src/devices/bluetooth.cpp` placed before the generic FTMS handling so `XCX-` devices are constructed as `xcxbike`. 
- Project integration: added `devices/xcxbike/xcxbike.cpp` and `devices/xcxbike/xcxbike.h` to `src/qdomyos-zwift.pri`. 
- Tests and test-data: added unit-style parser tests `tst/Devices/TestXcxBikeParser.h` and `tst/Devices/TestXcxBikeParser.cpp` (four supplied capture packets + rejection cases) and registered `XCX-001048` in device test data index to expect `xcxbike` and explicitly exclude `ftmsbike`. 
- Implementation is read-only for proprietary control: `forceResistance`, start/stop and FTMS control are not used or emulated; `watts()` returns zero when cadence is zero in line with repository conventions. 

### Testing

- Parser invariants: executed a Python validation that decoded all four supplied capture packets using the same parser logic (all 4 packets decoded and matched expected values). — succeeded. 
- Static checks: ran `git diff --cached --check` and repository grep checks to confirm no forbidden writes or accidental FTMS usage are present in the new `xcxbike` code (no `writeCharacteristic`/`2ad2`/`1826`/`ftms` usages introduced). — succeeded. 
- Detection precedence check: ran a script that verifies the inserted `XCX-` branch appears before the `ftmsbike` creation and instantiates `xcxbike` in that code path. — succeeded. 
- Unit tests added: `tst/Devices/TestXcxBikeParser.*` were added to the test suite (`tst/qdomyos-zwift-tests.pro`) but the full Google Test build/run was not executed because the Qt build tools (`qmake`) and Qt development environment are not available in the execution environment. — not run due to missing `qmake`/Qt. 
- Notes: attempts to call the local `make_pr` helper and run a packaged MCP helper failed due to environment/network restrictions; these are orthogonal to the code changes and do not affect the implementation or parser verification performed above.

Files changed (high level): `src/devices/xcxbike/{xcxbike.h,xcxbike.cpp}`, `src/devices/bluetooth.cpp`, `src/devices/bluetooth.h`, `src/qdomyos-zwift.pri`, `tst/Devices/TestXcxBikeParser.*`, `tst/Devices/deviceindex.*`, `tst/Devices/devicetestdataindex.cpp`.

If you want, I can run the full unit test build and/or tighten name-matching rules (e.g., restrict to `XCX-001048`) once a Qt/toolchain-enabled environment is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7af17e3204832591bda3025f91e981)