### PR TITLE
Implement SRAM AXS encrypted drivetrain support

### DIFF
--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -429,7 +429,7 @@ bool bluetooth::zwiftDeviceAvaiable() {
 bool bluetooth::sramDeviceAvaiable() {
 
     Q_FOREACH (QBluetoothDeviceInfo b, devices) {
-        if (b.name().toUpper().startsWith("SRAM ")) {
+        if (sramaxscontroller::isCompatibleDevice(b)) {
            return true;
         }
     }
@@ -3361,7 +3361,7 @@ void bluetooth::connectedAndDiscovered() {
 
     if(settings.value(QZSettings::sram_axs_controller, QZSettings::default_sram_axs_controller).toBool()) {
         for (const QBluetoothDeviceInfo &b : qAsConst(devices)) {
-            if (((b.name().toUpper().startsWith("SRAM "))) && !sramAXSController && this->device() &&
+            if (sramaxscontroller::isCompatibleDevice(b) && !sramAXSController && this->device() &&
                     this->device()->deviceType() == BIKE) {
 
                 sramAXSController = new sramaxscontroller();

--- a/src/devices/sramAXSController/sramAXSController.cpp
+++ b/src/devices/sramAXSController/sramAXSController.cpp
@@ -1,274 +1,408 @@
 #include "sramAXSController.h"
+
+#include "sramAXSCrypto.h"
+#include "homeform.h"
+
 #include <QBluetoothLocalDevice>
 #include <QDateTime>
 #include <QEventLoop>
-#include <QFile>
 #include <QMetaEnum>
+#include <QRandomGenerator>
+#include <QRegularExpression>
 #include <QSettings>
-#include <QThread>
 #include <QTimer>
-#include <QEventLoop>
-#include <chrono>
 
-using namespace std::chrono_literals;
+namespace {
+const quint16 SRAM_COMPANY_ID = 0x0933;
+const int SRAM_MAX_GEAR = 24;
 
-sramaxscontroller::sramaxscontroller() {}
+bool readVarint(const QByteArray &bytes, int &offset, quint64 &value) {
+    value = 0;
+    int shift = 0;
+    while (offset < bytes.size() && shift <= 63) {
+        const uint8_t byte = static_cast<uint8_t>(bytes.at(offset++));
+        value |= static_cast<quint64>(byte & 0x7f) << shift;
+        if ((byte & 0x80) == 0) return true;
+        shift += 7;
+    }
+    return false;
+}
 
-void sramaxscontroller::update() {}
+bool skipField(const QByteArray &bytes, int &offset, int wireType) {
+    quint64 length = 0;
+    switch (wireType) {
+    case 0: return readVarint(bytes, offset, length);
+    case 1: offset += 8; return offset <= bytes.size();
+    case 2: return readVarint(bytes, offset, length) && length <= static_cast<quint64>(bytes.size() - offset) &&
+                   ((offset += static_cast<int>(length)) >= 0);
+    case 5: offset += 4; return offset <= bytes.size();
+    default: return false;
+    }
+}
+}
+
+sramaxscontroller::sramaxscontroller() {
+    reconnectTimer.setSingleShot(true);
+    connect(&reconnectTimer, &QTimer::timeout, this, [this]() {
+        if (m_control && m_control->state() == QLowEnergyController::UnconnectedState)
+            m_control->connectToDevice();
+    });
+}
+
+const QBluetoothUuid sramaxscontroller::liveStateUuid() {
+    return QBluetoothUuid(QStringLiteral("d905000b-90aa-4c7c-b036-1e01fb8eb7ee"));
+}
+
+const QBluetoothUuid sramaxscontroller::liveStateChangedUuid() {
+    return QBluetoothUuid(QStringLiteral("d9050054-90aa-4c7c-b036-1e01fb8eb7ee"));
+}
+
+const QBluetoothUuid sramaxscontroller::drivetrainConfigUuid() {
+    return QBluetoothUuid(QStringLiteral("d9050025-90aa-4c7c-b036-1e01fb8eb7ee"));
+}
+
+const QBluetoothUuid sramaxscontroller::bondServiceUuid() {
+    return QBluetoothUuid(QStringLiteral("d905ee51-90aa-4c7c-b036-1e01fb8eb7ee"));
+}
+
+const QBluetoothUuid sramaxscontroller::bondCharacteristicUuid() {
+    return QBluetoothUuid(QStringLiteral("d905ee52-90aa-4c7c-b036-1e01fb8eb7ee"));
+}
+
+const QBluetoothUuid sramaxscontroller::serialUuid() {
+    return QBluetoothUuid(QStringLiteral("d905fe54-90aa-4c7c-b036-1e01fb8eb7ee"));
+}
+
+bool sramaxscontroller::isCompatibleDevice(const QBluetoothDeviceInfo &device) {
+    const QString name = device.name().trimmed();
+    const bool namedSram = name.startsWith(QStringLiteral("SRAM "), Qt::CaseInsensitive) && name.size() > 5;
+    return namedSram || device.manufacturerIds().contains(SRAM_COMPANY_ID);
+}
+
+int sramaxscontroller::decodeRearGear(const QByteArray &plaintext) {
+    int offset = 0;
+    while (offset < plaintext.size()) {
+        quint64 key = 0;
+        if (!readVarint(plaintext, offset, key)) return -1;
+        const int field = static_cast<int>(key >> 3);
+        const int wireType = static_cast<int>(key & 7);
+        if (field <= 0) return -1;
+        if (field == 21 && wireType == 0) {
+            quint64 value = 0;
+            if (!readVarint(plaintext, offset, value) || value < 1 || value > SRAM_MAX_GEAR) return -1;
+            return static_cast<int>(value);
+        }
+        if (!skipField(plaintext, offset, wireType)) return -1;
+    }
+    return -1;
+}
+
+int sramaxscontroller::decodeRearGearCount(const QByteArray &plaintext) {
+    int offset = 0;
+    while (offset < plaintext.size()) {
+        quint64 key = 0;
+        if (!readVarint(plaintext, offset, key)) return -1;
+        const int field = static_cast<int>(key >> 3);
+        const int wireType = static_cast<int>(key & 7);
+        if (field == 24 && wireType == 0) {
+            quint64 value = 0;
+            if (!readVarint(plaintext, offset, value) || value < 1 || value > SRAM_MAX_GEAR) return -1;
+            return static_cast<int>(value);
+        }
+        if (!skipField(plaintext, offset, wireType)) return -1;
+    }
+    return -1;
+}
+
+int sramaxscontroller::virtualGearDirectionForRearDelta(int delta) {
+    if (delta == 0) return 0;
+    return delta < 0 ? 1 : -1; // 1 = QZ gear up, -1 = QZ gear down
+}
+
+void sramaxscontroller::deviceDiscovered(const QBluetoothDeviceInfo &device) {
+    if (!isCompatibleDevice(device)) return;
+    bluetoothDevice = device;
+    deviceIdentifier = device.name().trimmed().mid(5).toUtf8();
+    m_control = QLowEnergyController::createCentral(bluetoothDevice, this);
+    connect(m_control, &QLowEnergyController::serviceDiscovered, this, &sramaxscontroller::serviceDiscovered);
+    connect(m_control, &QLowEnergyController::discoveryFinished, this, &sramaxscontroller::serviceScanDone);
+    connect(m_control, &QLowEnergyController::connected, this, [this]() {
+        emit debug(QStringLiteral("SRAM AXS connected; discovering services"));
+        m_control->discoverServices();
+    });
+    connect(m_control, &QLowEnergyController::disconnected, this, [this]() {
+        emit debug(QStringLiteral("SRAM AXS disconnected; waiting to reconnect"));
+        readyStarted = false;
+        pairingStarted = false;
+        lastRearGear = -1;
+        services.clear();
+        liveService = nullptr;
+        bondService = nullptr;
+        serialService = nullptr;
+        configService = nullptr;
+        emit disconnected();
+        if (!reconnectTimer.isActive()) reconnectTimer.start(1500);
+    });
+    connect(m_control, &QLowEnergyController::stateChanged, this, &sramaxscontroller::controllerStateChanged);
+    connect(m_control, static_cast<void (QLowEnergyController::*)(QLowEnergyController::Error)>(&QLowEnergyController::error),
+            this, &sramaxscontroller::error);
+    m_control->connectToDevice();
+}
+
+bool sramaxscontroller::connected() {
+    return m_control && (m_control->state() == QLowEnergyController::DiscoveredState ||
+                         m_control->state() == QLowEnergyController::ConnectedState);
+}
 
 void sramaxscontroller::serviceDiscovered(const QBluetoothUuid &gatt) {
-    emit debug(QStringLiteral("serviceDiscovered ") + gatt.toString());
+    Q_UNUSED(gatt);
 }
 
-void sramaxscontroller::writeCharacteristic(QLowEnergyService *service, QLowEnergyCharacteristic characteristic,
-                                           uint8_t *data, uint8_t data_len, QString info, bool disable_log,
-                                           bool wait_for_response) {
-    QEventLoop loop;
-    QTimer timeout;
-
-    if (!service) {
-        qDebug() << "no gattCustomService available";
-        return;
-    }
-
-    if (wait_for_response) {
-        connect(service, &QLowEnergyService::characteristicChanged, &loop, &QEventLoop::quit);
-        timeout.singleShot(300ms, &loop, &QEventLoop::quit);
-    } else {
-        connect(service, &QLowEnergyService::characteristicWritten, &loop, &QEventLoop::quit);
-        timeout.singleShot(300ms, &loop, &QEventLoop::quit);
-    }
-
-    if (writeBuffer) {
-        delete writeBuffer;
-    }
-    writeBuffer = new QByteArray((const char *)data, data_len);
-
-    if (characteristic.properties() & QLowEnergyCharacteristic::WriteNoResponse) {
-        service->writeCharacteristic(characteristic, *writeBuffer, QLowEnergyService::WriteWithoutResponse);
-    } else {
-        service->writeCharacteristic(characteristic, *writeBuffer);
-    }
-
-    if (!disable_log)
-        qDebug() << " >> " << writeBuffer->toHex(' ') << " // " << info;
-
-    loop.exec();
-}
-
-
-void sramaxscontroller::disconnectBluetooth() {
-    qDebug() << QStringLiteral("sramaxscontroller::disconnect") << m_control;
-
-    if (m_control) {
-        m_control->disconnectFromDevice();
-    }
-}
-
-void sramaxscontroller::characteristicChanged(const QLowEnergyCharacteristic &characteristic, const QByteArray &newValue) {
-    // qDebug() << "characteristicChanged" << characteristic.uuid() << newValue << newValue.length();
-    Q_UNUSED(characteristic);
-    emit packetReceived();
-
-    qDebug() << QStringLiteral(" << ") << characteristic.uuid() << newValue.toHex(' ');
-
-    QBluetoothUuid sx(QStringLiteral("d905000b-90aa-4c7c-b036-1e01fb8eb7ee"));
-    QBluetoothUuid dx(QStringLiteral("d9050054-90aa-4c7c-b036-1e01fb8eb7ee"));
-    if(characteristic.uuid() == sx) {
-        emit plus();
-    } else if(characteristic.uuid() == dx) {
-        emit minus();
+void sramaxscontroller::serviceScanDone() {
+    if (!m_control) return;
+    const QList<QBluetoothUuid> serviceUuids = m_control->services();
+    for (const QBluetoothUuid &uuid : serviceUuids) {
+        QLowEnergyService *service = m_control->createServiceObject(uuid, this);
+        if (!service) continue;
+        services.append(service);
+        connect(service, &QLowEnergyService::stateChanged, this, &sramaxscontroller::stateChanged);
+        connect(service, &QLowEnergyService::characteristicChanged, this, &sramaxscontroller::characteristicChanged);
+        connect(service, &QLowEnergyService::characteristicRead, this, &sramaxscontroller::characteristicRead);
+        connect(service, &QLowEnergyService::characteristicWritten, this, &sramaxscontroller::characteristicWritten);
+        connect(service, &QLowEnergyService::descriptorWritten, this, &sramaxscontroller::descriptorWritten);
+        connect(service, static_cast<void (QLowEnergyService::*)(QLowEnergyService::ServiceError)>(&QLowEnergyService::error),
+                this, &sramaxscontroller::errorService);
+        service->discoverDetails();
     }
 }
 
 void sramaxscontroller::stateChanged(QLowEnergyService::ServiceState state) {
-    QBluetoothUuid _gattWriteCharCustomService (QStringLiteral("d905ee51-90aa-4c7c-b036-1e01fb8eb7ee"));
-    QBluetoothUuid _gattWriteCharControlPointId(QStringLiteral("d905ee52-90aa-4c7c-b036-1e01fb8eb7ee"));
-    QMetaEnum metaEnum = QMetaEnum::fromType<QLowEnergyService::ServiceState>();
-    emit debug(QStringLiteral("BTLE stateChanged ") + QString::fromLocal8Bit(metaEnum.valueToKey(state)));
+    if (state != QLowEnergyService::ServiceDiscovered) return;
+    for (QLowEnergyService *service : qAsConst(services))
+        if (service->state() != QLowEnergyService::ServiceDiscovered && service->state() != QLowEnergyService::InvalidService) return;
+    if (readyStarted) return;
 
-    for (QLowEnergyService *s : qAsConst(gattCommunicationChannelService)) {
-        qDebug() << QStringLiteral("stateChanged") << s->serviceUuid() << s->state();
+    for (QLowEnergyService *service : qAsConst(services)) {
+        if (service->state() != QLowEnergyService::ServiceDiscovered) continue;
+        for (const QLowEnergyCharacteristic &characteristic : service->characteristics()) {
+            const QBluetoothUuid uuid = characteristic.uuid();
+            if (uuid == liveStateUuid()) { liveService = service; liveCharacteristic = characteristic; }
+            if (uuid == liveStateChangedUuid()) { liveStateChangedCharacteristic = characteristic; }
+            if (uuid == drivetrainConfigUuid()) { configService = service; drivetrainConfigCharacteristic = characteristic; }
+            if (uuid == bondCharacteristicUuid()) { bondService = service; bondCharacteristic = characteristic; }
+            if (uuid == serialUuid()) { serialService = service; serialCharacteristic = characteristic; }
 
-        if (s->state() != QLowEnergyService::ServiceDiscovered && s->state() != QLowEnergyService::InvalidService) {
-            qDebug() << QStringLiteral("not all services discovered");
-            return;
-        }
-    }
-
-    qDebug() << QStringLiteral("all services discovered!");
-
-    notificationSubscribed = 0;
-
-    for (QLowEnergyService *s : qAsConst(gattCommunicationChannelService)) {
-        if (s->state() == QLowEnergyService::ServiceDiscovered) {
-            // establish hook into notifications
-            connect(s, &QLowEnergyService::characteristicChanged, this, &sramaxscontroller::characteristicChanged);
-            connect(s, &QLowEnergyService::characteristicWritten, this, &sramaxscontroller::characteristicWritten);
-            connect(
-                s, static_cast<void (QLowEnergyService::*)(QLowEnergyService::ServiceError)>(&QLowEnergyService::error),
-                this, &sramaxscontroller::errorService);
-            connect(s, &QLowEnergyService::descriptorWritten, this, &sramaxscontroller::descriptorWritten);
-
-            qDebug() << s->serviceUuid() << QStringLiteral("connected!");
-
-            auto characteristics_list = s->characteristics();
-            for (const QLowEnergyCharacteristic &c : qAsConst(characteristics_list)) {
-                qDebug() << QStringLiteral("char uuid") << c.uuid() << QStringLiteral("handle") << c.handle() << c.properties();
-
-                if (c.uuid() == _gattWriteCharControlPointId) {
-                    qDebug() << QStringLiteral("Custom service found");
-                    gattWriteCharControlPointId = c;
-                    gattWriteCharCustomService = s;
-                }
+            if ((uuid == liveStateUuid() || uuid == liveStateChangedUuid() || uuid == bondCharacteristicUuid()) &&
+                characteristic.descriptor(QBluetoothUuid::ClientCharacteristicConfiguration).isValid()) {
+                const QByteArray ccc = (characteristic.properties() & QLowEnergyCharacteristic::Indicate) ? QByteArray::fromHex("0200") : QByteArray::fromHex("0100");
+                service->writeDescriptor(characteristic.descriptor(QBluetoothUuid::ClientCharacteristicConfiguration), ccc);
             }
         }
     }
-
-    for (QLowEnergyService *s : qAsConst(gattCommunicationChannelService)) {
-        if (s->state() == QLowEnergyService::ServiceDiscovered) {
-            auto characteristics_list = s->characteristics();
-            for (const QLowEnergyCharacteristic &c : qAsConst(characteristics_list)) {
-                auto descriptors_list = c.descriptors();
-                for (const QLowEnergyDescriptor &d : qAsConst(descriptors_list)) {
-                    qDebug() << QStringLiteral("descriptor uuid") << d.uuid() << QStringLiteral("handle") << d.handle();
-                }
-
-                if ((c.properties() & QLowEnergyCharacteristic::Notify) == QLowEnergyCharacteristic::Notify) {
-                    QByteArray descriptor;
-                    descriptor.append((char)0x01);
-                    descriptor.append((char)0x00);
-                    if (c.descriptor(QBluetoothUuid::ClientCharacteristicConfiguration).isValid()) {
-                        s->writeDescriptor(c.descriptor(QBluetoothUuid::ClientCharacteristicConfiguration), descriptor);
-                        notificationSubscribed++;
-                    } else {
-                        qDebug() << QStringLiteral("ClientCharacteristicConfiguration") << c.uuid()
-                                 << c.descriptor(QBluetoothUuid::ClientCharacteristicConfiguration).uuid()
-                                 << c.descriptor(QBluetoothUuid::ClientCharacteristicConfiguration).handle()
-                                 << QStringLiteral(" is not valid");
-                    }
-
-                    qDebug() << s->serviceUuid() << c.uuid() << QStringLiteral("notification subscribed!");
-                } else if ((c.properties() & QLowEnergyCharacteristic::Indicate) == QLowEnergyCharacteristic::Indicate) {
-                    QByteArray descriptor;
-                    descriptor.append((char)0x02);
-                    descriptor.append((char)0x00);
-                    if (c.descriptor(QBluetoothUuid::ClientCharacteristicConfiguration).isValid()) {
-                        s->writeDescriptor(c.descriptor(QBluetoothUuid::ClientCharacteristicConfiguration), descriptor);
-                        notificationSubscribed++;
-                    } else {
-                        qDebug() << QStringLiteral("ClientCharacteristicConfiguration") << c.uuid()
-                                 << c.descriptor(QBluetoothUuid::ClientCharacteristicConfiguration).uuid()
-                                 << c.descriptor(QBluetoothUuid::ClientCharacteristicConfiguration).handle()
-                                 << QStringLiteral(" is not valid");
-                    }
-
-                    qDebug() << s->serviceUuid() << c.uuid() << QStringLiteral("indication subscribed!");
-                }
-            }
-        }
-    }
+    readyStarted = true;
+    QTimer::singleShot(500, this, &sramaxscontroller::beginReady);
 }
 
-void sramaxscontroller::descriptorWritten(const QLowEnergyDescriptor &descriptor, const QByteArray &newValue) {
-    emit debug(QStringLiteral("descriptorWritten ") + descriptor.name() + " " + newValue.toHex(' '));
-
-    if (notificationSubscribed)
-        notificationSubscribed--;
-
-    if (!notificationSubscribed) {
-        uint8_t d = 0x73;
-        if(gattWriteCharCustomService) {
-            writeCharacteristic(gattWriteCharCustomService, gattWriteCharControlPointId, &d, 1, "init", false, true);
-        } else {
-            qDebug() << "ERROR! no custom services found!";
-        }
-    }
-}
-
-void sramaxscontroller::characteristicWritten(const QLowEnergyCharacteristic &characteristic, const QByteArray &newValue) {
-    Q_UNUSED(characteristic);
-    emit debug(QStringLiteral("characteristicWritten ") + newValue.toHex(' '));
-}
-
-void sramaxscontroller::serviceScanDone(void) {
-    emit debug(QStringLiteral("serviceScanDone"));
-
-    auto services_list = m_control->services();
-    for (const QBluetoothUuid &s : qAsConst(services_list)) {
-        qDebug() << s << "discovering...";
-        gattCommunicationChannelService.append(m_control->createServiceObject(s));
-        connect(gattCommunicationChannelService.constLast(), &QLowEnergyService::stateChanged, this,
-                &sramaxscontroller::stateChanged);
-        gattCommunicationChannelService.constLast()->discoverDetails();
-    }
-}
-
-void sramaxscontroller::errorService(QLowEnergyService::ServiceError err) {
-    QMetaEnum metaEnum = QMetaEnum::fromType<QLowEnergyService::ServiceError>();
-    emit debug(QStringLiteral("sramaxscontroller::errorService") + QString::fromLocal8Bit(metaEnum.valueToKey(err)) +
-               m_control->errorString());
-}
-
-void sramaxscontroller::error(QLowEnergyController::Error err) {
-    QMetaEnum metaEnum = QMetaEnum::fromType<QLowEnergyController::Error>();
-    emit debug(QStringLiteral("sramaxscontroller::error") + QString::fromLocal8Bit(metaEnum.valueToKey(err)) +
-               m_control->errorString());
-}
-
-void sramaxscontroller::deviceDiscovered(const QBluetoothDeviceInfo &device) {
-    QSettings settings;
-    // QString sramaxscontrollerName = settings.value(QZSettings::heart_rate_belt_name),
-    // QStringLiteral("Disabled")).toString();//NOTE: clazy-unused-non-trivial-variable
-    emit debug(QStringLiteral("Found new device: ") + device.name() + QStringLiteral(" (") +
-               device.address().toString() + ')');
-    // if(device.name().startsWith(sramaxscontrollerName))
-    {
-        bluetoothDevice = device;
-        m_control = QLowEnergyController::createCentral(bluetoothDevice, this);
-        connect(m_control, &QLowEnergyController::serviceDiscovered, this, &sramaxscontroller::serviceDiscovered);
-        connect(m_control, &QLowEnergyController::discoveryFinished, this, &sramaxscontroller::serviceScanDone);
-        connect(m_control,
-                static_cast<void (QLowEnergyController::*)(QLowEnergyController::Error)>(&QLowEnergyController::error),
-                this, &sramaxscontroller::error);
-        connect(m_control, &QLowEnergyController::stateChanged, this, &sramaxscontroller::controllerStateChanged);
-
-        connect(m_control,
-                static_cast<void (QLowEnergyController::*)(QLowEnergyController::Error)>(&QLowEnergyController::error),
-                this, [this](QLowEnergyController::Error error) {
-                    Q_UNUSED(error);
-                    Q_UNUSED(this);
-                    emit debug(QStringLiteral("Cannot connect to remote device."));
-                    emit disconnected();
-                });
-        connect(m_control, &QLowEnergyController::connected, this, [this]() {
-            Q_UNUSED(this);
-            emit debug(QStringLiteral("Controller connected. Search services..."));
-            m_control->discoverServices();
-        });
-        connect(m_control, &QLowEnergyController::disconnected, this, [this]() {
-            Q_UNUSED(this);
-            emit debug(QStringLiteral("LowEnergy controller disconnected"));
-            emit disconnected();
-        });
-
-        // Connect
-        m_control->connectToDevice();
+void sramaxscontroller::beginReady() {
+    if (!liveService || !liveCharacteristic.isValid()) {
+        emit debug(QStringLiteral("SRAM AXS live-state characteristic not found"));
         return;
     }
+    if (serialService && serialCharacteristic.properties() & QLowEnergyCharacteristic::Read) {
+        serialService->readCharacteristic(serialCharacteristic);
+        return;
+    }
+    loadStoredKey();
+    if (deviceKey.isEmpty()) startPairing(); else startMonitoring();
 }
 
-bool sramaxscontroller::connected() {
-    if (!m_control) {
-        return false;
+void sramaxscontroller::characteristicRead(const QLowEnergyCharacteristic &characteristic, const QByteArray &newValue) {
+    if (characteristic.uuid() == serialUuid() && newValue.size() >= 4) {
+        const uint32_t serial = static_cast<uint8_t>(newValue.at(0)) |
+                                (static_cast<uint32_t>(static_cast<uint8_t>(newValue.at(1))) << 8) |
+                                (static_cast<uint32_t>(static_cast<uint8_t>(newValue.at(2))) << 16) |
+                                (static_cast<uint32_t>(static_cast<uint8_t>(newValue.at(3))) << 24);
+        deviceIdentifier = QByteArray::number(serial);
+        loadStoredKey();
+        if (deviceKey.isEmpty()) startPairing(); else startMonitoring();
+    } else if (characteristic.uuid() == liveStateUuid()) {
+        processLiveFrame(newValue);
+    } else if (characteristic.uuid() == drivetrainConfigUuid()) {
+        const QByteArray plaintext = sramaxscrypto::eaxDecrypt(deviceKey, newValue.left(16), newValue.mid(16));
+        const int count = sramaxscontroller::decodeRearGearCount(plaintext);
+        if (count > 0) totalRearGears = count;
     }
-    return m_control->state() == QLowEnergyController::DiscoveredState;
+}
+
+void sramaxscontroller::characteristicChanged(const QLowEnergyCharacteristic &characteristic, const QByteArray &newValue) {
+    emit packetReceived();
+    if (characteristic.uuid() == bondCharacteristicUuid()) {
+        bondResponses.enqueue(newValue);
+        emit bondResponseReceived();
+        return;
+    }
+    if (characteristic.uuid() == liveStateUuid() && newValue.size() >= 32) processLiveFrame(newValue);
+    if (characteristic.uuid() == liveStateUuid() || characteristic.uuid() == liveStateChangedUuid())
+        QTimer::singleShot(0, this, &sramaxscontroller::readLiveState);
+}
+
+void sramaxscontroller::readLiveState() {
+    if (liveService && liveCharacteristic.isValid() && (liveCharacteristic.properties() & QLowEnergyCharacteristic::Read))
+        liveService->readCharacteristic(liveCharacteristic);
+}
+
+void sramaxscontroller::processLiveFrame(const QByteArray &frame) {
+    if (frame.size() < 32 || deviceKey.size() != 16) return;
+    bool authenticated = false;
+    const QByteArray plaintext = sramaxscrypto::eaxDecrypt(deviceKey, frame.left(16), frame.mid(16), &authenticated);
+    if (authenticated) processPlaintext(plaintext);
+}
+
+void sramaxscontroller::processPlaintext(const QByteArray &plaintext) {
+    const int rearGear = decodeRearGear(plaintext);
+    if (rearGear < 1) return;
+    if (lastRearGear < 0) { lastRearGear = rearGear; return; }
+    const int delta = rearGear - lastRearGear;
+    if (delta == 0 || qAbs(delta) > totalRearGears) return;
+    lastRearGear = rearGear;
+    const int direction = virtualGearDirectionForRearDelta(delta);
+    for (int i = 0; i < qAbs(delta); ++i) {
+        if (direction > 0) emit plus(); else emit minus();
+    }
+}
+
+QString sramaxscontroller::deviceIdentifierString() const {
+    return QString::fromUtf8(deviceIdentifier).trimmed().isEmpty()
+               ? QStringLiteral("unknown") : QString::fromUtf8(deviceIdentifier).trimmed();
+}
+
+QString sramaxscontroller::keySettingName() const {
+    QString id = deviceIdentifierString();
+    id.replace(QRegularExpression(QStringLiteral("[^A-Za-z0-9_-]")), QStringLiteral("_"));
+    return QStringLiteral("sram_axs_key/") + id;
+}
+
+void sramaxscontroller::loadStoredKey() {
+    QSettings settings;
+    const QByteArray stored = QByteArray::fromHex(settings.value(keySettingName()).toByteArray());
+    deviceKey = stored.size() == 16 ? stored : QByteArray();
+    emit debug(deviceKey.isEmpty() ? QStringLiteral("SRAM AXS key not found") : QStringLiteral("SRAM AXS key loaded"));
+}
+
+void sramaxscontroller::startMonitoring() {
+    if (deviceKey.size() != 16) return;
+    emit debug(QStringLiteral("SRAM AXS drivetrain monitoring started"));
+    if (drivetrainConfigCharacteristic.isValid() && (drivetrainConfigCharacteristic.properties() & QLowEnergyCharacteristic::Read))
+        configService->readCharacteristic(drivetrainConfigCharacteristic);
+    readLiveState();
+}
+
+void sramaxscontroller::writeBondValue(const QByteArray &value) {
+    if (!bondService || !bondCharacteristic.isValid()) return;
+    const QLowEnergyService::WriteMode mode = (bondCharacteristic.properties() & QLowEnergyCharacteristic::WriteNoResponse)
+                                                  ? QLowEnergyService::WriteWithoutResponse : QLowEnergyService::WriteWithResponse;
+    if (mode == QLowEnergyService::WriteWithResponse) {
+        QEventLoop loop;
+        QTimer timeout;
+        timeout.setSingleShot(true);
+        const QMetaObject::Connection connection = connect(bondService, &QLowEnergyService::characteristicWritten, &loop,
+                                                            [&](const QLowEnergyCharacteristic &characteristic, const QByteArray &) {
+                                                                if (characteristic.uuid() == bondCharacteristicUuid()) loop.quit();
+                                                            });
+        connect(&timeout, &QTimer::timeout, &loop, &QEventLoop::quit);
+        bondService->writeCharacteristic(bondCharacteristic, value, mode);
+        timeout.start(2000);
+        loop.exec();
+        disconnect(connection);
+        return;
+    }
+    bondService->writeCharacteristic(bondCharacteristic, value, mode);
+}
+
+QByteArray sramaxscontroller::waitForBondValue(int minimumLength, int timeoutMs, int exactLength) {
+    QByteArray accumulated;
+    auto take = [this, minimumLength, exactLength, &accumulated]() {
+        while (!bondResponses.isEmpty()) {
+            const QByteArray value = bondResponses.dequeue();
+            if (exactLength != 0) {
+                if (value.size() == exactLength) return value;
+            } else {
+                accumulated.append(value);
+                if (accumulated.size() >= minimumLength) return accumulated.left(minimumLength);
+            }
+        }
+        return QByteArray();
+    };
+    QByteArray result = take();
+    if (!result.isEmpty()) return result;
+    QEventLoop loop;
+    QTimer timeout;
+    timeout.setSingleShot(true);
+    const QMetaObject::Connection connection = connect(this, &sramaxscontroller::bondResponseReceived, &loop, [&]() {
+        result = take();
+        if (!result.isEmpty()) loop.quit();
+    });
+    connect(&timeout, &QTimer::timeout, &loop, &QEventLoop::quit);
+    timeout.start(timeoutMs);
+    loop.exec();
+    disconnect(connection);
+    return result;
+}
+
+void sramaxscontroller::startPairing() {
+    if (pairingStarted || !bondService || !bondCharacteristic.isValid()) return;
+    pairingStarted = true;
+    emit debug(QStringLiteral("SRAM AXS has no stored key; hold the AXS button until its light blinks"));
+    if (homeform::singleton()) homeform::singleton()->setToastRequested(QStringLiteral("Hold SRAM AXS button until it blinks"));
+    QTimer::singleShot(3000, this, [this]() {
+        bondResponses.clear();
+        writeBondValue(QByteArray::fromHex("000102030405060708090a0b0c0d0e0f"));
+        QByteArray privateKey(16, Qt::Uninitialized);
+        for (int i = 0; i < privateKey.size(); ++i) privateKey[i] = static_cast<char>(QRandomGenerator::system()->generate() & 0xff);
+        const QByteArray publicKey = sramaxscrypto::computePublicKey(privateKey);
+        writeBondValue(publicKey);
+        const QByteArray devicePublicKey = waitForBondValue(16, 5000, 16);
+        const QByteArray sharedSecret = sramaxscrypto::computeSharedSecret(privateKey, devicePublicKey);
+        const QByteArray transportBlob = waitForBondValue(48);
+        bool authenticated = false;
+        const QByteArray newKey = sramaxscrypto::decryptTransportedKey(sharedSecret, transportBlob, &authenticated);
+        if (!authenticated || newKey.size() != 16) {
+            emit debug(QStringLiteral("SRAM AXS pairing failed (no authenticated key)"));
+            pairingStarted = false;
+            return;
+        }
+        writeBondValue(QByteArray(1, static_cast<char>(0x73)));
+        deviceKey = newKey;
+        QSettings settings;
+        settings.setValue(keySettingName(), deviceKey.toHex());
+        emit debug(QStringLiteral("SRAM AXS key generated and stored"));
+        startMonitoring();
+    });
+}
+
+void sramaxscontroller::disconnectBluetooth() {
+    reconnectTimer.stop();
+    if (m_control) m_control->disconnectFromDevice();
 }
 
 void sramaxscontroller::controllerStateChanged(QLowEnergyController::ControllerState state) {
-    qDebug() << QStringLiteral("controllerStateChanged") << state;
-    if (state == QLowEnergyController::UnconnectedState && m_control) {
-        qDebug() << QStringLiteral("trying to connect back again...");
-        m_control->connectToDevice();
-    }
+    if (state == QLowEnergyController::UnconnectedState && m_control && !reconnectTimer.isActive()) reconnectTimer.start(1500);
+}
+
+void sramaxscontroller::characteristicWritten(const QLowEnergyCharacteristic &characteristic, const QByteArray &newValue) {
+    Q_UNUSED(characteristic); Q_UNUSED(newValue);
+}
+
+void sramaxscontroller::descriptorWritten(const QLowEnergyDescriptor &descriptor, const QByteArray &newValue) {
+    Q_UNUSED(descriptor); Q_UNUSED(newValue);
+}
+
+void sramaxscontroller::error(QLowEnergyController::Error err) {
+    Q_UNUSED(err);
+    emit debug(QStringLiteral("SRAM AXS controller error: ") + m_control->errorString());
+}
+
+void sramaxscontroller::errorService(QLowEnergyService::ServiceError err) {
+    Q_UNUSED(err);
+    emit debug(QStringLiteral("SRAM AXS service error"));
 }

--- a/src/devices/sramAXSController/sramAXSController.h
+++ b/src/devices/sramAXSController/sramAXSController.h
@@ -2,28 +2,12 @@
 #define SRAMAXSCONTROLLER_H
 
 #include <QBluetoothDeviceDiscoveryAgent>
-#include <QtBluetooth/qlowenergyadvertisingdata.h>
-#include <QtBluetooth/qlowenergyadvertisingparameters.h>
 #include <QtBluetooth/qlowenergycharacteristic.h>
-#include <QtBluetooth/qlowenergycharacteristicdata.h>
 #include <QtBluetooth/qlowenergycontroller.h>
-#include <QtBluetooth/qlowenergydescriptordata.h>
 #include <QtBluetooth/qlowenergyservice.h>
-#include <QtBluetooth/qlowenergyservicedata.h>
 #include <QtCore/qbytearray.h>
-
-#ifndef Q_OS_ANDROID
-#include <QtCore/qcoreapplication.h>
-#else
-#include <QtGui/qguiapplication.h>
-#endif
-#include <QtCore/qlist.h>
-#include <QtCore/qmutex.h>
-#include <QtCore/qscopedpointer.h>
+#include <QtCore/qqueue.h>
 #include <QtCore/qtimer.h>
-
-#include <QObject>
-#include <QTime>
 
 #include "devices/bluetoothdevice.h"
 
@@ -33,16 +17,52 @@ class sramaxscontroller : public bluetoothdevice {
     sramaxscontroller();
     bool connected() override;
 
+    static bool isCompatibleDevice(const QBluetoothDeviceInfo &device);
+    static int decodeRearGear(const QByteArray &plaintext);
+    static int decodeRearGearCount(const QByteArray &plaintext);
+    // QZ's virtual gear-up means a harder/larger virtual ratio. SRAM positions
+    // increase toward the larger/easier cassette cogs, so the directions invert.
+    static int virtualGearDirectionForRearDelta(int delta);
+
   private:
-    QList<QLowEnergyService *> gattCommunicationChannelService;
-    QLowEnergyCharacteristic gattWriteCharControlPointId;
-    QLowEnergyService* gattWriteCharCustomService;
+    static const QBluetoothUuid liveStateUuid();
+    static const QBluetoothUuid liveStateChangedUuid();
+    static const QBluetoothUuid drivetrainConfigUuid();
+    static const QBluetoothUuid bondServiceUuid();
+    static const QBluetoothUuid bondCharacteristicUuid();
+    static const QBluetoothUuid serialUuid();
 
-    void writeCharacteristic(QLowEnergyService *service, QLowEnergyCharacteristic characteristic,
-                                               uint8_t *data, uint8_t data_len, QString info, bool disable_log,
-                                               bool wait_for_response);
+    QList<QLowEnergyService *> services;
+    QLowEnergyService *liveService = nullptr;
+    QLowEnergyService *bondService = nullptr;
+    QLowEnergyService *serialService = nullptr;
+    QLowEnergyService *configService = nullptr;
+    QLowEnergyCharacteristic liveCharacteristic;
+    QLowEnergyCharacteristic liveStateChangedCharacteristic;
+    QLowEnergyCharacteristic drivetrainConfigCharacteristic;
+    QLowEnergyCharacteristic bondCharacteristic;
+    QLowEnergyCharacteristic serialCharacteristic;
 
-    volatile int notificationSubscribed = 0;
+    QByteArray deviceKey;
+    QByteArray deviceIdentifier;
+    QQueue<QByteArray> bondResponses;
+    QTimer reconnectTimer;
+    int lastRearGear = -1;
+    int totalRearGears = 24;
+    bool pairingStarted = false;
+    bool readyStarted = false;
+
+    void writeBondValue(const QByteArray &value);
+    QByteArray waitForBondValue(int minimumLength, int timeoutMs = 5000, int exactLength = 0);
+    void beginReady();
+    void loadStoredKey();
+    void startMonitoring();
+    void startPairing();
+    void readLiveState();
+    void processLiveFrame(const QByteArray &frame);
+    void processPlaintext(const QByteArray &plaintext);
+    QString keySettingName() const;
+    QString deviceIdentifierString() const;
 
   signals:
     void disconnected();
@@ -50,24 +70,23 @@ class sramaxscontroller : public bluetoothdevice {
     void packetReceived();
     void plus();
     void minus();
+    void bondResponseReceived();
 
   public slots:
     void deviceDiscovered(const QBluetoothDeviceInfo &device);
     void disconnectBluetooth();
 
   private slots:
-
     void characteristicChanged(const QLowEnergyCharacteristic &characteristic, const QByteArray &newValue);
+    void characteristicRead(const QLowEnergyCharacteristic &characteristic, const QByteArray &newValue);
     void characteristicWritten(const QLowEnergyCharacteristic &characteristic, const QByteArray &newValue);
     void descriptorWritten(const QLowEnergyDescriptor &descriptor, const QByteArray &newValue);
     void stateChanged(QLowEnergyService::ServiceState state);
     void controllerStateChanged(QLowEnergyController::ControllerState state);
-
     void serviceDiscovered(const QBluetoothUuid &gatt);
-    void serviceScanDone(void);
-    void update();
+    void serviceScanDone();
     void error(QLowEnergyController::Error err);
-    void errorService(QLowEnergyService::ServiceError);
+    void errorService(QLowEnergyService::ServiceError err);
 };
 
 #endif // SRAMAXSCONTROLLER_H

--- a/src/devices/sramAXSController/sramAXSCrypto.cpp
+++ b/src/devices/sramAXSController/sramAXSCrypto.cpp
@@ -1,0 +1,297 @@
+#include "sramAXSCrypto.h"
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+
+namespace {
+
+using Block = std::array<uint8_t, 16>;
+
+static const uint8_t sbox[256] = {
+    0x63,0x7c,0x77,0x7b,0xf2,0x6b,0x6f,0xc5,0x30,0x01,0x67,0x2b,0xfe,0xd7,0xab,0x76,
+    0xca,0x82,0xc9,0x7d,0xfa,0x59,0x47,0xf0,0xad,0xd4,0xa2,0xaf,0x9c,0xa4,0x72,0xc0,
+    0xb7,0xfd,0x93,0x26,0x36,0x3f,0xf7,0xcc,0x34,0xa5,0xe5,0xf1,0x71,0xd8,0x31,0x15,
+    0x04,0xc7,0x23,0xc3,0x18,0x96,0x05,0x9a,0x07,0x12,0x80,0xe2,0xeb,0x27,0xb2,0x75,
+    0x09,0x83,0x2c,0x1a,0x1b,0x6e,0x5a,0xa0,0x52,0x3b,0xd6,0xb3,0x29,0xe3,0x2f,0x84,
+    0x53,0xd1,0x00,0xed,0x20,0xfc,0xb1,0x5b,0x6a,0xcb,0xbe,0x39,0x4a,0x4c,0x58,0xcf,
+    0xd0,0xef,0xaa,0xfb,0x43,0x4d,0x33,0x85,0x45,0xf9,0x02,0x7f,0x50,0x3c,0x9f,0xa8,
+    0x51,0xa3,0x40,0x8f,0x92,0x9d,0x38,0xf5,0xbc,0xb6,0xda,0x21,0x10,0xff,0xf3,0xd2,
+    0xcd,0x0c,0x13,0xec,0x5f,0x97,0x44,0x17,0xc4,0xa7,0x7e,0x3d,0x64,0x5d,0x19,0x73,
+    0x60,0x81,0x4f,0xdc,0x22,0x2a,0x90,0x88,0x46,0xee,0xb8,0x14,0xde,0x5e,0x0b,0xdb,
+    0xe0,0x32,0x3a,0x0a,0x49,0x06,0x24,0x5c,0xc2,0xd3,0xac,0x62,0x91,0x95,0xe4,0x79,
+    0xe7,0xc8,0x37,0x6d,0x8d,0xd5,0x4e,0xa9,0x6c,0x56,0xf4,0xea,0x65,0x7a,0xae,0x08,
+    0xba,0x78,0x25,0x2e,0x1c,0xa6,0xb4,0xc6,0xe8,0xdd,0x74,0x1f,0x4b,0xbd,0x8b,0x8a,
+    0x70,0x3e,0xb5,0x66,0x48,0x03,0xf6,0x0e,0x61,0x35,0x57,0xb9,0x86,0xc1,0x1d,0x9e,
+    0xe1,0xf8,0x98,0x11,0x69,0xd9,0x8e,0x94,0x9b,0x1e,0x87,0xe9,0xce,0x55,0x28,0xdf,
+    0x8c,0xa1,0x89,0x0d,0xbf,0xe6,0x42,0x68,0x41,0x99,0x2d,0x0f,0xb0,0x54,0xbb,0x16};
+static const uint8_t rcon[10] = {0x01,0x02,0x04,0x08,0x10,0x20,0x40,0x80,0x1b,0x36};
+
+uint8_t xtime(uint8_t a) { return static_cast<uint8_t>(((a << 1) ^ ((a & 0x80) ? 0x1b : 0)) & 0xff); }
+
+class Aes128 {
+  public:
+    explicit Aes128(const QByteArray &key) {
+        for (int i = 0; i < 16; ++i)
+            roundKeys[static_cast<size_t>(i)] = static_cast<uint8_t>(key.at(i));
+        for (int i = 4; i < 44; ++i) {
+            uint8_t t[4];
+            std::memcpy(t, &roundKeys[static_cast<size_t>((i - 1) * 4)], 4);
+            if ((i % 4) == 0) {
+                const uint8_t first = t[0];
+                t[0] = sbox[t[1]] ^ rcon[(i / 4) - 1];
+                t[1] = sbox[t[2]];
+                t[2] = sbox[t[3]];
+                t[3] = sbox[first];
+            }
+            for (int j = 0; j < 4; ++j)
+                roundKeys[static_cast<size_t>(i * 4 + j)] =
+                    roundKeys[static_cast<size_t>((i - 4) * 4 + j)] ^ t[j];
+        }
+    }
+
+    Block encrypt(const Block &input) const {
+        Block state = input;
+        addRoundKey(state, 0);
+        for (int round = 1; round < 10; ++round) {
+            for (uint8_t &b : state) b = sbox[b];
+            shiftRows(state);
+            mixColumns(state);
+            addRoundKey(state, round);
+        }
+        for (uint8_t &b : state) b = sbox[b];
+        shiftRows(state);
+        addRoundKey(state, 10);
+        return state;
+    }
+
+  private:
+    std::array<uint8_t, 176> roundKeys{};
+
+    void addRoundKey(Block &state, int round) const {
+        for (int i = 0; i < 16; ++i) state[static_cast<size_t>(i)] ^= roundKeys[static_cast<size_t>(round * 16 + i)];
+    }
+
+    static void shiftRows(Block &s) {
+        uint8_t t = s[1]; s[1] = s[5]; s[5] = s[9]; s[9] = s[13]; s[13] = t;
+        t = s[2]; s[2] = s[10]; s[10] = t; t = s[6]; s[6] = s[14]; s[14] = t;
+        t = s[15]; s[15] = s[11]; s[11] = s[7]; s[7] = s[3]; s[3] = t;
+    }
+
+    static void mixColumns(Block &s) {
+        for (int c = 0; c < 4; ++c) {
+            const int i = c * 4;
+            const uint8_t a0 = s[static_cast<size_t>(i)], a1 = s[static_cast<size_t>(i + 1)],
+                          a2 = s[static_cast<size_t>(i + 2)], a3 = s[static_cast<size_t>(i + 3)];
+            s[static_cast<size_t>(i)] = xtime(a0) ^ (xtime(a1) ^ a1) ^ a2 ^ a3;
+            s[static_cast<size_t>(i + 1)] = a0 ^ xtime(a1) ^ (xtime(a2) ^ a2) ^ a3;
+            s[static_cast<size_t>(i + 2)] = a0 ^ a1 ^ xtime(a2) ^ (xtime(a3) ^ a3);
+            s[static_cast<size_t>(i + 3)] = (xtime(a0) ^ a0) ^ a1 ^ a2 ^ xtime(a3);
+        }
+    }
+};
+
+Block blockFrom(const QByteArray &bytes, int offset = 0) {
+    Block out{};
+    for (int i = 0; i < 16 && offset + i < bytes.size(); ++i) out[static_cast<size_t>(i)] = static_cast<uint8_t>(bytes.at(offset + i));
+    return out;
+}
+
+QByteArray blockTo(const Block &block) {
+    QByteArray out(16, Qt::Uninitialized);
+    for (int i = 0; i < 16; ++i) out[i] = static_cast<char>(block[static_cast<size_t>(i)]);
+    return out;
+}
+
+void xorBlock(Block &a, const Block &b) { for (int i = 0; i < 16; ++i) a[static_cast<size_t>(i)] ^= b[static_cast<size_t>(i)]; }
+
+Block shiftLeft(const Block &input) {
+    Block out{};
+    uint8_t carry = 0;
+    for (int i = 15; i >= 0; --i) {
+        out[static_cast<size_t>(i)] = static_cast<uint8_t>((input[static_cast<size_t>(i)] << 1) | carry);
+        carry = static_cast<uint8_t>(input[static_cast<size_t>(i)] >> 7);
+    }
+    return out;
+}
+
+Block cmac(const Aes128 &aes, const QByteArray &message) {
+    Block l = aes.encrypt(Block{});
+    Block k1 = shiftLeft(l); if (l[0] & 0x80) k1[15] ^= 0x87;
+    Block k2 = shiftLeft(k1); if (k1[0] & 0x80) k2[15] ^= 0x87;
+
+    const int blocks = qMax(1, (message.size() + 15) / 16);
+    const bool complete = message.size() > 0 && (message.size() % 16) == 0;
+    Block x{};
+    for (int i = 0; i < blocks - 1; ++i) {
+        xorBlock(x, blockFrom(message, i * 16));
+        x = aes.encrypt(x);
+    }
+    Block last = blockFrom(message, (blocks - 1) * 16);
+    const int remainder = message.size() - (blocks - 1) * 16;
+    if (complete) xorBlock(last, k1);
+    else { last[static_cast<size_t>(remainder)] = 0x80; xorBlock(last, k2); }
+    xorBlock(x, last);
+    return aes.encrypt(x);
+}
+
+Block omac(const Aes128 &aes, uint8_t type, const QByteArray &data) {
+    QByteArray prefixed(16, '\0');
+    prefixed[15] = static_cast<char>(type);
+    prefixed.append(data);
+    return cmac(aes, prefixed);
+}
+
+QByteArray ctr(const Aes128 &aes, const Block &iv, const QByteArray &data) {
+    QByteArray out(data.size(), Qt::Uninitialized);
+    Block counter = iv;
+    for (int offset = 0; offset < data.size(); offset += 16) {
+        const Block stream = aes.encrypt(counter);
+        const int count = qMin(16, data.size() - offset);
+        for (int i = 0; i < count; ++i) out[offset + i] = static_cast<char>(static_cast<uint8_t>(data.at(offset + i)) ^ stream[static_cast<size_t>(i)]);
+        for (int i = 15; i >= 0; --i) { counter[static_cast<size_t>(i)]++; if (counter[static_cast<size_t>(i)] != 0) break; }
+    }
+    return out;
+}
+
+bool equalTag(const Block &a, const QByteArray &b) {
+    if (b.size() != 16) return false;
+    uint8_t difference = 0;
+    for (int i = 0; i < 16; ++i) difference |= a[static_cast<size_t>(i)] ^ static_cast<uint8_t>(b.at(i));
+    return difference == 0;
+}
+
+struct U128 { uint32_t w[4]{}; };
+
+U128 fromBigEndian(const QByteArray &bytes) {
+    U128 out{};
+    for (int i = 0; i < 16; ++i) out.w[i / 4] = (out.w[i / 4] << 8) | static_cast<uint8_t>(bytes.at(i));
+    std::swap(out.w[0], out.w[3]); std::swap(out.w[1], out.w[2]);
+    return out;
+}
+
+QByteArray toBigEndian(const U128 &value) {
+    QByteArray out(16, Qt::Uninitialized);
+    for (int i = 0; i < 4; ++i) for (int j = 0; j < 4; ++j)
+        out[i * 4 + j] = static_cast<char>(value.w[3 - i] >> (24 - j * 8));
+    return out;
+}
+
+int compare(const U128 &a, const U128 &b) {
+    for (int i = 3; i >= 0; --i) if (a.w[i] != b.w[i]) return a.w[i] < b.w[i] ? -1 : 1;
+    return 0;
+}
+
+void subtract(U128 &a, const U128 &b) {
+    uint64_t borrow = 0;
+    for (int i = 0; i < 4; ++i) {
+        const uint64_t sub = static_cast<uint64_t>(b.w[i]) + borrow;
+        const uint64_t old = a.w[i];
+        a.w[i] = static_cast<uint32_t>(old - sub);
+        borrow = old < sub ? 1 : 0;
+    }
+}
+
+U128 reduceProduct(const uint32_t product[8]) {
+    U128 result{};
+    uint64_t carry = 0;
+    for (int i = 0; i < 4; ++i) {
+        const uint64_t value = static_cast<uint64_t>(product[i]) + static_cast<uint64_t>(product[i + 4]) * 713 + carry;
+        result.w[i] = static_cast<uint32_t>(value);
+        carry = value >> 32;
+    }
+    uint64_t high = carry;
+    while (high != 0) {
+        carry = 0;
+        for (int i = 0; i < 4; ++i) {
+            const uint64_t value = static_cast<uint64_t>(result.w[i]) + (i == 0 ? high * 713 : 0) + carry;
+            result.w[i] = static_cast<uint32_t>(value);
+            carry = value >> 32;
+        }
+        high = carry;
+    }
+    const U128 modulus{{0xfffffd37u, 0xffffffffu, 0xffffffffu, 0xffffffffu}};
+    while (compare(result, modulus) >= 0) subtract(result, modulus);
+    return result;
+}
+
+U128 multiplyMod(const U128 &a, const U128 &b) {
+    uint32_t product[8]{};
+    for (int i = 0; i < 4; ++i) {
+        uint64_t carry = 0;
+        for (int j = 0; j < 4; ++j) {
+            const uint64_t value = static_cast<uint64_t>(a.w[i]) * b.w[j] + product[i + j] + carry;
+            product[i + j] = static_cast<uint32_t>(value);
+            carry = value >> 32;
+        }
+        int k = i + 4;
+        while (carry && k < 8) {
+            const uint64_t value = static_cast<uint64_t>(product[k]) + carry;
+            product[k] = static_cast<uint32_t>(value);
+            carry = value >> 32;
+            ++k;
+        }
+    }
+    return reduceProduct(product);
+}
+
+U128 powerMod(U128 base, const QByteArray &littleEndianExponent) {
+    U128 result{{1, 0, 0, 0}};
+    for (int byte = 0; byte < 16; ++byte) {
+        const uint8_t bits = static_cast<uint8_t>(littleEndianExponent.at(byte));
+        for (int bit = 0; bit < 8; ++bit) {
+            if (bits & (1u << bit)) result = multiplyMod(result, base);
+            base = multiplyMod(base, base);
+        }
+    }
+    return result;
+}
+
+} // namespace
+
+namespace sramaxscrypto {
+
+QByteArray eaxEncrypt(const QByteArray &key, const QByteArray &nonce, const QByteArray &message) {
+    if (key.size() != 16 || nonce.size() != 16) return QByteArray();
+    const Aes128 aes(key);
+    const Block nonceTag = omac(aes, 0, nonce);
+    const Block headerTag = omac(aes, 1, QByteArray());
+    const QByteArray ciphertext = ctr(aes, nonceTag, message);
+    const Block ciphertextTag = omac(aes, 2, ciphertext);
+    Block tag = nonceTag; xorBlock(tag, ciphertextTag); xorBlock(tag, headerTag);
+    return ciphertext + blockTo(tag);
+}
+
+QByteArray eaxDecrypt(const QByteArray &key, const QByteArray &nonce, const QByteArray &ciphertextAndTag,
+                     bool *authenticated) {
+    if (authenticated) *authenticated = false;
+    if (key.size() != 16 || nonce.size() != 16 || ciphertextAndTag.size() < 16) return QByteArray();
+    const Aes128 aes(key);
+    const QByteArray ciphertext = ciphertextAndTag.left(ciphertextAndTag.size() - 16);
+    const QByteArray receivedTag = ciphertextAndTag.right(16);
+    const Block nonceTag = omac(aes, 0, nonce);
+    const Block headerTag = omac(aes, 1, QByteArray());
+    const Block ciphertextTag = omac(aes, 2, ciphertext);
+    Block tag = nonceTag; xorBlock(tag, ciphertextTag); xorBlock(tag, headerTag);
+    if (!equalTag(tag, receivedTag)) return QByteArray();
+    if (authenticated) *authenticated = true;
+    return ctr(aes, nonceTag, ciphertext);
+}
+
+QByteArray computePublicKey(const QByteArray &privateKey) {
+    if (privateKey.size() != 16) return QByteArray();
+    U128 generator{{5, 0, 0, 0}};
+    return toBigEndian(powerMod(generator, privateKey));
+}
+
+QByteArray computeSharedSecret(const QByteArray &privateKey, const QByteArray &devicePublicKey) {
+    if (privateKey.size() != 16 || devicePublicKey.size() != 16) return QByteArray();
+    return toBigEndian(powerMod(fromBigEndian(devicePublicKey), privateKey));
+}
+
+QByteArray decryptTransportedKey(const QByteArray &sharedSecret, const QByteArray &transportBlob, bool *authenticated) {
+    if (transportBlob.size() != 48) { if (authenticated) *authenticated = false; return QByteArray(); }
+    return eaxDecrypt(sharedSecret, transportBlob.left(16), transportBlob.mid(16), authenticated);
+}
+
+} // namespace sramaxscrypto

--- a/src/devices/sramAXSController/sramAXSCrypto.h
+++ b/src/devices/sramAXSController/sramAXSCrypto.h
@@ -1,0 +1,19 @@
+#ifndef SRAMAXSCRYPTO_H
+#define SRAMAXSCRYPTO_H
+
+#include <QByteArray>
+
+namespace sramaxscrypto {
+
+QByteArray eaxEncrypt(const QByteArray &key, const QByteArray &nonce, const QByteArray &message);
+QByteArray eaxDecrypt(const QByteArray &key, const QByteArray &nonce, const QByteArray &ciphertextAndTag,
+                     bool *authenticated = nullptr);
+
+QByteArray computePublicKey(const QByteArray &privateKey);
+QByteArray computeSharedSecret(const QByteArray &privateKey, const QByteArray &devicePublicKey);
+QByteArray decryptTransportedKey(const QByteArray &sharedSecret, const QByteArray &transportBlob,
+                                 bool *authenticated = nullptr);
+
+} // namespace sramaxscrypto
+
+#endif // SRAMAXSCRYPTO_H

--- a/src/qdomyos-zwift.pri
+++ b/src/qdomyos-zwift.pri
@@ -106,6 +106,7 @@ SOURCES += \
     $$PWD/devices/sportstechelliptical/sportstechelliptical.cpp \
     $$PWD/devices/cycplusbc2controller/cycplusbc2controller.cpp \
     $$PWD/devices/sramAXSController/sramAXSController.cpp \
+    $$PWD/devices/sramAXSController/sramAXSCrypto.cpp \
     $$PWD/devices/thinkridercontroller/thinkridercontroller.cpp \
     $$PWD/devices/stairclimber.cpp \
     $$PWD/devices/echelonstairclimber/echelonstairclimber.cpp \
@@ -399,6 +400,7 @@ HEADERS += \
     $$PWD/devices/sportstechelliptical/sportstechelliptical.h \
     $$PWD/devices/cycplusbc2controller/cycplusbc2controller.h \
     $$PWD/devices/sramAXSController/sramAXSController.h \
+    $$PWD/devices/sramAXSController/sramAXSCrypto.h \
     $$PWD/devices/thinkridercontroller/thinkridercontroller.h \
     $$PWD/devices/stairclimber.h \
     $$PWD/devices/technogymbike/technogymbike.h \

--- a/src/settings-catalog.json
+++ b/src/settings-catalog.json
@@ -9324,12 +9324,12 @@
     {
       "key": "sram_axs_controller",
       "name": "Sram Axs Controller",
-      "description": null,
+      "description": "Pair with a SRAM AXS drivetrain and use rear-derailleur gear changes as QZ virtual gearing commands.",
       "parent": "General",
       "type": "boolean",
       "qmlType": "bool",
       "control": "switch",
-      "visible": false,
+      "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null

--- a/src/settings.qml
+++ b/src/settings.qml
@@ -14914,7 +14914,6 @@ import AndroidStatusBar 1.0
                         }
                     }
 
-/*
                 AccordionElement {
                         title: qsTr("SRAM Devices Options")
                         indicatRectColor: Material.color(Material.Grey)
@@ -14938,7 +14937,7 @@ import AndroidStatusBar 1.0
                             }
 
                             Label {
-                                text: qsTr("Use it to change the gears on QZ!")
+                                text: qsTr("Use authenticated SRAM AXS rear-derailleur gear changes as QZ virtual gear commands.")
                                 font.bold: true
                                 font.italic: true
                                 font.pixelSize: Qt.application.font.pixelSize - 2
@@ -14950,7 +14949,7 @@ import AndroidStatusBar 1.0
                                 color: Material.color(Material.Lime)
                             }
                         }
-                    }*/
+                    }
 
                 AccordionElement {
                         title: qsTr("Thinkrider Options")

--- a/tst/Devices/TestSramAxs.cpp
+++ b/tst/Devices/TestSramAxs.cpp
@@ -1,0 +1,1 @@
+#include "TestSramAxs.h"

--- a/tst/Devices/TestSramAxs.h
+++ b/tst/Devices/TestSramAxs.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include "devices/sramAXSController/sramAXSCrypto.h"
+#include "devices/sramAXSController/sramAXSController.h"
+
+TEST(SramAxsCryptoTest, DerivesKnownSramBondValues) {
+    const QByteArray privateKey = QByteArray::fromHex("6418b20cb4e1d4cf4af19b184aff1d2a");
+    const QByteArray devicePublicKey = QByteArray::fromHex("9ac11ad0a4f6c2b99c5559e2d210c410");
+    EXPECT_EQ(sramaxscrypto::computePublicKey(privateKey).toHex(), QByteArray("297ca1db5827261af813875fd09800b0"));
+    const QByteArray shared = sramaxscrypto::computeSharedSecret(privateKey, devicePublicKey);
+    EXPECT_EQ(shared.toHex(), QByteArray("55406a336a328156b81019d7ac3d5d24"));
+    bool authenticated = false;
+    const QByteArray key = sramaxscrypto::decryptTransportedKey(
+        shared, QByteArray::fromHex("8d7a16ed42128ee445b9864f20324a0e0b9e1982be7a9ad3cf611f453696fa8d2f24f1878c44eb7f77ff5b4a3c616395"),
+        &authenticated);
+    EXPECT_TRUE(authenticated);
+    EXPECT_EQ(key.toHex(), QByteArray("b0690781867fde13ac1b9d30bbb4004f"));
+}
+
+TEST(SramAxsCryptoTest, MatchesPublishedEaxVectorAndRejectsTampering) {
+    const QByteArray key = QByteArray::fromHex("55406a336a328156b81019d7ac3d5d24");
+    const QByteArray nonce = QByteArray::fromHex("8d7a16ed42128ee445b9864f20324a0e");
+    const QByteArray sealed = sramaxscrypto::eaxEncrypt(key, nonce, QByteArray::fromHex("b0690781867fde13ac1b9d30bbb4004f"));
+    EXPECT_EQ(sealed.toHex(), QByteArray("0b9e1982be7a9ad3cf611f453696fa8d2f24f1878c44eb7f77ff5b4a3c616395"));
+    bool authenticated = false;
+    EXPECT_TRUE(sramaxscrypto::eaxDecrypt(key, nonce, sealed, &authenticated).isEmpty());
+    EXPECT_TRUE(authenticated);
+    QByteArray tampered = sealed;
+    tampered[tampered.size() - 1] = static_cast<char>(tampered.at(tampered.size() - 1) ^ 1);
+    authenticated = true;
+    EXPECT_TRUE(sramaxscrypto::eaxDecrypt(key, nonce, tampered, &authenticated).isEmpty());
+    EXPECT_FALSE(authenticated);
+}
+
+TEST(SramAxsProtocolTest, DecodesRearGearAndDoesNotEmitOnBaseline) {
+    EXPECT_EQ(sramaxscontroller::decodeRearGear(QByteArray::fromHex("a00101a80107b0010c")), 7);
+    EXPECT_EQ(sramaxscontroller::decodeRearGear(QByteArray::fromHex("a80108")), 8);
+    EXPECT_EQ(sramaxscontroller::decodeRearGear(QByteArray::fromHex("a80100")), -1);
+    EXPECT_EQ(sramaxscontroller::virtualGearDirectionForRearDelta(-1), 1);
+    EXPECT_EQ(sramaxscontroller::virtualGearDirectionForRearDelta(1), -1);
+}

--- a/tst/qdomyos-zwift-tests.pro
+++ b/tst/qdomyos-zwift-tests.pro
@@ -35,6 +35,7 @@ SOURCES += \
         Devices/TestRenphoBikeKnobGears.cpp \
         Devices/TestNordictrackEllipticalS700Parser.cpp \
         Devices/TestXcxBikeParser.cpp \
+        Devices/TestSramAxs.cpp \
         main.cpp
 
 # Avoid the "File too big" error building in Windows. This has happened when a template class is used with Google Test / typed tests
@@ -69,6 +70,7 @@ HEADERS += \
     Devices/TestRenphoBikeKnobGears.h \
     Devices/TestNordictrackEllipticalS700Parser.h \
     Devices/TestXcxBikeParser.h \
+    Devices/TestSramAxs.h \
     Devices/TestOctaneTreadmillZR8.h \
     Devices/TestSunnyfitStepper.h \
     Erg/ergtabletestsuite.h \


### PR DESCRIPTION
## Summary

- add SRAM AXS BLE discovery and encrypted SRAMBond v1 pairing
- persist per-device keys and decrypt authenticated AES-128 EAX drivetrain packets
- decode rear-derailleur position and map gear changes to QZ virtual gearing
- add SRAM AXS settings and deterministic protocol tests

## Context

Fixes #2768: https://github.com/cagnulein/qdomyos-zwift/issues/2768

The SRAM AXS protocol implementation was taken from and cross-checked against [GaborWnuk/sram-axs](https://github.com/GaborWnuk/sram-axs), including the documented SRAMBond v1 exchange, AES-EAX behavior, fixtures, and drivetrain status decoding. The implementation is adapted to QZ's Qt/C++ architecture.

## Validation

- `git diff --cached --check`
- `python3 -m json.tool src/settings-catalog.json`
- clang syntax checks for the new Qt/C++ translation units
- deterministic DH, AES-EAX, and protobuf protocol tests added
- full qmake/gtest runtime was not run because the installed Qt qmake binaries are x86-only on this ARM host