### PR TITLE
Avoid FTMS control preamble on SF-T treadmills

### DIFF
--- a/src/devices/horizontreadmill/horizontreadmill.cpp
+++ b/src/devices/horizontreadmill/horizontreadmill.cpp
@@ -1266,7 +1266,7 @@ void horizontreadmill::forceSpeed(double requestSpeed) {
         }
     } else if (gattFTMSService) {
         // for the Tecnogym Myrun
-        if(!anplus_treadmill && !trx3500_treadmill && !wellfit_treadmill && !mobvoi_tmp_treadmill && !SW_TREADMILL && !ICONCEPT_FTMS_treadmill && !YPOO_MINI_PRO && !T3G_PRO && !T3G_ELITE && !FS_TREADMILL) {
+        if(!anplus_treadmill && !trx3500_treadmill && !wellfit_treadmill && !mobvoi_tmp_treadmill && !SW_TREADMILL && !ICONCEPT_FTMS_treadmill && !YPOO_MINI_PRO && !T3G_PRO && !T3G_ELITE && !FS_TREADMILL && !SF_TREADMILL) {
             uint8_t write[] = {FTMS_REQUEST_CONTROL};
             writeCharacteristic(gattFTMSService, gattWriteCharControlPointId, write, sizeof(write), "requestControl", false,
                                 false);
@@ -2780,6 +2780,9 @@ void horizontreadmill::deviceDiscovered(const QBluetoothDeviceInfo &device) {
             qDebug() << QStringLiteral("FS- treadmill found");
             FS_TREADMILL = true;
             maxInclination = 40.0;
+        } else if (device.name().toUpper().startsWith(QStringLiteral("SF-T"))) {
+            qDebug() << QStringLiteral("SF-T treadmill found");
+            SF_TREADMILL = true;
         }
 
         if (device.name().toUpper().startsWith(QStringLiteral("TRX3500"))) {

--- a/src/devices/horizontreadmill/horizontreadmill.h
+++ b/src/devices/horizontreadmill/horizontreadmill.h
@@ -128,6 +128,7 @@ class horizontreadmill : public treadmill {
     bool TM4500 = false;
     bool TM6500 = false;
     bool FS_TREADMILL = false;
+    bool SF_TREADMILL = false;
     bool WT_TREADMILL = false;
     bool THERUN_T15 = false;
     bool MERACH_TREADMILL = false;


### PR DESCRIPTION
### Motivation
- SF-T (Sunny Fitness) treadmills should not receive the FTMS "Request Control"/"Start/Resume" preamble on every speed update because those commands cause incorrect behavior on those units.

### Description
- Add a new `SF_TREADMILL` flag and detect Bluetooth names starting with `SF-T`, and exclude `SF_TREADMILL` from the FTMS preamble that sends `Request Control` and `Start/Resume` during `forceSpeed` in `horizontreadmill`; changes applied to `src/devices/horizontreadmill/horizontreadmill.h` and `src/devices/horizontreadmill/horizontreadmill.cpp`.

### Testing
- Ran automated repository checks and searches: `git diff --check` succeeded and `rg`/searches confirmed the new `SF_TREADMILL` symbol and the updated device-name detection; no unit tests or device integration tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a83d842d0048325b3ab5e4af7aab7cf)