### PR TITLE
Show guidance toast when manually selected device isn't found

### DIFF
--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -236,6 +236,13 @@ void bluetooth::finished() {
         return;
     }
 
+    const QString manualDevice =
+        settings.value(QZSettings::filter_device, QZSettings::default_filter_device).toString();
+    if (!onlyDiscover && !gymModeEnabled() &&
+        manualDevice.compare(QZSettings::default_filter_device, Qt::CaseInsensitive) != 0) {
+        emit manualDeviceNotFound(manualDevice);
+    }
+
     QString heartRateBeltName =
         settings.value(QZSettings::heart_rate_belt_name, QZSettings::default_heart_rate_belt_name).toString();
     QString ftmsAccessoryName =

--- a/src/devices/bluetooth.h
+++ b/src/devices/bluetooth.h
@@ -387,6 +387,7 @@ class bluetooth : public QObject, public SignalHandler {
   signals:
     void deviceConnected(QBluetoothDeviceInfo b);
     void deviceFound(QString name);
+    void manualDeviceNotFound(QString name);
     void searchingStop();
     void ftmsAccessoryConnected(smartspin2k *d);
 

--- a/src/homeform.cpp
+++ b/src/homeform.cpp
@@ -878,6 +878,12 @@ homeform::homeform(QQmlApplicationEngine *engine, bluetooth *bl) {
     connect(bluetoothManager, &bluetooth::bluetoothDeviceConnected, this, &homeform::bluetoothDeviceConnected);
     connect(bluetoothManager, &bluetooth::bluetoothDeviceDisconnected, this, &homeform::bluetoothDeviceDisconnected);
     connect(bluetoothManager, &bluetooth::deviceFound, this, &homeform::deviceFound);
+    connect(bluetoothManager, &bluetooth::manualDeviceNotFound, this, [this](const QString &name) {
+        setToastRequested(
+            QStringLiteral("QZ is looking for %1. Please wake it up or change this device under the Manual Device "
+                           "setting in Advanced Settings.")
+                .arg(name));
+    });
     connect(bluetoothManager, &bluetooth::deviceConnected, this, &homeform::deviceConnected);
     connect(bluetoothManager, &bluetooth::ftmsAccessoryConnected, this, &homeform::ftmsAccessoryConnected);
     connect(bluetoothManager, &bluetooth::deviceConnected, this, &homeform::trainProgramSignals);


### PR DESCRIPTION
### Motivation
- When a user sets the Manual Device and discovery finishes without finding that device, the UI should inform the user and explain next steps. 
- The notification must be suppressed during device-list refreshes (`onlyDiscover`) and while gym mode is active to avoid false or noisy messages.

### Description
- Add a `manualDeviceNotFound(QString)` signal to `bluetooth` and emit it from `bluetooth::finished()` when `filter_device` is set to a non-default value and discovery completes, guarded by `!onlyDiscover` and `!gymModeEnabled()` (`src/devices/bluetooth.h`, `src/devices/bluetooth.cpp`).
- Connect the new `manualDeviceNotFound` signal in `homeform` to call `setToastRequested(...)` and show the message `QZ is looking for <name>. Please wake it up or change this device under the Manual Device setting in Advanced Settings.` (`src/homeform.cpp`).
- Preserve existing discovery behavior for all other cases (no change to discovery flow or device matching logic).

### Testing
- ✅ Ran `git diff --check` to ensure no whitespace or trivial diffs introduced and it passed.
- ✅ Inspected working tree with `git status --short` to confirm the three modified files (`src/devices/bluetooth.cpp`, `src/devices/bluetooth.h`, `src/homeform.cpp`) are staged/modified as expected.
- ⚠️ Attempted to invoke the local `make_pr` helper but it failed due to a missing `mcp.server.fastmcp` module in the environment, so automated PR-tool submission could not be exercised.
- ⚠️ Build was not executed because `qmake` is not available in this environment, so runtime verification was not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7eb2594604832596d0a5a24d23503b)