### PR TITLE
Ensure build-variant workflow patches C++ defaults to match QML settings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2175,8 +2175,33 @@ jobs:
           echo "#define INTERVALSICU_CLIENT_SECRET ${{ secrets.intervalsicu_client_secret }}" >> secret.h
           echo "${{ secrets.cesiumkey }}" >> inner_templates/googlemaps/cesium-key.js
           echo "#define LICENSE" >> secret.h
-          # Set variant-specific IP setting
-          sed -i 's/property string ${{ matrix.variant.setting_key }}: ""/property string ${{ matrix.variant.setting_key }}: "${{ matrix.variant.setting_value }}"/' settings.qml
+          # Keep the QML and C++ defaults identical for this artifact variant.
+          SETTING_KEY='${{ matrix.variant.setting_key }}' \
+          SETTING_VALUE='${{ matrix.variant.setting_value }}' \
+          python3 - <<'PY'
+          import os
+          from pathlib import Path
+
+          key = os.environ["SETTING_KEY"]
+          value = os.environ["SETTING_VALUE"]
+          replacements = {
+              Path("settings.qml"): (
+                  f'            property string {key}: ""',
+                  f'            property string {key}: "{value}"',
+              ),
+              Path("qzsettings.cpp"): (
+                  f'const QString QZSettings::default_{key} = QStringLiteral("");',
+                  f'const QString QZSettings::default_{key} = QStringLiteral("{value}");',
+              ),
+          }
+          for path, (original, variant) in replacements.items():
+              contents = path.read_text()
+              if contents.count(original) != 1:
+                  raise SystemExit(f"Expected exactly one {original!r} in {path}")
+              path.write_text(contents.replace(original, variant))
+              if path.read_text().count(variant) != 1:
+                  raise SystemExit(f"Failed to set {variant!r} in {path}")
+          PY
           cd ..
 
           ln -sfn $ANDROID_SDK_ROOT/ndk/21.4.7075529 $ANDROID_NDK
@@ -2318,8 +2343,33 @@ jobs:
           echo "#define INTERVALSICU_CLIENT_SECRET ${{ secrets.intervalsicu_client_secret }}" >> secret.h
           echo "${{ secrets.cesiumkey }}" >> inner_templates/googlemaps/cesium-key.js
           echo "#define LICENSE" >> secret.h
-          # Set variant-specific IP setting
-          sed -i 's/property string ${{ matrix.variant.setting_key }}: ""/property string ${{ matrix.variant.setting_key }}: "${{ matrix.variant.setting_value }}"/' settings.qml
+          # Keep the QML and C++ defaults identical for this artifact variant.
+          SETTING_KEY='${{ matrix.variant.setting_key }}' \
+          SETTING_VALUE='${{ matrix.variant.setting_value }}' \
+          python3 - <<'PY'
+          import os
+          from pathlib import Path
+
+          key = os.environ["SETTING_KEY"]
+          value = os.environ["SETTING_VALUE"]
+          replacements = {
+              Path("settings.qml"): (
+                  f'            property string {key}: ""',
+                  f'            property string {key}: "{value}"',
+              ),
+              Path("qzsettings.cpp"): (
+                  f'const QString QZSettings::default_{key} = QStringLiteral("");',
+                  f'const QString QZSettings::default_{key} = QStringLiteral("{value}");',
+              ),
+          }
+          for path, (original, variant) in replacements.items():
+              contents = path.read_text()
+              if contents.count(original) != 1:
+                  raise SystemExit(f"Expected exactly one {original!r} in {path}")
+              path.write_text(contents.replace(original, variant))
+              if path.read_text().count(variant) != 1:
+                  raise SystemExit(f"Failed to set {variant!r} in {path}")
+          PY
           cd ..
 
           # Keep FitPro APKs usable on older 32-bit iFIT/ProForm consoles.


### PR DESCRIPTION
### Motivation
- The workflow previously changed only the QML `src/settings.qml` defaults for some build variants which caused a runtime mismatch with the C++ fallback `QZSettings::default_*` values and required users to save settings manually before the C++ code used the intended value. 
- This must be fixed for every artifact variant that deliberately overrides a persistent setting in the workflow (NordicTrack / FitPro matrices) so the displayed QML default and the C++ fallback are identical. 
- Keep the change minimal and targeted so only deliberate workflow overrides are synchronized and normal release behavior is unchanged. 

### Description
- Replaced the simple `sed` QML-only replacement in `.github/workflows/main.yml` with a small Python snippet that patches both `src/settings.qml` (the `property string ...`) and `src/qzsettings.cpp` (the `const QString QZSettings::default_...`) to the same `matrix.variant` value for each variant. 
- Each replacement is precise (matches the exact declaration text) and includes strict checks that exactly one original occurrence exists and exactly one updated occurrence is present, causing the workflow to fail loudly if the source text changed or the patch cannot be applied. 
- The change is applied only in the existing build-matrix steps for the NordicTrack and FitPro artifact jobs so unrelated settings and normal release behavior are not modified. 

### Testing
- Simulated the four distinct override replacements (`nordictrack_2950_ip`, `tdf_10_ip`, `proform_elliptical_ip`, `proform_rower_ip`) against temporary copies and verified both `settings.qml` and `qzsettings.cpp` contained the expected `"localhost"` variant default, and these simulations passed. 
- Parsed `.github/workflows/main.yml` as YAML and ran `git diff --check` which reported no problems; `actionlint` was not installed in the environment used for verification. 
- A commit was produced with the workflow change and the workflow will now fail during build-time if any expected declaration is not found or the replacement verification fails, preventing silent mismatches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7af9d6b87883258a6830df586bb479)