### PR TITLE
Fix excessive Android USB serial debug logging

### DIFF
--- a/src/android/src/Usbserial.java
+++ b/src/android/src/Usbserial.java
@@ -38,9 +38,10 @@ import java.util.LinkedList;
 import java.util.concurrent.Callable;
 import java.util.ArrayList;
 import java.util.List;
-import java.nio.charset.StandardCharsets;
 
 public class Usbserial {
+
+    private static final char[] HEX_DIGITS = "0123456789ABCDEF".toCharArray();
 
     static UsbSerialPort port = null;
     static java.io.FileDescriptor localSerialFd = null;
@@ -54,6 +55,19 @@ public class Usbserial {
         "/dev/ttyS2",
         "/dev/ttyS3"
     };
+
+    private static String bytesToHex(byte[] data, int length) {
+        int count = Math.min(Math.max(length, 0), data.length);
+        StringBuilder hex = new StringBuilder(count == 0 ? 0 : count * 3 - 1);
+        for (int i = 0; i < count; i++) {
+            if (i > 0)
+                hex.append(' ');
+            int value = data[i] & 0xFF;
+            hex.append(HEX_DIGITS[value >>> 4]);
+            hex.append(HEX_DIGITS[value & 0x0F]);
+        }
+        return hex.toString();
+    }
 
     public static void open(Context context) {
         open(context, 2400); // Default baud rate for Computrainer
@@ -207,7 +221,8 @@ public class Usbserial {
         if(port == null)
            return;
 
-        QLog.d("QZ","UsbSerial writing " + new String(bytes, StandardCharsets.UTF_8));
+        QLog.d("QZ", "UsbSerial writing " + bytes.length + " bytes: " +
+                bytesToHex(bytes, bytes.length));
         try {
             port.write(bytes, 2000);
         }
@@ -254,7 +269,8 @@ public class Usbserial {
 
         try {
             lastReadLen = port.read(receiveData, 2000);
-            QLog.d("QZ","UsbSerial reading " + lastReadLen + new String(receiveData, StandardCharsets.UTF_8));
+            QLog.d("QZ", "UsbSerial reading " + lastReadLen + " bytes: " +
+                    bytesToHex(receiveData, lastReadLen));
         }
         catch (IOException e) {
             // Do something here


### PR DESCRIPTION
### Motivation
- Prevent runaway Android debug-log growth caused by converting the entire 4096-byte USB receive buffer to UTF-8 after every serial read.  
- The existing log statement was emitting stale and unused bytes from the shared buffer and produced a real-world capture of ~2.8 GB in ~31 minutes with ~2.7 GB from `UsbSerial reading` lines.  
- Keep serial I/O behavior identical while making debug output safe and useful for protocol debugging.

### Description
- Add a bounded hexadecimal encoder `bytesToHex(byte[] data, int length)` that clamps negative/oversized lengths and prints only the first `length` bytes as space-separated hex pairs.  
- Replace unsafe `new String(..., StandardCharsets.UTF_8)` logging with `QLog.d("QZ", "UsbSerial reading " + lastReadLen + " bytes: " + bytesToHex(...))` for reads and a matching `UsbSerial writing` hex line for writes, preserving the 4096-byte shared `receiveData` buffer, `lastReadLen` semantics, and the 2000 ms timeout.  
- Remove direct binary-to-UTF8 conversions in `src/android/src/Usbserial.java` and ensure the change is narrowly scoped to logging only with no changes to driver handling or protocol logic.

### Testing
- Compiled and ran a small harness `javac /tmp/UsbserialHexCheck.java && java -cp /tmp UsbserialHexCheck` which verifies bounded reads, buffer reuse isolation, correct encoding of `00`, `80`, `FF`, zero/negative lengths, and oversized-length handling (succeeded).  
- Performed source invariant checks and grep scans (no remaining `new String`/`StandardCharsets` uses in `Usbserial.java`) and validated invariants about the shared 4096-byte buffer, 2000 ms timeout, and shared return array with a short Python check (succeeded).  
- Ran `git diff --check` and commit operations to ensure a clean working tree and that the patch applied cleanly (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7f7163e2d483258ade8c325e2c36e6)