### PR TITLE
Add StopWorkout command and implement safe treadmill stop with serialized IO

### DIFF
--- a/src/android/fitpro/com/nettarion/hyperborea/core/model/DeviceCommand.kt
+++ b/src/android/fitpro/com/nettarion/hyperborea/core/model/DeviceCommand.kt
@@ -9,6 +9,7 @@ sealed interface DeviceCommand {
     data class AdjustSpeed(val increase: Boolean) : DeviceCommand
     data object PauseWorkout : DeviceCommand
     data object ResumeWorkout : DeviceCommand
+    data object StopWorkout : DeviceCommand
     data object CalibrateIncline : DeviceCommand
     data class SetFanSpeed(val level: Int) : DeviceCommand
     data class SetVolume(val level: Int) : DeviceCommand

--- a/src/android/fitpro/com/nettarion/hyperborea/hardware/fitpro/v1/V1Session.kt
+++ b/src/android/fitpro/com/nettarion/hyperborea/hardware/fitpro/v1/V1Session.kt
@@ -61,6 +61,10 @@ class V1Session(
     private var pollJob: Job? = null
     private var pendingWriteFields: Map<V1DataField, Float> = emptyMap()
     private val pendingWriteMutex = Mutex()
+    /** Serializes complete HID request/response transactions with multi-step safety commands. */
+    private val ioMutex = Mutex()
+    /** Preserves command ordering; in particular Resume cannot interleave with Stop. */
+    private val commandMutex = Mutex()
     @Volatile private var pendingCalibration: CompletableDeferred<Unit>? = null
     private var lastLogTimeMs = 0L
     private var consecutivePollErrors = 0
@@ -125,9 +129,8 @@ class V1Session(
             transport.clearBuffer()
             handshake()
 
-            // Console init (done while still in IDLE), then bring the workout up the way the
-            // console firmware expects (device-type-dependent — treadmills stop at WARM_UP and
-            // wait for the physical Start key, see transitionToActive).
+            // Console init is done while still in IDLE. Belt motion must only become possible after
+            // an explicit ResumeWorkout command; non-treadmills retain their activation sequence.
             prepareConsole()
             accumulator.start()
             transitionToActive()
@@ -195,10 +198,11 @@ class V1Session(
      */
     private suspend fun gracefulEndForDisconnect() {
         val isBelt = detectedDeviceType.isBeltBased
-        if (isBelt) haltBeltConfirmed()
+        if (isBelt) haltBeltConfirmed("disconnect")
 
         // Clean end (write-only): tell the MCU the run is over so it does its end-of-workout
         // housekeeping. GRADE=0 on belt machines so an incline trainer doesn't park raised.
+        logger.i(TAG, "Disconnect cleanup: writing WORKOUT_MODE=IDLE${if (isBelt) ", GRADE=0" else ""}")
         writeMessage(V1Message.Outgoing.ReadWriteData(
             writeFields = buildMap {
                 put(V1DataField.WORKOUT_MODE, WorkoutMode.IDLE.raw)
@@ -224,7 +228,8 @@ class V1Session(
      * MCU acknowledges speed 0 (or we run out of attempts). Belt machines only — callers gate on
      * [DeviceType.isBeltBased].
      */
-    private suspend fun haltBeltConfirmed() {
+    private suspend fun haltBeltConfirmed(reason: String): Boolean {
+        logger.i(TAG, "Belt halt requested ($reason): writing KPH=0 and WORKOUT_MODE=PAUSE")
         repeat(BELT_HALT_CONFIRM_ATTEMPTS) { attempt ->
             val response = sendReadWrite(
                 writeFields = if (attempt == 0) mapOf(
@@ -234,13 +239,40 @@ class V1Session(
                 readFields = setOf(V1DataField.KPH),
             )
             val commandedKph = response?.fields?.get(V1DataField.KPH)
+            logger.d(TAG, "Belt halt KPH readback ($reason, attempt ${attempt + 1}): $commandedKph")
             if (commandedKph != null && commandedKph <= BELT_STOPPED_KPH) {
-                logger.i(TAG, "Belt halt confirmed (KPH=$commandedKph) before disconnect")
-                return
+                logger.i(TAG, "Belt stopped confirmed ($reason, KPH=$commandedKph)")
+                return true
             }
             delay(STATE_CONFIRM_POLL_MS)
         }
-        logger.w(TAG, "Belt halt not confirmed after $BELT_HALT_CONFIRM_ATTEMPTS attempts — sent KPH=0 + PAUSE, proceeding")
+        logger.w(TAG, "Belt halt timed out ($reason) after $BELT_HALT_CONFIRM_ATTEMPTS attempts — KPH=0 + PAUSE was sent")
+        return false
+    }
+
+    /** Ends a belt workout without ending the USB session or its polling loop. */
+    private suspend fun stopWorkoutSafely() {
+        logger.i(TAG, "StopWorkout requested: beginning connected treadmill stop sequence")
+
+        // Stop supersedes any target changes which have not reached the MCU yet. Holding
+        // commandMutex prevents a later Resume from being queued until this sequence completes.
+        pendingWriteMutex.withLock {
+            if (pendingWriteFields.isNotEmpty()) {
+                logger.i(TAG, "StopWorkout: discarding ${pendingWriteFields.size} queued write(s) before belt halt")
+            }
+            pendingWriteFields = emptyMap()
+        }
+        lastSentSpeed = 0f
+
+        haltBeltConfirmed("StopWorkout")
+
+        logger.i(TAG, "StopWorkout: writing WORKOUT_MODE=IDLE")
+        val finalMode = writeAndConfirmWorkoutMode(WorkoutMode.IDLE) { it == WorkoutMode.IDLE }
+        if (finalMode == WorkoutMode.IDLE) {
+            logger.i(TAG, "StopWorkout complete: final WORKOUT_MODE=IDLE; USB session remains connected")
+        } else {
+            logger.w(TAG, "StopWorkout complete without IDLE readback confirmation; USB session remains connected")
+        }
     }
 
     override suspend fun identify(): DeviceIdentity? {
@@ -273,6 +305,12 @@ class V1Session(
     }
 
     override suspend fun writeFeature(command: DeviceCommand) {
+        commandMutex.withLock {
+            writeFeatureSerialized(command)
+        }
+    }
+
+    private suspend fun writeFeatureSerialized(command: DeviceCommand) {
         if (command is DeviceCommand.CalibrateIncline) {
             if (_sessionState.value !is SessionState.Streaming) {
                 throw IllegalStateException("Not connected")
@@ -284,6 +322,12 @@ class V1Session(
         }
 
         if (_sessionState.value !is SessionState.Streaming) return
+
+        logger.i(TAG, "Command requested: ${command::class.simpleName}")
+        if (command is DeviceCommand.StopWorkout && detectedDeviceType.isBeltBased) {
+            ioMutex.withLock { stopWorkoutSafely() }
+            return
+        }
 
         val fields = commandToFields(command)
 
@@ -331,6 +375,9 @@ class V1Session(
                 put(V1DataField.WORKOUT_MODE, WorkoutMode.RUNNING.raw)
             }
         }
+        // V1 belt machines handle this as a confirmed sequence in writeFeatureSerialized. For
+        // non-belt V1 equipment, retain the historical stop-as-pause behavior.
+        is DeviceCommand.StopWorkout -> mapOf(V1DataField.WORKOUT_MODE to WorkoutMode.PAUSE.raw)
         is DeviceCommand.CalibrateIncline -> emptyMap()
         is DeviceCommand.SetFanSpeed -> mapOf(V1DataField.FAN_STATE to command.level.toFloat())
         is DeviceCommand.SetVolume -> mapOf(V1DataField.VOLUME to command.level.toFloat())
@@ -362,7 +409,8 @@ class V1Session(
         logger.i(
             TAG,
             "Device info: sw=$softwareVersion, hw=$hardwareVersion, serial=$serialNumber, " +
-                "equipmentDeviceId=$equipmentDeviceId, supportedBitFields=${supportedBitFields.size}",
+                "equipmentDeviceId=$equipmentDeviceId, supportedBitFields=${supportedBitFields.size} " +
+                "${supportedBitFields.sorted()}",
         )
         pollFields = computePollFields(supportedBitFields)
         detectedDeviceType = DeviceDatabase.deviceTypeFromEquipmentId(equipmentDeviceId)
@@ -526,9 +574,11 @@ class V1Session(
             V1DataField.IDLE_MODE_LOCKOUT.fieldIndex in supportedBitFields
 
         if (supportsRequireStart) {
+            logger.i(TAG, "Console init: writing REQUIRE_START_REQUESTED=ENABLED")
             writeConsoleField(V1DataField.REQUIRE_START_REQUESTED, FIELD_ENABLED)
         }
         if (!isTreadmill && supportsIdleLockout) {
+            logger.i(TAG, "Console init: writing IDLE_MODE_LOCKOUT=ENABLED")
             writeConsoleField(V1DataField.IDLE_MODE_LOCKOUT, FIELD_ENABLED)
         }
     }
@@ -573,15 +623,9 @@ class V1Session(
      * Brings the console up to the workout-active state the way the firmware expects. Two paths,
      * because treadmills and aerobic machines have fundamentally different start safety:
      *
-     * - **Treadmill / incline trainer**: arm the console in WARM_UP and stop. Writing
-     *   `WORKOUT_MODE=RUNNING` from the app does *not* move the belt — the MCU gates belt motion
-     *   on a rising edge of the read-only `START_REQUESTED` telemetry (set when the user presses
-     *   the physical Start key). Writing RUNNING anyway would just time out the confirmation poll
-     *   and surface as a (semantically wrong) "console didn't confirm the workout started"
-     *   degraded warning. Instead, the orchestrator parks in
-     *   [com.nettarion.hyperborea.core.orchestration.OrchestratorState.AwaitingConsoleStart] and
-     *   the running [pollOnce] loop picks up `WORKOUT_MODE=RUNNING` once the MCU completes the
-     *   transition.
+     * - **Treadmill / incline trainer**: remain in IDLE. Real V1 treadmill firmware starts its belt
+     *   when WARM_UP is written, so connection alone must never make that transition. ResumeWorkout
+     *   is the sole software action that writes RUNNING.
      * - **Bike / elliptical / rower**: drive the state machine ourselves —
      *   `IDLE → WARM_UP(10) → RUNNING(2)` with confirmation polling. `IDLE_MODE_LOCKOUT` must be
      *   disabled immediately before writing RUNNING (the firmware refuses the RUNNING transition
@@ -592,11 +636,14 @@ class V1Session(
      */
     private suspend fun transitionToActive() {
         if (detectedDeviceType == DeviceType.TREADMILL) {
-            if (supportsIdleLockout()) {
-                writeConsoleField(V1DataField.IDLE_MODE_LOCKOUT, FIELD_DISABLED)
-            }
-            val mode = writeAndConfirmWorkoutMode(WorkoutMode.WARM_UP) { it != WorkoutMode.IDLE }
-            logger.i(TAG, "Console state: IDLE → ${mode ?: WorkoutMode.UNKNOWN} (awaiting physical Start key)")
+            val currentMode = accumulator.snapshot().workoutMode
+                ?.let { WorkoutMode.fromRaw(it.toFloat()) }
+                ?: WorkoutMode.UNKNOWN
+            logger.i(
+                TAG,
+                "V1 startup: detectedDeviceType=$detectedDeviceType, current WORKOUT_MODE=$currentMode; " +
+                    "skipping transitionToActive and leaving the treadmill stopped in IDLE",
+            )
             _degradedReason.value = null
             return
         }
@@ -613,6 +660,7 @@ class V1Session(
     }
 
     private suspend fun writeAndConfirmWorkoutMode(target: WorkoutMode, accept: (WorkoutMode) -> Boolean): WorkoutMode? {
+        logger.i(TAG, "Writing WORKOUT_MODE=$target")
         repeat((STATE_CONFIRM_TIMEOUT_MS / STATE_CONFIRM_POLL_MS).toInt()) { attempt ->
             // Assert the target on the first attempt; subsequent attempts just poll the read-back.
             val response = sendReadWrite(
@@ -640,10 +688,24 @@ class V1Session(
         writeFields: Map<V1DataField, Float> = emptyMap(),
         readFields: Set<V1DataField> = emptySet(),
     ): V1Message.Incoming.DataResponse? {
+        logSafetyWrites(writeFields)
         writeMessage(V1Message.Outgoing.ReadWriteData(writeFields = writeFields, readFields = readFields))
         delay(READ_DELAY_MS)
         val raw = readPacketOrNull() ?: return null
         return V1Codec.decodeSingleDataResponse(raw, readFields.ifEmpty { V1DataField.periodicReadFields })
+    }
+
+    private fun logSafetyWrites(writeFields: Map<V1DataField, Float>) {
+        writeFields[V1DataField.WORKOUT_MODE]?.let {
+            logger.i(TAG, "Explicit WORKOUT_MODE write: ${WorkoutMode.fromRaw(it)} ($it)")
+        }
+        writeFields[V1DataField.KPH]?.let { logger.i(TAG, "Explicit KPH write: $it") }
+        writeFields[V1DataField.IDLE_MODE_LOCKOUT]?.let {
+            logger.i(TAG, "Explicit IDLE_MODE_LOCKOUT write: $it")
+        }
+        writeFields[V1DataField.REQUIRE_START_REQUESTED]?.let {
+            logger.i(TAG, "Explicit REQUIRE_START_REQUESTED write: $it")
+        }
     }
 
     private suspend fun writeMessage(message: V1Message.Outgoing) {
@@ -688,12 +750,17 @@ class V1Session(
         }
     }
 
-    private suspend fun pollOnce() {
+    private suspend fun pollOnce() = ioMutex.withLock {
+        pollOnceLocked()
+    }
+
+    private suspend fun pollOnceLocked() {
         val writeFields: Map<V1DataField, Float>
         pendingWriteMutex.withLock {
             writeFields = pendingWriteFields
             pendingWriteFields = emptyMap()
         }
+        logSafetyWrites(writeFields)
 
         // ReadWriteData targets DEVICE_MAIN (0x02) — FITNESS_BIKE (0x07) returns DEV_NOT_SUPPORTED.
         // pollFields is periodicReadFields ∩ supportedBitFields so the response payload size matches
@@ -755,7 +822,9 @@ class V1Session(
                 logger.w(
                     TAG,
                     "DataResponse payload size doesn't match the requested ${pollFields.size}-field shape " +
-                        "(decoded ${decoded.fields.size} field(s)) — later field offsets may be unreliable.",
+                        "(requested=[${pollFields.sortedBy { it.fieldIndex }.joinToString { it.name }}], " +
+                        "decoded ${decoded.fields.size}=[${decoded.fields.keys.joinToString { it.name }}], " +
+                        "supportedBitFields=${supportedBitFields.sorted()}) — later field offsets may be unreliable.",
                 )
             } else if (!decoded.isTruncated && lastTruncatedSeen) {
                 logger.i(TAG, "DataResponse payload size now matches the requested field shape again.")

--- a/src/android/fitpro/com/nettarion/hyperborea/hardware/fitpro/v2/V2Session.kt
+++ b/src/android/fitpro/com/nettarion/hyperborea/hardware/fitpro/v2/V2Session.kt
@@ -202,7 +202,8 @@ class V2Session(
                 V2FeatureId.GOAL_WATTS,
                 command.watts.toFloat(),
             )
-            is DeviceCommand.PauseWorkout -> {
+            is DeviceCommand.PauseWorkout,
+            is DeviceCommand.StopWorkout -> {
                 accumulator.pause()
                 V2Message.Outgoing.WriteFeature(V2FeatureId.WORKOUT_STATE, V2WorkoutMode.PAUSED.raw)
             }

--- a/src/android/src/FitProDeviceService.kt
+++ b/src/android/src/FitProDeviceService.kt
@@ -258,7 +258,7 @@ object FitProDeviceService {
     @JvmStatic fun startWorkout() { send(DeviceCommand.ResumeWorkout) }
     @JvmStatic fun resumeWorkout() { send(DeviceCommand.ResumeWorkout) }
     @JvmStatic fun pauseWorkout() { send(DeviceCommand.PauseWorkout) }
-    @JvmStatic fun stopWorkout() { send(DeviceCommand.PauseWorkout) }
+    @JvmStatic fun stopWorkout() { send(DeviceCommand.StopWorkout) }
 
     @JvmStatic fun startWorkoutStateMonitoring() { /* handled by the exerciseData collector */ }
     @JvmStatic fun stopWorkoutStateMonitoring() { /* no-op */ }

--- a/src/devices/nordictrackifitadbtreadmill/nordictrackifitadbtreadmill.cpp
+++ b/src/devices/nordictrackifitadbtreadmill/nordictrackifitadbtreadmill.cpp
@@ -864,10 +864,7 @@ void nordictrackifitadbtreadmill::update() {
 
                         // Only call Start() if QZ is not already running (to avoid toggling pause)
                         if (qzPausedOrStopped) {
-                            requestStartOrigin = ORIGIN_GRPC;
-                            requestStopOrigin = ORIGIN_GRPC;
-                            requestPauseOrigin = ORIGIN_GRPC;
-                            homeform::singleton()->Start();
+                            homeform::singleton()->StartFromDevice();
                         } else {
                             emit debug("QZ already running, not calling Start() again");
                         }
@@ -878,17 +875,14 @@ void nordictrackifitadbtreadmill::update() {
                          (currentWorkoutState == 1 && (previousState == 3 || previousState == 4 || previousState == 5))) {
                     emit debug("Workout completed in iFit app - showing workout complete screen");
                     if (homeform::singleton()) {
-                        requestStopOrigin = ORIGIN_GRPC;
-                        homeform::singleton()->StopRequested();
+                        homeform::singleton()->StopFromDevice();
                     }
                 }
                 // If workout paused (RUNNING -> PAUSED)
                 else if (currentWorkoutState == 4 && previousState == 3) {
                     emit debug("Workout paused in iFit app - auto-pausing QZ recording");
                     if (homeform::singleton()) {
-                        requestStopOrigin = ORIGIN_GRPC;
-                        requestPauseOrigin = ORIGIN_GRPC;
-                        homeform::singleton()->Start();
+                        homeform::singleton()->PauseFromDevice();
                     }
                 }
 
@@ -1306,14 +1300,12 @@ void nordictrackifitadbtreadmill::startGrpcWorkoutStateMonitoring() {
         } else if (initialState == 4) { // PAUSED
             emit debug("iFit workout paused - auto-pausing QZ recording");
             if (homeform::singleton()) {
-                requestPauseOrigin = ORIGIN_GRPC;
-                homeform::singleton()->Start(); // This will pause since QZ is already running
+                homeform::singleton()->PauseFromDevice();
             }
         } else if (initialState == 1 || initialState == 5) { // IDLE or RESULTS
             emit debug("iFit workout stopped/idle - auto-stopping QZ recording");
             if (homeform::singleton()) {
-                requestStopOrigin = ORIGIN_GRPC;
-                homeform::singleton()->Stop();
+                homeform::singleton()->StopFromDevice();
             }
         }
 

--- a/src/homeform.cpp
+++ b/src/homeform.cpp
@@ -5851,6 +5851,7 @@ void homeform::Start_inner(bool send_event_to_device) {
 
         paused = false;
         stopped = false;
+        m_deviceStopDispatched = false;
     }
 
     if (settings.value(QZSettings::top_bar_enabled, QZSettings::default_top_bar_enabled).toBool()) {
@@ -5880,7 +5881,7 @@ void homeform::PauseFromDevice() {
 
 void homeform::StopFromDevice() {
     qDebug() << QStringLiteral("Physical stop button pressed on device - stopping app");
-    Stop();
+    Stop_inner(false);  // State synchronization only: the device has already stopped itself.
 }
 
 void homeform::StartRequested() {
@@ -5902,7 +5903,9 @@ void homeform::StopFromTrainProgram(bool paused) {
     Stop();
 }
 
-void homeform::Stop() {
+void homeform::Stop() { Stop_inner(true); }
+
+void homeform::Stop_inner(bool send_event_to_device) {
     QSettings settings;
 
     m_startRequested = false;
@@ -5916,10 +5919,21 @@ void homeform::Stop() {
 #endif
 #endif
 
-    qDebug() << QStringLiteral("Stop pressed - paused") << paused << QStringLiteral("stopped") << stopped;
+    qDebug() << QStringLiteral("Stop_inner: origin=")
+             << (send_event_to_device ? QStringLiteral("LOCAL") : QStringLiteral("FITPRO"))
+             << QStringLiteral("paused=") << paused << QStringLiteral("qzStopped=") << stopped
+             << QStringLiteral("deviceStopDispatched=") << m_deviceStopDispatched;
 
     if (stopped) {
-        qDebug() << QStringLiteral("Stop pressed - already pressed, ignoring...");
+        if (send_event_to_device && !m_deviceStopDispatched && bluetoothManager->device()) {
+            qDebug() << QStringLiteral("Stop_inner: QZ already stopped but physical Stop was not dispatched; propagating now");
+            m_deviceStopDispatched = true;
+            bluetoothManager->device()->stop(false);
+        } else {
+            qDebug() << QStringLiteral("Stop_inner: QZ state already stopped; device propagation")
+                     << (send_event_to_device ? QStringLiteral("already dispatched by the local action")
+                                              : QStringLiteral("suppressed for hardware origin"));
+        }
         return;
     }
 
@@ -5947,8 +5961,12 @@ void homeform::Stop() {
         }
     }
 
-    if (bluetoothManager->device()) {
+    if (bluetoothManager->device() && send_event_to_device && !m_deviceStopDispatched) {
+        qDebug() << QStringLiteral("Stop_inner: propagating local Stop to connected device");
+        m_deviceStopDispatched = true;
         bluetoothManager->device()->stop(false);
+    } else if (bluetoothManager->device()) {
+        qDebug() << QStringLiteral("Stop_inner: suppressing outbound device Stop for hardware-originated state");
     }
 
     paused = false;

--- a/src/homeform.h
+++ b/src/homeform.h
@@ -1073,6 +1073,8 @@ public:
 
     bool m_autoresistance = true;
     bool m_stopRequested = false;
+    // Device-command deduplication is independent from the QZ recording/UI stopped state.
+    bool m_deviceStopDispatched = false;
     bool m_startRequested = false;
     bool m_overridePower = false;
     bool m_nativeShortcutCaptureSuspended = false;
@@ -1124,6 +1126,7 @@ public:
     bool getDevice();
     bool getLap();
     void Start_inner(bool send_event_to_device);
+    void Stop_inner(bool send_event_to_device);
     QTextToSpeech *ensureSpeech();
 
     QTextToSpeech *m_speech = nullptr;
@@ -1177,6 +1180,11 @@ public:
     void Start();
     void Stop();
     void StopRequested();
+    // Device-originated controls are public slots because device implementations invoke them
+    // directly while suppressing command echo back to the physical console.
+    void StartFromDevice();
+    void PauseFromDevice();
+    void StopFromDevice();
 
   private slots:
     void StopFromTrainProgram(bool paused);
@@ -1254,10 +1262,6 @@ public:
     void garmin_upload_file_prepare();
     void garmin_download_todays_workout();
     void handleRestoreDefaultWheelDiameter();
-    void StartFromDevice();  // Called when physical start button pressed on hardware
-    void PauseFromDevice();  // Called when physical pause button pressed on hardware
-    void StopFromDevice();   // Called when physical stop button pressed on hardware
-
 #if defined(Q_OS_WIN) || (defined(Q_OS_MAC) && !defined(Q_OS_IOS)) || (defined(Q_OS_ANDROID) && defined(LICENSE))
     void licenseReply(QNetworkReply *reply);
     void licenseTimeout();


### PR DESCRIPTION
### Motivation
- Provide a proper `StopWorkout` command that safely stops belt-based equipment without disconnecting the USB session and prevent unsafe interleaving with other commands.
- Avoid accidental belt starts on connect by ensuring belt motion only begins on explicit `ResumeWorkout` and improve safety/logging around explicit writes to critical fields.

### Description
- Introduces `DeviceCommand.StopWorkout` and updates the JNI surface to send `StopWorkout` instead of reusing `PauseWorkout` via `FitProDeviceService.stopWorkout`.
- Implements serialized command and IO ordering in `V1Session` by adding `commandMutex` and `ioMutex`, making `writeFeature` acquire `commandMutex` and protecting multi-step safety sequences with `ioMutex`.
- Adds a safe belt-stop flow: `stopWorkoutSafely()` clears queued writes, halts belt with `haltBeltConfirmed(reason)`, writes `WORKOUT_MODE=IDLE` and confirms mode; `haltBeltConfirmed` now returns success/failure and accepts a `reason` for logging.
- Locks poll and write round-trips with `ioMutex` and logs safety-relevant writes via `logSafetyWrites`, plus various logging and handshake/poll robustness improvements; V1 startup/transition behavior is adjusted to keep treadmills in `IDLE` until explicit resume.
- Makes `V2Session` treat `StopWorkout` the same as `PauseWorkout` (pause accumulator and write paused state), preserving expected behavior for V2 devices.
- Propagates device-originated start/pause/stop into the application UI stack by adding `StartFromDevice`, `PauseFromDevice`, `StopFromDevice` slots and refactors stop handling in `homeform` to avoid echoing device-originated stop events and to track `m_deviceStopDispatched` for deduplication.
- Updates `nordictrackifitadbtreadmill` glue to call the new `*FromDevice` methods and to stop/start/pause the app appropriately when the remote device changes workout state.

### Testing
- Built Android project artifacts with `./gradlew assembleDebug` and the build completed successfully.
- Ran JVM unit tests with `./gradlew test` and the test suite completed without failures for the modified modules.
- Built the native Qt/C++ components (project build) and the build completed successfully.
- No new automated unit tests were added for the new `StopWorkout` behavior in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c89dd495c8325ade0cf068259943f)