### PR TITLE
Add Apple Health upload to Workout History

### DIFF
--- a/src/WorkoutsHistory.qml
+++ b/src/WorkoutsHistory.qml
@@ -44,15 +44,18 @@ Page {
         }
     }
 
-    function hasAnyUploadServiceConfigured() {
-        return rootItem &&
-               (rootItem.isStravaLoggedIn() ||
-                rootItem.isGarminUploadConfigured() ||
-                rootItem.isIntervalsICUUploadConfigured())
+    function hasAnyUploadServiceConfigured(workoutId) {
+        return (rootItem &&
+                (rootItem.isStravaLoggedIn() ||
+                 rootItem.isGarminUploadConfigured() ||
+                 rootItem.isIntervalsICUUploadConfigured())) ||
+               (Qt.platform.os === "ios" &&
+                workoutModel &&
+                workoutModel.canWriteAppleHealth(workoutId))
     }
 
     function openUploadMenu(delegateItem, workoutId, workoutTitle) {
-        if (!workoutModel || !hasAnyUploadServiceConfigured()) {
+        if (!workoutModel || !hasAnyUploadServiceConfigured(workoutId)) {
             return
         }
 
@@ -480,6 +483,14 @@ Page {
             text: "Upload to Intervals.icu"
             visible: rootItem && rootItem.isIntervalsICUUploadConfigured()
             onTriggered: rootItem.uploadHistoricalWorkoutToIntervalsICU(uploadMenu.filePath)
+        }
+
+        MenuItem {
+            text: "Upload to Apple Health"
+            visible: Qt.platform.os === "ios" &&
+                     workoutModel &&
+                     workoutModel.canWriteAppleHealth(uploadMenu.workoutId)
+            onTriggered: workoutModel.uploadWorkoutToAppleHealth(uploadMenu.workoutId)
         }
     }
 

--- a/src/ios/lockscreen.h
+++ b/src/ios/lockscreen.h
@@ -20,6 +20,9 @@ class lockscreen {
     void setHeartRate(unsigned char heartRate);
     void startWorkout(unsigned short deviceType);
     void stopWorkout();
+    bool canWriteHistoricalWorkoutToHealthKit(unsigned short sport);
+    bool saveHistoricalWorkoutToHealthKit(unsigned short sport, double startTimestamp, double endTimestamp,
+                                          double distanceMeters, double calories);
     void workoutTrackingUpdate(double speed, unsigned short cadence, unsigned short watt, unsigned short currentCalories,
                                unsigned long long currentSteps, unsigned char deviceType, double currentDistance,
                                double totalKcal, bool useMiles, unsigned char heartRate,

--- a/src/ios/lockscreen.mm
+++ b/src/ios/lockscreen.mm
@@ -3,6 +3,7 @@
 #import <UIKit/UIKit.h>
 #import <WatchConnectivity/WatchConnectivity.h>
 #import <CoreBluetooth/CoreBluetooth.h>
+#import <HealthKit/HealthKit.h>
 #import <WebKit/WKWebsiteDataStore.h>
 #import <AVFoundation/AVFoundation.h>
 #import <ConnectIQ/ConnectIQ.h>
@@ -48,6 +49,43 @@ static NSString *LockscreenStringFromCString(const char *message)
         string = [NSString stringWithFormat:@"(invalid UTF8) %s", message];
     }
     return string;
+}
+
+static HKWorkoutActivityType HistoricalHealthKitActivityType(unsigned short sport)
+{
+    switch (sport) {
+    case 1: // FIT_SPORT_RUNNING
+        return HKWorkoutActivityTypeRunning;
+    case 11: // FIT_SPORT_WALKING
+        return HKWorkoutActivityTypeWalking;
+    case 2: // FIT_SPORT_CYCLING
+        return HKWorkoutActivityTypeCycling;
+    case 15: // FIT_SPORT_ROWING
+        return HKWorkoutActivityTypeRowing;
+    case 4: // FIT_SPORT_FITNESS_EQUIPMENT
+        return HKWorkoutActivityTypeElliptical;
+    default:
+        return HKWorkoutActivityTypeOther;
+    }
+}
+
+static HKQuantityType *HistoricalHealthKitDistanceType(unsigned short sport)
+{
+    switch (sport) {
+    case 1:
+    case 11:
+        return [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierDistanceWalkingRunning];
+    case 2:
+    case 4:
+        return [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierDistanceCycling];
+    case 15:
+        if (@available(iOS 18.0, *)) {
+            return [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierDistanceRowing];
+        }
+        return nil;
+    default:
+        return nil;
+    }
 }
 
 static ios_eliteariafan* ios_eliteAriaFan = nil;
@@ -129,6 +167,98 @@ void lockscreen::startWorkout(unsigned short deviceType) {
 void lockscreen::stopWorkout() {
     if(workoutTracking != nil && !appleWatchAppInstalled())
         [workoutTracking stopWorkOut];
+}
+
+bool lockscreen::canWriteHistoricalWorkoutToHealthKit(unsigned short sport) {
+    if (![HKHealthStore isHealthDataAvailable]) {
+        return false;
+    }
+
+    HKHealthStore *healthStore = [[HKHealthStore alloc] init];
+    HKWorkoutType *workoutType = [HKObjectType workoutType];
+    HKQuantityType *energyType = [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierActiveEnergyBurned];
+    HKQuantityType *distanceType = HistoricalHealthKitDistanceType(sport);
+
+    if ([healthStore authorizationStatusForType:workoutType] != HKAuthorizationStatusSharingAuthorized ||
+        !energyType || [healthStore authorizationStatusForType:energyType] != HKAuthorizationStatusSharingAuthorized) {
+        return false;
+    }
+
+    return !distanceType || [healthStore authorizationStatusForType:distanceType] == HKAuthorizationStatusSharingAuthorized;
+}
+
+bool lockscreen::saveHistoricalWorkoutToHealthKit(unsigned short sport, double startTimestamp, double endTimestamp,
+                                                   double distanceMeters, double calories) {
+    if (endTimestamp <= startTimestamp || !canWriteHistoricalWorkoutToHealthKit(sport)) {
+        return false;
+    }
+
+    HKHealthStore *healthStore = [[HKHealthStore alloc] init];
+    HKWorkoutConfiguration *configuration = [[HKWorkoutConfiguration alloc] init];
+    configuration.activityType = HistoricalHealthKitActivityType(sport);
+    configuration.locationType = HKWorkoutSessionLocationTypeIndoor;
+
+    HKWorkoutBuilder *builder = [[HKWorkoutBuilder alloc] initWithHealthStore:healthStore
+                                                                configuration:configuration
+                                                                       device:[HKDevice localDevice]];
+    NSDate *startDate = [NSDate dateWithTimeIntervalSince1970:startTimestamp];
+    NSDate *endDate = [NSDate dateWithTimeIntervalSince1970:endTimestamp];
+
+    [builder beginCollectionWithStartDate:startDate completion:^(BOOL success, NSError *error) {
+        if (!success) {
+            qDebug() << "Historical Apple Health workout begin failed:" << error.localizedDescription.UTF8String;
+            return;
+        }
+
+        NSMutableArray<HKSample *> *samples = [NSMutableArray array];
+        HKQuantityType *energyType = [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierActiveEnergyBurned];
+        if (calories > 0 && energyType) {
+            HKQuantity *energy = [HKQuantity quantityWithUnit:[HKUnit kilocalorieUnit] doubleValue:calories];
+            [samples addObject:[HKQuantitySample quantitySampleWithType:energyType
+                                                               quantity:energy
+                                                              startDate:startDate
+                                                                endDate:endDate]];
+        }
+
+        HKQuantityType *distanceType = HistoricalHealthKitDistanceType(sport);
+        if (distanceMeters > 0 && distanceType) {
+            HKQuantity *distance = [HKQuantity quantityWithUnit:[HKUnit meterUnit] doubleValue:distanceMeters];
+            [samples addObject:[HKQuantitySample quantitySampleWithType:distanceType
+                                                               quantity:distance
+                                                              startDate:startDate
+                                                                endDate:endDate]];
+        }
+
+        void (^finishWorkout)(void) = ^{
+            [builder endCollectionWithEndDate:endDate completion:^(BOOL endSuccess, NSError *endError) {
+                if (!endSuccess) {
+                    qDebug() << "Historical Apple Health workout end failed:" << endError.localizedDescription.UTF8String;
+                    return;
+                }
+                [builder finishWorkoutWithCompletion:^(HKWorkout *workout, NSError *finishError) {
+                    if (finishError) {
+                        qDebug() << "Historical Apple Health workout save failed:" << finishError.localizedDescription.UTF8String;
+                    } else {
+                        qDebug() << "Historical workout saved to Apple Health";
+                    }
+                }];
+            }];
+        };
+
+        if (samples.count == 0) {
+            finishWorkout();
+        } else {
+            [builder addSamples:samples completion:^(BOOL addSuccess, NSError *addError) {
+                if (!addSuccess) {
+                    qDebug() << "Historical Apple Health workout samples failed:" << addError.localizedDescription.UTF8String;
+                    return;
+                }
+                finishWorkout();
+            }];
+        }
+    }];
+
+    return true;
 }
 
 long lockscreen::heartRate()

--- a/src/workoutmodel.h
+++ b/src/workoutmodel.h
@@ -3,9 +3,14 @@
 
 #include <QAbstractListModel>
 #include <QSqlDatabase>
+#include <QSqlQuery>
 #include <QThread>
 #include <QDate>
+#include <QDateTime>
 #include "fitdatabaseprocessor.h"
+#ifdef Q_OS_IOS
+#include "ios/lockscreen.h"
+#endif
 
 class WorkoutLoaderWorker;
 
@@ -48,6 +53,55 @@ class WorkoutModel : public QAbstractListModel {
     Q_INVOKABLE bool hasTrainingProgram(int workoutId);
     Q_INVOKABLE bool openPelotonUrl(int workoutId);
     Q_INVOKABLE bool loadTrainingProgram(int workoutId);
+
+    Q_INVOKABLE bool canWriteAppleHealth(int workoutId) const {
+#ifdef Q_OS_IOS
+        QSqlQuery query(m_db);
+        query.prepare("SELECT sport_type FROM workouts WHERE id = ?");
+        query.addBindValue(workoutId);
+        if (!query.exec() || !query.next()) {
+            return false;
+        }
+
+        lockscreen ls;
+        return ls.canWriteHistoricalWorkoutToHealthKit(static_cast<unsigned short>(query.value(0).toUInt()));
+#else
+        Q_UNUSED(workoutId);
+        return false;
+#endif
+    }
+
+    Q_INVOKABLE bool uploadWorkoutToAppleHealth(int workoutId) {
+#ifdef Q_OS_IOS
+        QSqlQuery query(m_db);
+        query.prepare("SELECT sport_type, start_time, end_time, total_distance, total_calories FROM workouts WHERE id = ?");
+        query.addBindValue(workoutId);
+        if (!query.exec() || !query.next()) {
+            return false;
+        }
+
+        const QDateTime start = query.value(1).toDateTime();
+        const QDateTime end = query.value(2).toDateTime();
+        if (!start.isValid() || !end.isValid() || end <= start) {
+            return false;
+        }
+
+        const unsigned short sport = static_cast<unsigned short>(query.value(0).toUInt());
+        lockscreen ls;
+        if (!ls.canWriteHistoricalWorkoutToHealthKit(sport)) {
+            return false;
+        }
+
+        return ls.saveHistoricalWorkoutToHealthKit(sport,
+                                                    start.toMSecsSinceEpoch() / 1000.0,
+                                                    end.toMSecsSinceEpoch() / 1000.0,
+                                                    query.value(3).toDouble() * 1000.0,
+                                                    query.value(4).toDouble());
+#else
+        Q_UNUSED(workoutId);
+        return false;
+#endif
+    }
 
     bool isLoading() const;
     bool isDatabaseProcessing() const;


### PR DESCRIPTION
## Summary

Adds an **Upload to Apple Health** action to the Workout History long-press menu.

- Shows the Apple Health item only on iOS.
- Shows it only when QZ has write authorization for the HealthKit workout type, active energy, and the distance type used by that workout.
- Imports the historical workout using its original start/end time, total distance, and calories.
- Maps FIT sports from the workout database to the corresponding HealthKit activity type (running, walking, cycling, rowing, elliptical; fallback to other).
- Uses `HKWorkoutBuilder` so the workout and its quantity samples are saved together.
- Keeps all non-iOS builds unchanged via `Q_OS_IOS` guards.

## Notes

For rowing, `distanceRowing` is used on iOS 18+; on older iOS versions the workout is still saved without a rowing-distance sample.

Apple documents `authorizationStatus(for:)` / `authorizationStatusForType:` as the authorization status for **saving** a given HealthKit type, which is what gates the menu item here.

## Test plan

- [ ] iOS with Apple Health write permissions granted: long-press a historical workout and verify `Upload to Apple Health` appears.
- [ ] iOS with Health write permissions denied: verify the Apple Health item does not appear.
- [ ] Android/other platforms: verify the Apple Health item never appears.
- [ ] Import running/walking/cycling workouts and verify original date, duration, distance, and calories in Apple Health.
- [ ] Import rowing on iOS 18+ and verify rowing distance is included.
- [ ] Verify existing Strava, Garmin, and Intervals.icu history uploads are unchanged.