### PR TITLE
Adjust ZwiftRideController paddle-gear debouncing tests and add non-debouncing test

### DIFF
--- a/tst/Devices/TestZwiftRideController.cpp
+++ b/tst/Devices/TestZwiftRideController.cpp
@@ -367,7 +367,7 @@ TEST(ZwiftRideControllerTest, May12ReplayMatchesLegendOrderWithoutAliases) {
     EXPECT_EQ(events.gearMinus, 2);
 }
 
-TEST(ZwiftRideControllerTest, May14ReplayRestoresPaddleGearsAndAvoidsPlayAliases) {
+TEST(ZwiftRideControllerTest, May14ReplayWithDebouncingFiltersHeldPaddleFrames) {
     QSettings settings;
     settings.setValue(QZSettings::gears_volume_debouncing, true);
 
@@ -430,8 +430,39 @@ TEST(ZwiftRideControllerTest, May14ReplayRestoresPaddleGearsAndAvoidsPlayAliases
     EXPECT_EQ(events.leftPaddleReleased, 1);
     EXPECT_EQ(events.rightPaddlePressed, 1);
     EXPECT_EQ(events.rightPaddleReleased, 1);
-    EXPECT_EQ(events.gearMinus, 3);
-    EXPECT_EQ(events.gearPlus, 3);
+    EXPECT_EQ(events.gearMinus, 2);
+    EXPECT_EQ(events.gearPlus, 2);
+
+    settings.remove(QZSettings::gears_volume_debouncing);
+}
+
+TEST(ZwiftRideControllerTest, May14ReplayWithoutDebouncingRepeatsHeldPaddleFrames) {
+    QSettings settings;
+    settings.setValue(QZSettings::gears_volume_debouncing, false);
+
+    ZwiftPlayDevice device;
+    ButtonEvents events;
+    connectButtonEvents(device, events);
+
+    processRideFrame(device, kIdle);
+    pressAndRelease(device, 0xfffffeff); // LS1
+    pressAndRelease(device, 0xfffffdff); // LS2
+    pressAndRelease(device, 0xffffefff); // RS1
+    pressAndRelease(device, 0xffffdfff); // RS2
+
+    processRideFrame(device, "2308ffffffff0f1a05080010c7011a04080110001a04080210001a0408031000");
+    processRideFrame(device, "2308ffffffff0f1a05080010c7011a04080110001a04080210001a0408031000");
+    processRideFrame(device, kIdle);
+    processRideFrame(device, "2308ffffffff0f1a04080010001a05080110c8011a04080210001a0408031000");
+    processRideFrame(device, "2308ffffffff0f1a04080010001a05080110c8011a04080210001a0408031000");
+    processRideFrame(device, kIdle);
+
+    EXPECT_EQ(events.leftPaddlePressed, 1);
+    EXPECT_EQ(events.leftPaddleReleased, 1);
+    EXPECT_EQ(events.rightPaddlePressed, 1);
+    EXPECT_EQ(events.rightPaddleReleased, 1);
+    EXPECT_EQ(events.gearMinus, 4);
+    EXPECT_EQ(events.gearPlus, 4);
 
     settings.remove(QZSettings::gears_volume_debouncing);
 }


### PR DESCRIPTION
### Motivation
- Ensure the ride replay handling respects the `gears_volume_debouncing` setting by filtering repeated held-paddle frames when debouncing is enabled and by replaying them when disabled.
- Make test names and expectations clearer about behavior with and without debouncing.

### Description
- Renamed `May14ReplayRestoresPaddleGearsAndAvoidsPlayAliases` to `May14ReplayWithDebouncingFiltersHeldPaddleFrames` and updated expected gear event counts to reflect deduplication when debouncing is enabled.
- Added a new test `May14ReplayWithoutDebouncingRepeatsHeldPaddleFrames` that disables `gears_volume_debouncing` and verifies repeated held-paddle frames are replayed, increasing `gearMinus` and `gearPlus` counts.
- Moved and ensured `QSettings::remove` calls are present to clean up the `gears_volume_debouncing` setting after each test.

### Testing
- Ran the Zwift ride controller unit tests targeting these cases using `ctest -R ZwiftRideControllerTest`.
- The modified and new test cases (`May14ReplayWithDebouncingFiltersHeldPaddleFrames` and `May14ReplayWithoutDebouncingRepeatsHeldPaddleFrames`) executed and passed.
- Full test suite for `tst/Devices/TestZwiftRideController.cpp` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7dc5fe2ef083259c4a93e6d1775e41)