### PR TITLE
Fix Zwift Click V2 held shifting to respect `gears_volume_debouncing`

### DIFF
--- a/src/zwift_play/abstractZapDevice.h
+++ b/src/zwift_play/abstractZapDevice.h
@@ -179,7 +179,7 @@ class AbstractZapDevice: public QObject {
             return 1;
         case 0x23: // zwift ride
             lastFrame = QDateTime::currentDateTime();
-            if (processRideControllerNotification(bytes, zwiftplay_swap, DEBOUNCE)) {
+            if (processRideControllerNotification(bytes, zwiftplay_swap, gears_volume_debouncing)) {
                 risingEdge--;
                 if(risingEdge < 0)
                     risingEdge = 0;
@@ -336,7 +336,7 @@ class AbstractZapDevice: public QObject {
         bool rightPaddle = false;
     };
 
-    bool processRideControllerNotification(const QByteArray &bytes, bool zwiftplay_swap, bool debounce) {
+    bool processRideControllerNotification(const QByteArray &bytes, bool zwiftplay_swap, bool gears_volume_debouncing) {
         quint32 buttonMap = 0xffffffff;
         bool buttonMapFound = false;
         RideAnalogState analogState;
@@ -435,8 +435,8 @@ class AbstractZapDevice: public QObject {
         emitIfChanged(current.rightPowerUp, lastRideButtonStateValid ? lastRideButtonState.rightPowerUp : false, &AbstractZapDevice::rideRightPowerUp);
         emitIfChanged(current.rightOnOff, lastRideButtonStateValid ? lastRideButtonState.rightOnOff : false, &AbstractZapDevice::rideRightOnOff);
 
-        processRideShiftGear(current, zwiftplay_swap, debounce);
-        processRideAnalogState(analogState, zwiftplay_swap, debounce);
+        processRideShiftGear(current, zwiftplay_swap, gears_volume_debouncing);
+        processRideAnalogState(analogState, zwiftplay_swap, gears_volume_debouncing);
 
         lastRideButtonState = current;
         lastRideButtonStateValid = true;
@@ -505,7 +505,7 @@ class AbstractZapDevice: public QObject {
         }
     }
 
-    void processRideAnalogState(const RideAnalogState &state, bool zwiftplay_swap, bool debounce) {
+    void processRideAnalogState(const RideAnalogState &state, bool zwiftplay_swap, bool gears_volume_debouncing) {
         const bool previousLeftPaddle = lastRideAnalogStateValid ? lastRideAnalogState.leftPaddle : false;
         const bool previousRightPaddle = lastRideAnalogStateValid ? lastRideAnalogState.rightPaddle : false;
 
@@ -516,10 +516,10 @@ class AbstractZapDevice: public QObject {
             emit rightPaddle(state.rightPaddle ? 100 : 0);
         }
 
-        if (debounce && state.leftPaddle && !previousLeftPaddle) {
+        if (state.leftPaddle && (!gears_volume_debouncing || !previousLeftPaddle)) {
             applyGearButtonSetting(QZSettings::zwiftplay_gear_paddle_left, QZSettings::default_zwiftplay_gear_paddle_left, zwiftplay_swap);
         }
-        if (debounce && state.rightPaddle && !previousRightPaddle) {
+        if (state.rightPaddle && (!gears_volume_debouncing || !previousRightPaddle)) {
             applyGearButtonSetting(QZSettings::zwiftplay_gear_paddle_right, QZSettings::default_zwiftplay_gear_paddle_right, zwiftplay_swap);
         }
 
@@ -527,11 +527,7 @@ class AbstractZapDevice: public QObject {
         lastRideAnalogStateValid = true;
     }
 
-    void processRideShiftGear(const RideButtonState &state, bool zwiftplay_swap, bool debounce) {
-        if (!debounce) {
-            return;
-        }
-
+    void processRideShiftGear(const RideButtonState &state, bool zwiftplay_swap, bool gears_volume_debouncing) {
         const bool previousLeftShiftUp = lastRideButtonStateValid ? lastRideButtonState.leftShiftUp : false;
         const bool previousLeftShiftDown = lastRideButtonStateValid ? lastRideButtonState.leftShiftDown : false;
         const bool previousRightShiftUp = lastRideButtonStateValid ? lastRideButtonState.rightShiftUp : false;
@@ -539,22 +535,22 @@ class AbstractZapDevice: public QObject {
         const bool previousLeftPowerUp = lastRideButtonStateValid ? lastRideButtonState.leftPowerUp : false;
         const bool previousRightPowerUp = lastRideButtonStateValid ? lastRideButtonState.rightPowerUp : false;
 
-        if (state.leftShiftUp && !previousLeftShiftUp) {
+        if (state.leftShiftUp && (!gears_volume_debouncing || !previousLeftShiftUp)) {
             applyGearButtonSetting(QZSettings::zwiftplay_gear_ls1, QZSettings::default_zwiftplay_gear_ls1, zwiftplay_swap);
         }
-        if (state.leftShiftDown && !previousLeftShiftDown) {
+        if (state.leftShiftDown && (!gears_volume_debouncing || !previousLeftShiftDown)) {
             applyGearButtonSetting(QZSettings::zwiftplay_gear_ls2, QZSettings::default_zwiftplay_gear_ls2, zwiftplay_swap);
         }
-        if (state.rightShiftUp && !previousRightShiftUp) {
+        if (state.rightShiftUp && (!gears_volume_debouncing || !previousRightShiftUp)) {
             applyGearButtonSetting(QZSettings::zwiftplay_gear_rs1, QZSettings::default_zwiftplay_gear_rs1, zwiftplay_swap);
         }
-        if (state.rightShiftDown && !previousRightShiftDown) {
+        if (state.rightShiftDown && (!gears_volume_debouncing || !previousRightShiftDown)) {
             applyGearButtonSetting(QZSettings::zwiftplay_gear_rs2, QZSettings::default_zwiftplay_gear_rs2, zwiftplay_swap);
         }
-        if (state.leftPowerUp && !previousLeftPowerUp) {
+        if (state.leftPowerUp && (!gears_volume_debouncing || !previousLeftPowerUp)) {
             applyGearButtonSetting(QZSettings::zwiftplay_gear_lb, QZSettings::default_zwiftplay_gear_lb, zwiftplay_swap);
         }
-        if (state.rightPowerUp && !previousRightPowerUp) {
+        if (state.rightPowerUp && (!gears_volume_debouncing || !previousRightPowerUp)) {
             applyGearButtonSetting(QZSettings::zwiftplay_gear_rb, QZSettings::default_zwiftplay_gear_rb, zwiftplay_swap);
         }
     }

--- a/tst/Devices/TestZwiftRideController.cpp
+++ b/tst/Devices/TestZwiftRideController.cpp
@@ -4,6 +4,7 @@
 
 #include <QByteArray>
 #include <QObject>
+#include <QSettings>
 
 namespace {
 
@@ -367,6 +368,9 @@ TEST(ZwiftRideControllerTest, May12ReplayMatchesLegendOrderWithoutAliases) {
 }
 
 TEST(ZwiftRideControllerTest, May14ReplayRestoresPaddleGearsAndAvoidsPlayAliases) {
+    QSettings settings;
+    settings.setValue(QZSettings::gears_volume_debouncing, true);
+
     ZwiftPlayDevice device;
     ButtonEvents events;
     connectButtonEvents(device, events);
@@ -428,4 +432,103 @@ TEST(ZwiftRideControllerTest, May14ReplayRestoresPaddleGearsAndAvoidsPlayAliases
     EXPECT_EQ(events.rightPaddleReleased, 1);
     EXPECT_EQ(events.gearMinus, 3);
     EXPECT_EQ(events.gearPlus, 3);
+
+    settings.remove(QZSettings::gears_volume_debouncing);
+}
+
+TEST(ZwiftRideControllerTest, HeldShiftButtonsFollowGearDebouncingSetting) {
+    QSettings settings;
+    settings.setValue(QZSettings::gears_volume_debouncing, true);
+
+    {
+        ZwiftPlayDevice device;
+        ButtonEvents events;
+        connectButtonEvents(device, events);
+
+        processRideFrame(device, kIdle);
+        processRideFrame(device, 0xfffffeff); // LS1
+        processRideFrame(device, 0xfffffeff);
+        processRideFrame(device, 0xfffffeff);
+        processRideFrame(device, kIdle);
+        processRideFrame(device, 0xffffefff); // RS1
+        processRideFrame(device, 0xffffefff);
+
+        EXPECT_EQ(events.gearMinus, 1);
+        EXPECT_EQ(events.gearPlus, 1);
+    }
+
+    settings.setValue(QZSettings::gears_volume_debouncing, false);
+
+    {
+        ZwiftPlayDevice device;
+        ButtonEvents events;
+        connectButtonEvents(device, events);
+
+        processRideFrame(device, kIdle);
+        processRideFrame(device, 0xfffffeff); // LS1
+        processRideFrame(device, 0xfffffeff);
+        processRideFrame(device, 0xfffffeff);
+        processRideFrame(device, kIdle);
+        processRideFrame(device, 0xffffefff); // RS1
+        processRideFrame(device, 0xffffefff);
+
+        EXPECT_EQ(events.gearMinus, 3);
+        EXPECT_EQ(events.gearPlus, 2);
+    }
+
+    settings.setValue(QZSettings::zwiftplay_swap, true);
+
+    {
+        ZwiftPlayDevice device;
+        ButtonEvents events;
+        connectButtonEvents(device, events);
+
+        processRideFrame(device, kIdle);
+        processRideFrame(device, 0xfffffeff); // LS1, swapped to gear up
+        processRideFrame(device, 0xfffffeff);
+
+        EXPECT_EQ(events.gearMinus, 0);
+        EXPECT_EQ(events.gearPlus, 2);
+    }
+
+    settings.remove(QZSettings::zwiftplay_swap);
+    settings.remove(QZSettings::gears_volume_debouncing);
+}
+
+TEST(ZwiftRideControllerTest, HeldRidePaddlesRepeatGearActionsOnlyWithDebouncingDisabled) {
+    const char *leftPaddlePressed = "2308ffffffff0f1a05080010c7011a04080110001a04080210001a0408031000";
+    QSettings settings;
+    settings.setValue(QZSettings::gears_volume_debouncing, true);
+
+    {
+        ZwiftPlayDevice device;
+        ButtonEvents events;
+        connectButtonEvents(device, events);
+
+        processRideFrame(device, kIdle);
+        processRideFrame(device, leftPaddlePressed);
+        processRideFrame(device, leftPaddlePressed);
+        processRideFrame(device, leftPaddlePressed);
+
+        EXPECT_EQ(events.leftPaddlePressed, 1);
+        EXPECT_EQ(events.gearMinus, 1);
+    }
+
+    settings.setValue(QZSettings::gears_volume_debouncing, false);
+
+    {
+        ZwiftPlayDevice device;
+        ButtonEvents events;
+        connectButtonEvents(device, events);
+
+        processRideFrame(device, kIdle);
+        processRideFrame(device, leftPaddlePressed);
+        processRideFrame(device, leftPaddlePressed);
+        processRideFrame(device, leftPaddlePressed);
+
+        EXPECT_EQ(events.leftPaddlePressed, 1);
+        EXPECT_EQ(events.gearMinus, 3);
+    }
+
+    settings.remove(QZSettings::gears_volume_debouncing);
 }


### PR DESCRIPTION
### Motivation

- Zwift Click V2 (Ride / `0x23`) was handled as edge-only regardless of the user `gears_volume_debouncing` setting, so holding a button produced only a single gear change instead of repeating when debouncing was disabled.
- The goal is for Click V2 to follow the same user-configurable semantics as Click V1: when `gears_volume_debouncing` is true emit one event per press edge, and when false allow each incoming V2 notification that still reports the button pressed to generate another gear change.

### Description

- Changed the Ride processing path to pass the actual user setting into Ride handlers by replacing the derived macro argument with the real `gears_volume_debouncing` boolean in `processRideControllerNotification` call and signature, and propagated it to subfunctions in `src/zwift_play/abstractZapDevice.h`.
- Modified `processRideShiftGear` to emit gear actions under the condition `state.X && (!gears_volume_debouncing || !previousX)` for all Ride gear buttons so that:
  - `gears_volume_debouncing == true` keeps edge-only behavior, and
  - `gears_volume_debouncing == false` allows repeated events while the button remains pressed.
- Applied the same semantic to analog paddle mappings inside `processRideAnalogState` so paddle gear actions follow the `gears_volume_debouncing` setting while leaving normal paddle position signals unchanged.
- Preserved existing behavior for Click V1 (`0x37`), preserved `zwiftplay_swap` semantics, button mappings, `emitRidePaddleGear` timing rules, and auto-repeat timer logic; no new artificial repeat timers were added.
- Files changed: `src/zwift_play/abstractZapDevice.h` (behavioral changes and signature updates) and `tst/Devices/TestZwiftRideController.cpp` (new/extended unit tests exercising held-button and paddle behaviors and `zwiftplay_swap`).

### Testing

- Added Google Test cases in `tst/Devices/TestZwiftRideController.cpp` to validate held-shift behavior with `gears_volume_debouncing` both true and false, verify swapped directions via `zwiftplay_swap`, and ensure left/right paddles only repeat gear actions when debouncing is disabled.
- The tests were added to the test suite but could not be built/executed in this environment because the Qt/qmake build toolchain and project build were not available here; they should be run locally or in CI (`qmake`/`make` then run the `qdomyos-zwift-tests` test binary) and are expected to verify the changes.
- No runtime changes were made to Click V1 paths and existing `emitRidePaddleGear` timing logic was left intact to avoid double-repeat interactions; unit tests focus on the Ride/Click V2 semantics described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7af3f501148325b7ca024e3c7a46b9)