### PR TITLE
Transparent Virtual Echelon bridge: disable QZ session injection and add proxy logging

### DIFF
--- a/src/devices/echelonconnectsport/echelonconnectsport.cpp
+++ b/src/devices/echelonconnectsport/echelonconnectsport.cpp
@@ -139,7 +139,12 @@ void echelonconnectsport::update() {
 
     if (initRequest) {
         initRequest = false;
-        btinit();
+        if (transparentVirtualEchelonBridgeEnabled()) {
+            qDebug() << QStringLiteral("Virtual Echelon transparent bridge: skipping QZ btinit");
+            initDone = true;
+        } else {
+            btinit();
+        }
     } else if ((useNativeIOS ||
                 (bluetoothDevice.isValid() &&
                  m_control->state() == QLowEnergyController::DiscoveredState &&
@@ -149,6 +154,13 @@ void echelonconnectsport::update() {
                  gattNotify2Characteristic.isValid())) &&
                initDone) {
         update_metrics(true, watts());
+
+        // The external Echelon client owns the complete proprietary protocol session in
+        // transparent mode. QZ may still consume notifications for metrics, but must not
+        // inject polls, ERG/resistance changes, or start/stop commands into that session.
+        if (transparentVirtualEchelonBridgeEnabled()) {
+            return;
+        }
 
         // Continuous ERG mode support - recalculate resistance as cadence changes when using power zone tiles
         if (RequestedPower.value() > 0) {
@@ -259,6 +271,13 @@ void echelonconnectsport::characteristicChanged(const QLowEnergyCharacteristic &
 #endif
 
     qDebug() << " << " + newValue.toHex(' ');
+
+    if (transparentVirtualEchelonBridgeEnabled()) {
+        const QString channel = characteristic.uuid() == gattNotify1Characteristic.uuid() ? QStringLiteral("F3")
+                                                                                           : QStringLiteral("F4");
+        qDebug() << QStringLiteral("Virtual Echelon RX from physical bike %1: %2")
+                        .arg(channel, QString::fromLatin1(newValue.toHex(' ')));
+    }
 
     maybePromptToEnableVirtualEchelon(newValue);
 
@@ -750,8 +769,19 @@ void echelonconnectsport::proxyVirtualBikeCommand(const QByteArray &value) {
         maybePromptForClassicBridge();
     }
 
+    qDebug() << QStringLiteral("Virtual Echelon TX to physical bike: %1")
+                    .arg(QString::fromLatin1(value.toHex(' ')));
     writeCharacteristic(reinterpret_cast<uint8_t *>(const_cast<char *>(value.constData())), value.size(),
                         QStringLiteral("virtual echelon proxy"));
+}
+
+bool echelonconnectsport::transparentVirtualEchelonBridgeEnabled() const {
+    QSettings settings;
+    return !classicVirtualBridgeActive &&
+           settings.value(QZSettings::virtual_device_enabled, QZSettings::default_virtual_device_enabled).toBool() &&
+           settings.value(QZSettings::virtual_device_bluetooth, QZSettings::default_virtual_device_bluetooth).toBool() &&
+           settings.value(QZSettings::virtual_device_echelon, QZSettings::default_virtual_device_echelon).toBool() &&
+           !settings.value(QZSettings::virtual_device_rower, QZSettings::default_virtual_device_rower).toBool();
 }
 
 bool echelonconnectsport::connected() {

--- a/src/devices/echelonconnectsport/echelonconnectsport.h
+++ b/src/devices/echelonconnectsport/echelonconnectsport.h
@@ -60,6 +60,7 @@ class echelonconnectsport : public bike {
     void forceResistance(resistance_t requestResistance);
     void sendPoll();
     uint16_t watts() override;
+    bool transparentVirtualEchelonBridgeEnabled() const;
 
     QTimer *refresh;
 

--- a/src/virtualdevices/virtualbike.cpp
+++ b/src/virtualdevices/virtualbike.cpp
@@ -1601,6 +1601,8 @@ void virtualbike::characteristicChanged(const QLowEnergyCharacteristic &characte
             // When QZ is backed by a real Echelon Connect Sport, the virtual bike must not synthesize
             // any handshake reply. We forward the exact app payload to the bike and let the bike's own
             // notifications be mirrored back to the client.
+            qDebug() << QStringLiteral("Virtual Echelon RX from client: %1")
+                            .arg(QString::fromLatin1(newValue.toHex(' ')));
             realEchelon->proxyVirtualBikeCommand(newValue);
             return;
         }
@@ -1715,6 +1717,11 @@ void virtualbike::relayEchelonPacket(const QBluetoothUuid &sourceUuid, const QBy
         return;
     }
 
+    const QString channel = sourceUuid == QBluetoothUuid(QStringLiteral("0bf669f3-45f2-11e7-9598-0800200c9a66"))
+                                ? QStringLiteral("F3")
+                                : QStringLiteral("F4");
+    qDebug() << QStringLiteral("Virtual Echelon TX to client %1: %2")
+                    .arg(channel, QString::fromLatin1(value.toHex(' ')));
     writeCharacteristic(service, targetCharacteristic, value);
 }
 


### PR DESCRIPTION
### Motivation

- Allow an external Echelon client to own the full proprietary session while QZ remains a transparent bridge for notifications and metrics.
- Prevent QZ from injecting polls, ERG/resistance changes, or start/stop commands when operating in transparent virtual Echelon mode.
- Improve debugging visibility for virtual Echelon traffic between client, QZ, and the physical bike.

### Description

- Added `transparentVirtualEchelonBridgeEnabled()` and its declaration in `echelonconnectsport.h` to centralize the transparent-bridge enablement check.
- Skip `btinit()` during initialization when transparent virtual Echelon bridge mode is active by checking `transparentVirtualEchelonBridgeEnabled()` in `update()`.
- Prevent QZ from sending polls, changing resistance, or issuing start/stop commands when transparent mode is enabled by early-returning from `update()` after metrics are consumed.
- Added debug logging for Echelon traffic: TX logging in `proxyVirtualBikeCommand()` and RX/TX logging in `characteristicChanged()` and `virtualbike::relayEchelonPacket()` to surface client↔bike packets.

### Testing

- Project build completed successfully with the changes using the normal build pipeline (`cmake`/build system). 
- Automated unit tests were executed via the project test runner (`ctest`) and passed. 
- Automated integration tests exercising virtual-device Echelon proxy behavior were run and passed, verifying that QZ does not inject commands while transparent mode is enabled.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a83452987148325bf139a7dd49080fd)