### PR TITLE
Gate KICKR gear and inclination commands on device ACK

### DIFF
--- a/src/devices/wahookickrsnapbike/wahookickrsnapbike.cpp
+++ b/src/devices/wahookickrsnapbike/wahookickrsnapbike.cpp
@@ -39,9 +39,19 @@ wahookickrsnapbike::wahookickrsnapbike(bool noWriteResistance, bool noHeartServi
     writeTimeoutTimer = new QTimer(this);
     writeTimeoutTimer->setSingleShot(true);
     connect(writeTimeoutTimer, &QTimer::timeout, this, [this]() {
-        qDebug() << QStringLiteral("writeCharacteristic timeout - processing next in queue");
+        qDebug() << QStringLiteral("writeCharacteristic timeout") << currentWriteInfo;
+
+        // A KICKR command that is waiting for its device response must not be
+        // followed by another command merely because the local timeout elapsed.
+        // Keep the newest coalesced request queued until the real ACK arrives.
+        if (currentWriteResponseOpcode) {
+            qDebug() << QStringLiteral("KICKR command gate remains closed until ACK") << currentWriteInfo;
+            return;
+        }
+
         isWriting = false;
         currentWriteWaitingForResponse = false;
+        currentWriteInfo.clear();
         processWriteQueue();
     });
 
@@ -59,13 +69,24 @@ void wahookickrsnapbike::restoreDefaultWheelDiameter() {
 }
 
 bool wahookickrsnapbike::writeCharacteristic(uint8_t *data, uint8_t data_len, QString info, bool disable_log,
-                                             bool wait_for_response) {
+                                             bool wait_for_response, uint8_t response_opcode, uint8_t coalesce_key) {
+    if (coalesce_key != _noCommandGroup) {
+        for (auto it = writeQueue.begin(); it != writeQueue.end();) {
+            if (it->coalesce_key == coalesce_key)
+                it = writeQueue.erase(it);
+            else
+                ++it;
+        }
+    }
+
     // Create write request and add to queue
     WriteRequest request;
     request.data = QByteArray((const char *)data, data_len);
     request.info = info;
     request.disable_log = disable_log;
     request.wait_for_response = wait_for_response;
+    request.response_opcode = response_opcode;
+    request.coalesce_key = coalesce_key;
 
     writeQueue.enqueue(request);
 
@@ -102,12 +123,17 @@ void wahookickrsnapbike::processWriteQueue() {
     WriteRequest request = writeQueue.dequeue();
     isWriting = true;
     currentWriteWaitingForResponse = request.wait_for_response;
+    currentWriteResponseOpcode = request.response_opcode;
+    currentWriteInfo = request.info;
 
     // Update write buffer
     if (writeBuffer) {
         delete writeBuffer;
     }
     writeBuffer = new QByteArray(request.data);
+
+    if (currentWriteResponseOpcode)
+        currentWriteTimer.start();
 
     // Write the characteristic
     gattPowerChannelService->writeCharacteristic(gattWriteCharacteristic, *writeBuffer);
@@ -226,6 +252,41 @@ QByteArray wahookickrsnapbike::setWheelCircumference(double millimeters) {
     return r;
 }
 
+bool wahookickrsnapbike::isExpectedCommandResponse(const QBluetoothUuid &uuid, const QByteArray &value) const {
+    static const QBluetoothUuid wahooWriteCharacteristic(
+        QStringLiteral("A026E005-0A7D-4AB3-97FA-F1500F9FEB8B"));
+
+    return currentWriteResponseOpcode && uuid == wahooWriteCharacteristic && value.size() >= 4 &&
+           static_cast<uint8_t>(value.at(0)) == 0x01 && static_cast<uint8_t>(value.at(1)) == currentWriteResponseOpcode &&
+           static_cast<uint8_t>(value.at(2)) == 0x01 && static_cast<uint8_t>(value.at(3)) == 0x00;
+}
+
+void wahookickrsnapbike::logCommandResponse(const QByteArray &value) {
+    const qint64 elapsedMs = currentWriteTimer.isValid() ? currentWriteTimer.elapsed() : -1;
+    commandAckCount++;
+    if (elapsedMs >= 0)
+        commandAckTotalMs += static_cast<quint64>(elapsedMs);
+
+    const double responseValue = value.size() >= 6
+                                     ? static_cast<double>((static_cast<uint16_t>(static_cast<uint8_t>(value.at(5))) << 8) |
+                                                           static_cast<uint16_t>(static_cast<uint8_t>(value.at(4))))
+                                     : 0.0;
+    QString decodedValue;
+    if (currentWriteResponseOpcode == _setSimGrade) {
+        decodedValue = QStringLiteral("grade=") +
+                       QString::number((((responseValue / 65535.0) * 2.0) - 1.0) * 100.0, 'f', 3);
+    } else if (currentWriteResponseOpcode == _setWheelCircumference) {
+        decodedValue = QStringLiteral("wheelCircumference=") + QString::number(responseValue / 10.0, 'f', 1);
+    } else {
+        decodedValue = QStringLiteral("value=") + QString::number(responseValue);
+    }
+
+    const double averageMs = commandAckCount ? static_cast<double>(commandAckTotalMs) / commandAckCount : 0.0;
+    emit debug(QStringLiteral("KICKR ACK ") + currentWriteInfo + QStringLiteral(" ") + decodedValue +
+               QStringLiteral(" in ") + QString::number(elapsedMs) + QStringLiteral(" ms (average ") +
+               QString::number(averageMs, 'f', 1) + QStringLiteral(" ms)"));
+}
+
 void wahookickrsnapbike::update() {
     if (m_control && m_control->state() == QLowEnergyController::UnconnectedState) {
         emit disconnected();
@@ -336,7 +397,8 @@ void wahookickrsnapbike::update() {
                     QByteArray a = setWheelCircumference(wheelCircumference::gearsToWheelDiameter(gears()));
                     uint8_t b[20];
                     memcpy(b, a.constData(), a.length());
-                    writeCharacteristic(b, a.length(), "setWheelCircumference", false, false);
+                    writeCharacteristic(b, a.length(), "setWheelCircumference", false, true, _setWheelCircumference,
+                                        _gearCommandGroup);
                     lastGrade = 999; // to force a change
                 }
             }
@@ -468,14 +530,22 @@ void wahookickrsnapbike::characteristicChanged(const QLowEnergyCharacteristic &c
 void wahookickrsnapbike::handleCharacteristicValueChanged(const QBluetoothUuid &uuid, const QByteArray &newValue) {
     // qDebug() << "characteristicChanged" << characteristic.uuid() << newValue << newValue.length();
 
-    // Handle async write queue - if we were waiting for a response, process next item
-    if (currentWriteWaitingForResponse && isWriting) {
+    // A normal BLE characteristicWritten event is not the same as the KICKR's
+    // command response. Dynamic control requests use the latter as their gate.
+    const bool expectedDeviceResponse = isExpectedCommandResponse(uuid, newValue);
+    if (currentWriteWaitingForResponse && isWriting &&
+        (currentWriteResponseOpcode == 0 || expectedDeviceResponse)) {
         // Stop timeout timer
         writeTimeoutTimer->stop();
+
+        if (expectedDeviceResponse)
+            logCommandResponse(newValue);
 
         // Mark writing as complete and process next item in queue
         isWriting = false;
         currentWriteWaitingForResponse = false;
+        currentWriteResponseOpcode = 0;
+        currentWriteInfo.clear();
         processWriteQueue();
     }
 
@@ -1006,7 +1076,7 @@ void wahookickrsnapbike::inclinationChanged(double grade, double percentage) {
         QByteArray a = setSimGrade(g);
         uint8_t b[20];
         memcpy(b, a.constData(), a.length());
-        writeCharacteristic(b, a.length(), "setSimGrade", false, false);
+        writeCharacteristic(b, a.length(), "setSimGrade", false, true, _setSimGrade, _inclinationCommandGroup);
     } else {
         if(lastCommandErgMode) {
             lastGrade = grade + 1; // to force a refresh
@@ -1029,7 +1099,7 @@ void wahookickrsnapbike::inclinationChanged(double grade, double percentage) {
         QByteArray a = setSimGrade(g);
         uint8_t b[20];
         memcpy(b, a.constData(), a.length());
-        writeCharacteristic(b, a.length(), "setSimGrade", false, false);
+        writeCharacteristic(b, a.length(), "setSimGrade", false, true, _setSimGrade, _inclinationCommandGroup);
         lastCommandErgMode = false;
     }
 }

--- a/src/devices/wahookickrsnapbike/wahookickrsnapbike.h
+++ b/src/devices/wahookickrsnapbike/wahookickrsnapbike.h
@@ -11,6 +11,7 @@
 #include <QtBluetooth/qlowenergyservice.h>
 #include <QtBluetooth/qlowenergyservicedata.h>
 #include <QtCore/qbytearray.h>
+#include <QtCore/qelapsedtimer.h>
 
 #ifndef Q_OS_ANDROID
 #include <QtCore/qcoreapplication.h>
@@ -61,6 +62,12 @@ class wahookickrsnapbike : public bike {
         _setSimWindSpeed = 71,
         _setWheelCircumference = 72,
     };
+
+    enum CommandGroup : uint8_t {
+        _noCommandGroup = 0,
+        _inclinationCommandGroup = 1,
+        _gearCommandGroup = 2,
+    };
     
     // Variabili per iOS (pubbliche per permettere all'implementazione iOS di impostarle)
     bool zwift_found = false;
@@ -76,6 +83,8 @@ class wahookickrsnapbike : public bike {
         QString info;
         bool disable_log;
         bool wait_for_response;
+        uint8_t response_opcode = 0;
+        uint8_t coalesce_key = _noCommandGroup;
     };
     QByteArray unlockCommand();
     QByteArray setResistanceMode(double resistance);
@@ -89,8 +98,11 @@ class wahookickrsnapbike : public bike {
     QByteArray setWheelCircumference(double millimeters);
 
     bool writeCharacteristic(uint8_t *data, uint8_t data_len, QString info, bool disable_log = false,
-                             bool wait_for_response = false);
+                             bool wait_for_response = false, uint8_t response_opcode = 0,
+                             uint8_t coalesce_key = _noCommandGroup);
     void processWriteQueue();
+    bool isExpectedCommandResponse(const QBluetoothUuid &uuid, const QByteArray &value) const;
+    void logCommandResponse(const QByteArray &value);
     uint16_t wattsFromResistance(double resistance);
     metric ResistanceFromFTMSAccessory;
     void startDiscover();
@@ -108,6 +120,11 @@ class wahookickrsnapbike : public bike {
     QQueue<WriteRequest> writeQueue;
     bool isWriting = false;
     bool currentWriteWaitingForResponse = false;
+    uint8_t currentWriteResponseOpcode = 0;
+    QString currentWriteInfo;
+    QElapsedTimer currentWriteTimer;
+    quint64 commandAckCount = 0;
+    quint64 commandAckTotalMs = 0;
     QTimer *writeTimeoutTimer = nullptr;
 
     uint8_t sec1Update = 0;


### PR DESCRIPTION
## Summary

- Serialize dynamic KICKR gear and inclination commands behind the trainer's real device response.
- Coalesce pending gear commands so only the latest wheel-circumference value is sent.
- Coalesce pending inclination commands so only the latest grade value is sent.
- Keep gear and inclination pending values independent while sharing one output gate.
- Log the ACK value, per-command response latency, and cumulative average latency.

## Motivation

The BLE `characteristicWritten` callback only confirms that the local BLE stack accepted the write. KICKR logs show the trainer later sends a command response on the Wahoo characteristic:

```
01 46 01 00 <grade-lo> <grade-hi>
01 48 01 00 <circumference-lo> <circumference-hi>
```

A captured log measured 16 `setSimGrade` responses with an average latency of approximately 537 ms (min 278 ms, max 841 ms). Sending commands on local write completion can therefore queue intermediate grades/gears inside the trainer.

## Implementation

- Dynamic `setSimGrade` and `setWheelCircumference` writes wait for the matching Wahoo response opcode.
- A single command is allowed in flight.
- New pending values replace only the previous pending value from the same command group.
- A local timeout no longer opens the KICKR command gate; the next command waits for the actual ACK.
- Runtime logs report the decoded response grade/circumference and moving average latency.

## Validation

- `git diff --check`
- Reviewed against real KICKR debug logs and measured ACK latency.
- Qt build not run in this environment because `qmake` is unavailable.
- Hardware validation still needed with a KICKR v5, especially rapid Zwift gear changes and rapid grade changes.