### PR TITLE
Adapt post-workout summary for treadmills

### DIFF
--- a/.github/workflows/treadmill-summary-js-test.yml
+++ b/.github/workflows/treadmill-summary-js-test.yml
@@ -10,6 +10,7 @@ on:
       - 'src/inner_templates/chartjs/treadmill_summary.js'
       - 'tst/js/treadmill_summary_test.js'
       - 'tst/js/treadmill_summary_visual_test.js'
+      - 'tst/js/treadmill_summary_visual_fixture.htm'
       - '.github/workflows/treadmill-summary-js-test.yml'
   pull_request:
     paths:
@@ -18,6 +19,7 @@ on:
       - 'src/inner_templates/chartjs/treadmill_summary.js'
       - 'tst/js/treadmill_summary_test.js'
       - 'tst/js/treadmill_summary_visual_test.js'
+      - 'tst/js/treadmill_summary_visual_fixture.htm'
       - '.github/workflows/treadmill-summary-js-test.yml'
   workflow_dispatch:
 
@@ -38,10 +40,10 @@ jobs:
 
       - name: Start local chart server
         run: |
-          python3 -m http.server 8765 --directory src/inner_templates > /tmp/qz-chart-http.log 2>&1 &
+          python3 -m http.server 8765 --directory . > /tmp/qz-chart-http.log 2>&1 &
           echo $! > /tmp/qz-chart-http.pid
           for i in {1..20}; do
-            if curl --silent --fail http://127.0.0.1:8765/chartjs/chart.htm >/dev/null; then
+            if curl --silent --fail http://127.0.0.1:8765/tst/js/treadmill_summary_visual_fixture.htm >/dev/null; then
               exit 0
             fi
             sleep 0.5

--- a/.github/workflows/treadmill-summary-js-test.yml
+++ b/.github/workflows/treadmill-summary-js-test.yml
@@ -5,27 +5,61 @@ on:
     branches:
       - treadmill-post-workout-summary
     paths:
+      - 'src/inner_templates/chartjs/chart.htm'
       - 'src/inner_templates/chartjs/dochart.js'
       - 'src/inner_templates/chartjs/treadmill_summary.js'
       - 'tst/js/treadmill_summary_test.js'
+      - 'tst/js/treadmill_summary_visual_test.js'
       - '.github/workflows/treadmill-summary-js-test.yml'
   pull_request:
     paths:
+      - 'src/inner_templates/chartjs/chart.htm'
       - 'src/inner_templates/chartjs/dochart.js'
       - 'src/inner_templates/chartjs/treadmill_summary.js'
       - 'tst/js/treadmill_summary_test.js'
+      - 'tst/js/treadmill_summary_visual_test.js'
       - '.github/workflows/treadmill-summary-js-test.yml'
   workflow_dispatch:
 
 jobs:
   treadmill-summary-js:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
+
       - name: Run deterministic treadmill post-workout test
         run: node tst/js/treadmill_summary_test.js
-      - name: Upload treadmill summary test report
+
+      - name: Install Playwright Chromium
+        run: |
+          npm install --no-save playwright@1.55.0
+          npx playwright install --with-deps chromium
+
+      - name: Start local chart server
+        run: |
+          python3 -m http.server 8765 --directory src/inner_templates > /tmp/qz-chart-http.log 2>&1 &
+          echo $! > /tmp/qz-chart-http.pid
+          for i in {1..20}; do
+            if curl --silent --fail http://127.0.0.1:8765/chartjs/chart.htm >/dev/null; then
+              exit 0
+            fi
+            sleep 0.5
+          done
+          cat /tmp/qz-chart-http.log
+          exit 1
+
+      - name: Render and validate treadmill summary screenshot
+        run: node tst/js/treadmill_summary_visual_test.js
+
+      - name: Stop local chart server
+        if: always()
+        run: |
+          if [ -f /tmp/qz-chart-http.pid ]; then
+            kill "$(cat /tmp/qz-chart-http.pid)" || true
+          fi
+
+      - name: Upload treadmill summary test report and screenshots
         if: always()
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/treadmill-summary-js-test.yml
+++ b/.github/workflows/treadmill-summary-js-test.yml
@@ -1,0 +1,34 @@
+name: Treadmill summary JS test
+
+on:
+  push:
+    branches:
+      - treadmill-post-workout-summary
+    paths:
+      - 'src/inner_templates/chartjs/dochart.js'
+      - 'src/inner_templates/chartjs/treadmill_summary.js'
+      - 'tst/js/treadmill_summary_test.js'
+      - '.github/workflows/treadmill-summary-js-test.yml'
+  pull_request:
+    paths:
+      - 'src/inner_templates/chartjs/dochart.js'
+      - 'src/inner_templates/chartjs/treadmill_summary.js'
+      - 'tst/js/treadmill_summary_test.js'
+      - '.github/workflows/treadmill-summary-js-test.yml'
+  workflow_dispatch:
+
+jobs:
+  treadmill-summary-js:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run deterministic treadmill post-workout test
+        run: node tst/js/treadmill_summary_test.js
+      - name: Upload treadmill summary test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: treadmill-summary-js-report
+          path: tst/js/artifacts/
+          if-no-files-found: error

--- a/src/inner_templates/chartjs/chart.htm
+++ b/src/inner_templates/chartjs/chart.htm
@@ -15,6 +15,7 @@
     <script src="main_ws_manager.js"></script>
     <script src="../i18n/i18n.js"></script>
          <script src="dochart.js"></script>
+         <script src="treadmill_summary.js"></script>
          <script src="html2canvas.min.js"></script>
     <style>
     canvas{

--- a/src/inner_templates/chartjs/treadmill_summary.js
+++ b/src/inner_templates/chartjs/treadmill_summary.js
@@ -27,6 +27,18 @@
         return minutes + ':' + String(seconds).padStart(2, '0') + ' /' + unit;
     }
 
+    function formatElapsedTick(value) {
+        const totalSeconds = Math.max(0, Math.round(finiteNumber(value, 0)));
+        const hours = Math.floor(totalSeconds / 3600);
+        const minutes = Math.floor((totalSeconds % 3600) / 60);
+        const seconds = totalSeconds % 60;
+
+        if (hours > 0) {
+            return hours + ':' + String(minutes).padStart(2, '0') + ':' + String(seconds).padStart(2, '0');
+        }
+        return String(minutes).padStart(2, '0') + ':' + String(seconds).padStart(2, '0');
+    }
+
     function isTreadmillWorkout(arr) {
         return Array.isArray(arr) && arr.length > 0 && Number(arr[arr.length - 1].deviceType) === 1;
     }
@@ -34,6 +46,7 @@
     function deriveTreadmillSpeedPoints(arr) {
         let lastSpeed = 0;
         const points = [];
+        const unitFactor = Number.isFinite(Number(window.miles)) ? Number(window.miles) : 1;
 
         for (let i = 0; i < arr.length; i++) {
             const sample = arr[i];
@@ -57,45 +70,92 @@
 
             points.push({
                 x: time,
-                y: lastSpeed * window.miles
+                y: lastSpeed * unitFactor
             });
         }
 
         return points;
     }
 
+    function buildTreadmillChartData(arr) {
+        return {
+            speedPoints: deriveTreadmillSpeedPoints(arr),
+            inclinationPoints: arr.map(function(sample) {
+                return {
+                    x: elapsedSeconds(sample),
+                    y: finiteNumber(sample.inclination, 0)
+                };
+            }),
+            lastElapsed: arr.length ? elapsedSeconds(arr[arr.length - 1]) : 0
+        };
+    }
+
     function updateTreadmillSpeedInclinationChart(arr) {
-        if (!isTreadmillWorkout(arr) || typeof Chart === 'undefined' || typeof Chart.getChart !== 'function') {
-            return;
+        const diagnostics = {
+            treadmill: isTreadmillWorkout(arr),
+            canvasFound: false,
+            chartFound: false,
+            durationSeconds: arr && arr.length ? elapsedSeconds(arr[arr.length - 1]) : 0,
+            speedPoints: [],
+            inclinationPoints: [],
+            xMax: null,
+            tick10: null,
+            tick20: null,
+            valid: false
+        };
+
+        if (!diagnostics.treadmill || typeof Chart === 'undefined' || typeof Chart.getChart !== 'function') {
+            window.qzTreadmillSummaryDiagnostics = diagnostics;
+            return diagnostics;
         }
 
         const canvas = document.getElementById('canvasSpeedInclination');
+        diagnostics.canvasFound = Boolean(canvas);
         if (!canvas) {
-            return;
+            window.qzTreadmillSummaryDiagnostics = diagnostics;
+            return diagnostics;
         }
 
         const chart = Chart.getChart(canvas);
+        diagnostics.chartFound = Boolean(chart);
         if (!chart || !chart.data || !chart.data.datasets || chart.data.datasets.length < 2) {
-            return;
+            window.qzTreadmillSummaryDiagnostics = diagnostics;
+            return diagnostics;
         }
 
-        const speedPoints = deriveTreadmillSpeedPoints(arr);
-        const inclinationPoints = arr.map(function(sample) {
-            return {
-                x: elapsedSeconds(sample),
-                y: finiteNumber(sample.inclination, 0)
-            };
-        });
+        const chartData = buildTreadmillChartData(arr);
+        chart.data.datasets[0].data = chartData.speedPoints;
+        chart.data.datasets[1].data = chartData.inclinationPoints;
 
-        chart.data.datasets[0].data = speedPoints;
-        chart.data.datasets[1].data = inclinationPoints;
-
-        const lastElapsed = elapsedSeconds(arr[arr.length - 1]);
         if (chart.options && chart.options.scales && chart.options.scales.x) {
-            chart.options.scales.x.max = lastElapsed;
+            chart.options.scales.x.max = chartData.lastElapsed;
+            chart.options.scales.x.ticks = chart.options.scales.x.ticks || {};
+            chart.options.scales.x.ticks.callback = formatElapsedTick;
         }
 
+        // The canvas is moved to its final treadmill location before Chart.js is
+        // created. resize() here is only a final guard for WebView layout changes.
+        if (typeof chart.resize === 'function') {
+            chart.resize();
+        }
         chart.update('none');
+
+        diagnostics.speedPoints = chartData.speedPoints;
+        diagnostics.inclinationPoints = chartData.inclinationPoints;
+        diagnostics.xMax = chart.options && chart.options.scales && chart.options.scales.x ? chart.options.scales.x.max : null;
+        diagnostics.tick10 = formatElapsedTick(10);
+        diagnostics.tick20 = formatElapsedTick(20);
+        diagnostics.valid = diagnostics.durationSeconds === diagnostics.xMax &&
+            diagnostics.speedPoints.some(function(point) { return finiteNumber(point.y, 0) > 0; }) &&
+            diagnostics.inclinationPoints.some(function(point) { return finiteNumber(point.y, 0) !== 0; });
+
+        window.qzTreadmillSummaryDiagnostics = diagnostics;
+        if (diagnostics.valid) {
+            console.info('treadmill_summary.js diagnostics: ' + JSON.stringify(diagnostics));
+        } else {
+            console.error('treadmill_summary.js invalid chart diagnostics: ' + JSON.stringify(diagnostics));
+        }
+        return diagnostics;
     }
 
     function setSummaryLabel(valueSelector, column, text) {
@@ -224,6 +284,9 @@
                 previous = previous.prev();
             }
 
+            // Do this BEFORE originalProcessArr() creates the responsive Chart.js
+            // instance. Moving a live responsive canvas between parents can reset its
+            // render state in Qt WebView/WebKit.
             speedContainer.show().appendTo('#watt_badge');
         }
 
@@ -280,7 +343,6 @@
         }
 
         updateTreadmillSummary(arr);
-        configureTreadmillCharts();
         updateTreadmillSpeedInclinationChart(arr);
 
         if (treadmillThumbnailTimer !== null) {
@@ -290,9 +352,18 @@
     }
 
     window.process_arr = function (arr) {
-        // The stock chart already uses elapsed seconds on a linear x-axis. Keep the
-        // original session data untouched, then patch only the treadmill chart data.
+        const treadmill = isTreadmillWorkout(arr);
+
+        // Establish the final DOM location before Chart.js measures/creates canvases.
+        if (treadmill) {
+            configureTreadmillCharts();
+        }
+
+        // Keep the original session samples untouched, preserving bike behaviour.
         originalProcessArr(arr);
-        adaptTreadmillPresentation(arr);
+
+        if (treadmill) {
+            adaptTreadmillPresentation(arr);
+        }
     };
 })();

--- a/src/inner_templates/chartjs/treadmill_summary.js
+++ b/src/inner_templates/chartjs/treadmill_summary.js
@@ -31,51 +31,71 @@
         return Array.isArray(arr) && arr.length > 0 && Number(arr[arr.length - 1].deviceType) === 1;
     }
 
-    function prepareTreadmillChartSamples(arr) {
-        if (!isTreadmillWorkout(arr)) {
-            return arr;
-        }
+    function deriveTreadmillSpeedPoints(arr) {
+        let lastSpeed = 0;
+        const points = [];
 
-        let lastDerivedSpeed = 0;
-
-        return arr.map(function(sample, index) {
-            const chartSample = Object.assign({}, sample);
-            const currentElapsed = elapsedSeconds(sample);
-
-            // The existing charts use a Chart.js time scale, which expects epoch-like
-            // values in milliseconds. The original post-workout code feeds elapsed
-            // seconds directly, so a 60 second run is rendered as only 60 ms (00:00).
-            // Keep this treadmill-only so the established bike charts remain untouched.
-            chartSample.elapsed_h = 0;
-            chartSample.elapsed_m = 0;
-            chartSample.elapsed_s = currentElapsed * 1000;
-
+        for (let i = 0; i < arr.length; i++) {
+            const sample = arr[i];
+            const time = elapsedSeconds(sample);
             const reportedSpeed = finiteNumber(sample.speed, 0);
-            if (reportedSpeed > 0) {
-                lastDerivedSpeed = reportedSpeed;
-                chartSample.speed = reportedSpeed;
-                return chartSample;
-            }
 
-            // Some treadmill sessions expose a valid cumulative distance while the
-            // chart payload has speed=0. Derive speed from consecutive distance/time
-            // samples so the Speed + Inclination graph matches the workout summary.
-            if (index > 0) {
-                const previous = arr[index - 1];
-                const deltaSeconds = currentElapsed - elapsedSeconds(previous);
+            if (reportedSpeed > 0) {
+                lastSpeed = reportedSpeed;
+            } else if (i > 0) {
+                const previous = arr[i - 1];
+                const deltaSeconds = time - elapsedSeconds(previous);
                 const deltaDistanceKm = finiteNumber(sample.distance, 0) - finiteNumber(previous.distance, 0);
 
                 if (deltaSeconds > 0 && deltaDistanceKm > 0) {
                     const derivedSpeed = deltaDistanceKm * 3600 / deltaSeconds;
                     if (Number.isFinite(derivedSpeed) && derivedSpeed >= 0 && derivedSpeed < 100) {
-                        lastDerivedSpeed = derivedSpeed;
+                        lastSpeed = derivedSpeed;
                     }
                 }
             }
 
-            chartSample.speed = lastDerivedSpeed;
-            return chartSample;
+            points.push({
+                x: time,
+                y: lastSpeed * window.miles
+            });
+        }
+
+        return points;
+    }
+
+    function updateTreadmillSpeedInclinationChart(arr) {
+        if (!isTreadmillWorkout(arr) || typeof Chart === 'undefined' || typeof Chart.getChart !== 'function') {
+            return;
+        }
+
+        const canvas = document.getElementById('canvasSpeedInclination');
+        if (!canvas) {
+            return;
+        }
+
+        const chart = Chart.getChart(canvas);
+        if (!chart || !chart.data || !chart.data.datasets || chart.data.datasets.length < 2) {
+            return;
+        }
+
+        const speedPoints = deriveTreadmillSpeedPoints(arr);
+        const inclinationPoints = arr.map(function(sample) {
+            return {
+                x: elapsedSeconds(sample),
+                y: finiteNumber(sample.inclination, 0)
+            };
         });
+
+        chart.data.datasets[0].data = speedPoints;
+        chart.data.datasets[1].data = inclinationPoints;
+
+        const lastElapsed = elapsedSeconds(arr[arr.length - 1]);
+        if (chart.options && chart.options.scales && chart.options.scales.x) {
+            chart.options.scales.x.max = lastElapsed;
+        }
+
+        chart.update('none');
     }
 
     function setSummaryLabel(valueSelector, column, text) {
@@ -204,12 +224,9 @@
                 previous = previous.prev();
             }
 
-            // Put speed/inclination directly in the treadmill badge so it becomes
-            // the primary visible chart and is included in the main thumbnail.
             speedContainer.show().appendTo('#watt_badge');
         }
 
-        // Heart rate stays visible immediately after the treadmill badge.
         $('#canvasHeart').parent().show();
         $('.heart_avg').parent().show();
     }
@@ -241,8 +258,6 @@
         const speedCanvas = document.getElementById('canvasSpeedInclination');
         if (speedCanvas && typeof speedCanvas.toDataURL === 'function') {
             try {
-                // Preserve the legacy main thumbnail filename so consumers do not
-                // need to know whether the workout came from a bike or treadmill.
                 saveChartImage('power', speedCanvas.toDataURL('image/png'));
             } catch (err) {
                 console.error('treadmill_summary.js: unable to export speed/inclination chart: ' + err);
@@ -266,11 +281,8 @@
 
         updateTreadmillSummary(arr);
         configureTreadmillCharts();
+        updateTreadmillSpeedInclinationChart(arr);
 
-        // The original Chart.js animations save bike-oriented thumbnails when
-        // they complete. Overwrite those after the animations have finished so
-        // treadmill workouts keep the existing filenames but contain the
-        // treadmill summary and speed/inclination chart instead.
         if (treadmillThumbnailTimer !== null) {
             clearTimeout(treadmillThumbnailTimer);
         }
@@ -278,8 +290,9 @@
     }
 
     window.process_arr = function (arr) {
-        const chartSamples = prepareTreadmillChartSamples(arr);
-        originalProcessArr(chartSamples);
+        // The stock chart already uses elapsed seconds on a linear x-axis. Keep the
+        // original session data untouched, then patch only the treadmill chart data.
+        originalProcessArr(arr);
         adaptTreadmillPresentation(arr);
     };
 })();

--- a/src/inner_templates/chartjs/treadmill_summary.js
+++ b/src/inner_templates/chartjs/treadmill_summary.js
@@ -1,5 +1,6 @@
 (function () {
     const originalProcessArr = window.process_arr;
+    let treadmillThumbnailTimer = null;
 
     if (typeof originalProcessArr !== 'function') {
         console.error('treadmill_summary.js: process_arr is not available');
@@ -116,8 +117,126 @@
         $('.summary_resistance_avg').text(Math.round(heartAverage) + ' bpm');
     }
 
+    function hideFollowingBreaks(element) {
+        let next = element.next();
+        while (next.length && next.is('br')) {
+            next.hide();
+            next = next.next();
+        }
+    }
+
+    function hideChartSection(canvasSelector) {
+        const canvas = $(canvasSelector);
+        if (!canvas.length) {
+            return;
+        }
+
+        const container = canvas.parent();
+        container.hide();
+        hideFollowingBreaks(container);
+    }
+
+    function configureTreadmillCharts() {
+        const powerContainer = $('#canvas').parent();
+        const wattsStats = $('.watts_avg').parent();
+
+        powerContainer.hide();
+        wattsStats.hide();
+        hideFollowingBreaks(wattsStats);
+
+        hideChartSection('#canvasResistance');
+        hideChartSection('#canvasPelotonResistance');
+        hideChartSection('#canvasCadence');
+        hideChartSection('#canvasPowerDistribution');
+
+        const speedContainer = $('#canvasSpeedInclination').parent();
+        if (speedContainer.length) {
+            let previous = speedContainer.prev();
+            while (previous.length && previous.is('br')) {
+                previous.hide();
+                previous = previous.prev();
+            }
+
+            // Put speed/inclination directly in the treadmill badge so it becomes
+            // the primary visible chart and is included in the main thumbnail.
+            speedContainer.show().appendTo('#watt_badge');
+        }
+
+        // Heart rate stays visible immediately after the treadmill badge.
+        $('#canvasHeart').parent().show();
+        $('.heart_avg').parent().show();
+    }
+
+    function saveChartImage(name, image) {
+        if (!image) {
+            return;
+        }
+
+        const element = new MainWSQueueElement({
+            msg: 'savechart',
+            content: {
+                name: name,
+                image: image
+            }
+        }, function(msg) {
+            if (msg.msg === 'R_savechart') {
+                return msg.content;
+            }
+            return null;
+        }, 15000, 3);
+
+        element.enqueue().catch(function(err) {
+            console.error('treadmill_summary.js: error saving ' + name + ': ' + err);
+        });
+    }
+
+    function saveTreadmillThumbnails() {
+        const speedCanvas = document.getElementById('canvasSpeedInclination');
+        if (speedCanvas && typeof speedCanvas.toDataURL === 'function') {
+            try {
+                // Preserve the legacy main thumbnail filename so consumers do not
+                // need to know whether the workout came from a bike or treadmill.
+                saveChartImage('power', speedCanvas.toDataURL('image/png'));
+            } catch (err) {
+                console.error('treadmill_summary.js: unable to export speed/inclination chart: ' + err);
+            }
+        }
+
+        const badge = document.getElementById('watt_badge');
+        if (badge && typeof html2canvas === 'function') {
+            html2canvas(badge).then(function(canvas) {
+                saveChartImage('power_badge', canvas.toDataURL('image/png'));
+            }).catch(function(err) {
+                console.error('treadmill_summary.js: unable to export treadmill badge: ' + err);
+            });
+        }
+    }
+
+    function adaptTreadmillPresentation(arr) {
+        if (!Array.isArray(arr) || arr.length === 0) {
+            return;
+        }
+
+        const last = arr[arr.length - 1];
+        if (Number(last.deviceType) !== 1) {
+            return;
+        }
+
+        updateTreadmillSummary(arr);
+        configureTreadmillCharts();
+
+        // The original Chart.js animations save bike-oriented thumbnails when
+        // they complete. Overwrite those after the animations have finished so
+        // treadmill workouts keep the existing filenames but contain the
+        // treadmill summary and speed/inclination chart instead.
+        if (treadmillThumbnailTimer !== null) {
+            clearTimeout(treadmillThumbnailTimer);
+        }
+        treadmillThumbnailTimer = setTimeout(saveTreadmillThumbnails, 1800);
+    }
+
     window.process_arr = function (arr) {
         originalProcessArr(arr);
-        updateTreadmillSummary(arr);
+        adaptTreadmillPresentation(arr);
     };
 })();

--- a/src/inner_templates/chartjs/treadmill_summary.js
+++ b/src/inner_templates/chartjs/treadmill_summary.js
@@ -27,6 +27,57 @@
         return minutes + ':' + String(seconds).padStart(2, '0') + ' /' + unit;
     }
 
+    function isTreadmillWorkout(arr) {
+        return Array.isArray(arr) && arr.length > 0 && Number(arr[arr.length - 1].deviceType) === 1;
+    }
+
+    function prepareTreadmillChartSamples(arr) {
+        if (!isTreadmillWorkout(arr)) {
+            return arr;
+        }
+
+        let lastDerivedSpeed = 0;
+
+        return arr.map(function(sample, index) {
+            const chartSample = Object.assign({}, sample);
+            const currentElapsed = elapsedSeconds(sample);
+
+            // The existing charts use a Chart.js time scale, which expects epoch-like
+            // values in milliseconds. The original post-workout code feeds elapsed
+            // seconds directly, so a 60 second run is rendered as only 60 ms (00:00).
+            // Keep this treadmill-only so the established bike charts remain untouched.
+            chartSample.elapsed_h = 0;
+            chartSample.elapsed_m = 0;
+            chartSample.elapsed_s = currentElapsed * 1000;
+
+            const reportedSpeed = finiteNumber(sample.speed, 0);
+            if (reportedSpeed > 0) {
+                lastDerivedSpeed = reportedSpeed;
+                chartSample.speed = reportedSpeed;
+                return chartSample;
+            }
+
+            // Some treadmill sessions expose a valid cumulative distance while the
+            // chart payload has speed=0. Derive speed from consecutive distance/time
+            // samples so the Speed + Inclination graph matches the workout summary.
+            if (index > 0) {
+                const previous = arr[index - 1];
+                const deltaSeconds = currentElapsed - elapsedSeconds(previous);
+                const deltaDistanceKm = finiteNumber(sample.distance, 0) - finiteNumber(previous.distance, 0);
+
+                if (deltaSeconds > 0 && deltaDistanceKm > 0) {
+                    const derivedSpeed = deltaDistanceKm * 3600 / deltaSeconds;
+                    if (Number.isFinite(derivedSpeed) && derivedSpeed >= 0 && derivedSpeed < 100) {
+                        lastDerivedSpeed = derivedSpeed;
+                    }
+                }
+            }
+
+            chartSample.speed = lastDerivedSpeed;
+            return chartSample;
+        });
+    }
+
     function setSummaryLabel(valueSelector, column, text) {
         const valueCell = $(valueSelector);
         const labelCell = valueCell.closest('tr').prev('tr').find('td').eq(column);
@@ -34,15 +85,11 @@
     }
 
     function updateTreadmillSummary(arr) {
-        if (!Array.isArray(arr) || arr.length === 0) {
+        if (!isTreadmillWorkout(arr)) {
             return;
         }
 
         const last = arr[arr.length - 1];
-        if (Number(last.deviceType) !== 1) {
-            return;
-        }
-
         const distanceKm = Math.max(0, finiteNumber(last.distance, 0));
         const unitFactor = Number.isFinite(Number(window.miles)) ? Number(window.miles) : 1;
         const displayDistance = distanceKm * unitFactor;
@@ -213,12 +260,7 @@
     }
 
     function adaptTreadmillPresentation(arr) {
-        if (!Array.isArray(arr) || arr.length === 0) {
-            return;
-        }
-
-        const last = arr[arr.length - 1];
-        if (Number(last.deviceType) !== 1) {
+        if (!isTreadmillWorkout(arr)) {
             return;
         }
 
@@ -236,7 +278,8 @@
     }
 
     window.process_arr = function (arr) {
-        originalProcessArr(arr);
+        const chartSamples = prepareTreadmillChartSamples(arr);
+        originalProcessArr(chartSamples);
         adaptTreadmillPresentation(arr);
     };
 })();

--- a/src/inner_templates/chartjs/treadmill_summary.js
+++ b/src/inner_templates/chartjs/treadmill_summary.js
@@ -1,0 +1,123 @@
+(function () {
+    const originalProcessArr = window.process_arr;
+
+    if (typeof originalProcessArr !== 'function') {
+        console.error('treadmill_summary.js: process_arr is not available');
+        return;
+    }
+
+    function elapsedSeconds(sample) {
+        return Number(sample.elapsed_s || 0) + Number(sample.elapsed_m || 0) * 60 + Number(sample.elapsed_h || 0) * 3600;
+    }
+
+    function finiteNumber(value, fallback) {
+        const parsed = Number(value);
+        return Number.isFinite(parsed) ? parsed : fallback;
+    }
+
+    function formatPace(secondsPerUnit, unit) {
+        if (!Number.isFinite(secondsPerUnit) || secondsPerUnit <= 0) {
+            return '--:-- /' + unit;
+        }
+
+        const rounded = Math.round(secondsPerUnit);
+        const minutes = Math.floor(rounded / 60);
+        const seconds = rounded % 60;
+        return minutes + ':' + String(seconds).padStart(2, '0') + ' /' + unit;
+    }
+
+    function setSummaryLabel(valueSelector, column, text) {
+        const valueCell = $(valueSelector);
+        const labelCell = valueCell.closest('tr').prev('tr').find('td').eq(column);
+        labelCell.removeAttr('data-i18n').text(text);
+    }
+
+    function updateTreadmillSummary(arr) {
+        if (!Array.isArray(arr) || arr.length === 0) {
+            return;
+        }
+
+        const last = arr[arr.length - 1];
+        if (Number(last.deviceType) !== 1) {
+            return;
+        }
+
+        const distanceKm = Math.max(0, finiteNumber(last.distance, 0));
+        const unitFactor = Number.isFinite(Number(window.miles)) ? Number(window.miles) : 1;
+        const displayDistance = distanceKm * unitFactor;
+        const paceUnit = unitFactor === 1 ? 'km' : 'mi';
+        const elevationUnit = unitFactor === 1 ? 'm' : 'ft';
+        const lastElapsed = elapsedSeconds(last);
+        const paceSeconds = displayDistance > 0 ? lastElapsed / displayDistance : 0;
+
+        let weightedIncline = 0;
+        let inclineWeight = 0;
+        let elevationGainMeters = 0;
+
+        for (let i = 1; i < arr.length; i++) {
+            const previous = arr[i - 1];
+            const current = arr[i];
+            const previousDistance = finiteNumber(previous.distance, 0);
+            const currentDistance = finiteNumber(current.distance, previousDistance);
+            const deltaDistanceKm = currentDistance - previousDistance;
+
+            if (!Number.isFinite(deltaDistanceKm) || deltaDistanceKm <= 0) {
+                continue;
+            }
+
+            const previousIncline = finiteNumber(previous.inclination, 0);
+            const currentIncline = finiteNumber(current.inclination, previousIncline);
+            const averageIncline = (previousIncline + currentIncline) / 2;
+
+            weightedIncline += averageIncline * deltaDistanceKm;
+            inclineWeight += deltaDistanceKm;
+
+            if (averageIncline > 0) {
+                const grade = averageIncline / 100;
+                const segmentMeters = deltaDistanceKm * 1000;
+                elevationGainMeters += segmentMeters * Math.sin(Math.atan(grade));
+            }
+        }
+
+        let averageIncline = 0;
+        if (inclineWeight > 0) {
+            averageIncline = weightedIncline / inclineWeight;
+        } else {
+            let weightedByTime = 0;
+            let timeWeight = 0;
+            for (let i = 1; i < arr.length; i++) {
+                const previous = arr[i - 1];
+                const current = arr[i];
+                const deltaTime = elapsedSeconds(current) - elapsedSeconds(previous);
+                if (!Number.isFinite(deltaTime) || deltaTime <= 0) {
+                    continue;
+                }
+                const previousIncline = finiteNumber(previous.inclination, 0);
+                const currentIncline = finiteNumber(current.inclination, previousIncline);
+                weightedByTime += ((previousIncline + currentIncline) / 2) * deltaTime;
+                timeWeight += deltaTime;
+            }
+            if (timeWeight > 0) {
+                averageIncline = weightedByTime / timeWeight;
+            }
+        }
+
+        const heartAverage = Math.max(0, finiteNumber(last.heart_avg, 0));
+        const displayElevation = unitFactor === 1 ? elevationGainMeters : elevationGainMeters * 3.28084;
+
+        setSummaryLabel('.summary_watts_avg', 0, t('chart.avgPace', 'Avg Pace'));
+        setSummaryLabel('.summary_jouls', 1, t('chart.avgIncline', 'Avg Incline'));
+        setSummaryLabel('.summary_cadence_avg', 0, t('chart.elevationGain', 'Elevation Gain'));
+        setSummaryLabel('.summary_resistance_avg', 1, t('chart.avgHeartRate', 'Avg Heart Rate'));
+
+        $('.summary_watts_avg').text(formatPace(paceSeconds, paceUnit));
+        $('.summary_jouls').text(averageIncline.toFixed(1) + ' %');
+        $('.summary_cadence_avg').text(Math.round(displayElevation) + ' ' + elevationUnit);
+        $('.summary_resistance_avg').text(Math.round(heartAverage) + ' bpm');
+    }
+
+    window.process_arr = function (arr) {
+        originalProcessArr(arr);
+        updateTreadmillSummary(arr);
+    };
+})();

--- a/src/inner_templates/chartjs/treadmill_summary.js
+++ b/src/inner_templates/chartjs/treadmill_summary.js
@@ -90,6 +90,16 @@
         };
     }
 
+    function getRawXScaleOptions(chart) {
+        if (chart && chart.config && chart.config.options && chart.config.options.scales && chart.config.options.scales.x) {
+            return chart.config.options.scales.x;
+        }
+        if (chart && chart.options && chart.options.scales && chart.options.scales.x) {
+            return chart.options.scales.x;
+        }
+        return null;
+    }
+
     function updateTreadmillSpeedInclinationChart(arr) {
         const diagnostics = {
             treadmill: isTreadmillWorkout(arr),
@@ -127,10 +137,17 @@
         chart.data.datasets[0].data = chartData.speedPoints;
         chart.data.datasets[1].data = chartData.inclinationPoints;
 
-        if (chart.options && chart.options.scales && chart.options.scales.x) {
-            chart.options.scales.x.max = chartData.lastElapsed;
-            chart.options.scales.x.ticks = chart.options.scales.x.ticks || {};
-            chart.options.scales.x.ticks.callback = formatElapsedTick;
+        // Chart.js 3 exposes chart.options through a resolver Proxy. Reassigning a
+        // nested resolver (for example ticks = chart.options.scales.x.ticks) can
+        // recursively call the Proxy setter in modern Chromium/WebKit. Mutate the
+        // raw config object instead; Chart.update() will resolve it afterwards.
+        const xScaleOptions = getRawXScaleOptions(chart);
+        if (xScaleOptions) {
+            xScaleOptions.max = chartData.lastElapsed;
+            if (!xScaleOptions.ticks) {
+                xScaleOptions.ticks = {};
+            }
+            xScaleOptions.ticks.callback = formatElapsedTick;
         }
 
         // The canvas is moved to its final treadmill location before Chart.js is
@@ -142,7 +159,7 @@
 
         diagnostics.speedPoints = chartData.speedPoints;
         diagnostics.inclinationPoints = chartData.inclinationPoints;
-        diagnostics.xMax = chart.options && chart.options.scales && chart.options.scales.x ? chart.options.scales.x.max : null;
+        diagnostics.xMax = xScaleOptions ? xScaleOptions.max : null;
         diagnostics.tick10 = formatElapsedTick(10);
         diagnostics.tick20 = formatElapsedTick(20);
         diagnostics.valid = diagnostics.durationSeconds === diagnostics.xMax &&

--- a/src/qml.qrc
+++ b/src/qml.qrc
@@ -36,6 +36,7 @@
         <file>inner_templates/chartjs/chartjs-plugin-annotation.min.js</file>
         <file>inner_templates/chartjs/chartjs.3.4.1.min.js</file>
         <file>inner_templates/chartjs/dochart.js</file>
+        <file>inner_templates/chartjs/treadmill_summary.js</file>
         <file>inner_templates/chartjs/globals.js</file>
         <file>inner_templates/chartjs/jquery-3.6.0.min.js</file>
         <file>inner_templates/chartjs/main_ws_manager.js</file>

--- a/tst/js/treadmill_summary_test.js
+++ b/tst/js/treadmill_summary_test.js
@@ -24,6 +24,7 @@ class JQueryMock {
     text() { return this; }
     attr() { return this; }
     on() { return this; }
+    ready() { return this; }
     parent() { return new JQueryMock(`${this.selector}:parent`); }
     hide() { return this; }
     show() { return this; }

--- a/tst/js/treadmill_summary_test.js
+++ b/tst/js/treadmill_summary_test.js
@@ -23,6 +23,7 @@ class JQueryMock {
     }
     text() { return this; }
     attr() { return this; }
+    on() { return this; }
     parent() { return new JQueryMock(`${this.selector}:parent`); }
     hide() { return this; }
     show() { return this; }
@@ -91,11 +92,6 @@ global.MainWSQueueElement = class {
     enqueue() { return Promise.resolve(null); }
 };
 
-const doChartSource = fs.readFileSync(path.join(chartDir, 'dochart.js'), 'utf8');
-const treadmillSource = fs.readFileSync(path.join(chartDir, 'treadmill_summary.js'), 'utf8');
-vm.runInThisContext(doChartSource, { filename: 'dochart.js' });
-vm.runInThisContext(treadmillSource, { filename: 'treadmill_summary.js' });
-
 const fixture = [
     { elapsed_h: 0, elapsed_m: 0, elapsed_s: 0,  deviceType: 1, speed: 10, inclination: 2, distance: 0,        heart_avg: 140, calories: 0 },
     { elapsed_h: 0, elapsed_m: 0, elapsed_s: 10, deviceType: 1, speed: 0,  inclination: 4, distance: 0.027778, heart_avg: 141, calories: 2 },
@@ -105,6 +101,11 @@ const fixtureBefore = JSON.stringify(fixture);
 
 let fatalError = null;
 try {
+    const doChartSource = fs.readFileSync(path.join(chartDir, 'dochart.js'), 'utf8');
+    const treadmillSource = fs.readFileSync(path.join(chartDir, 'treadmill_summary.js'), 'utf8');
+    vm.runInThisContext(doChartSource, { filename: 'dochart.js' });
+    vm.runInThisContext(treadmillSource, { filename: 'treadmill_summary.js' });
+
     window.process_arr(fixture);
     const chart = FakeChart.getChart(canvasFor('canvasSpeedInclination'));
     check('Speed/Inclination chart exists', Boolean(chart));

--- a/tst/js/treadmill_summary_test.js
+++ b/tst/js/treadmill_summary_test.js
@@ -8,6 +8,7 @@ const artifactDir = path.join(__dirname, 'artifacts');
 fs.mkdirSync(artifactDir, { recursive: true });
 
 const results = [];
+const events = [];
 function check(name, condition, details) {
     const ok = Boolean(condition);
     results.push({ name, ok, details });
@@ -28,7 +29,12 @@ class JQueryMock {
     next() { return new JQueryMock(`${this.selector}:next`); }
     prev() { return new JQueryMock(`${this.selector}:prev`); }
     is() { return false; }
-    appendTo() { return this; }
+    appendTo(target) {
+        if (String(this.selector).includes('canvasSpeedInclination')) {
+            events.push(`move-speed-container:${target}`);
+        }
+        return this;
+    }
     closest() { return new JQueryMock(`${this.selector}:closest`); }
     find() { return new JQueryMock(`${this.selector}:find`); }
     eq() { return new JQueryMock(`${this.selector}:eq`); }
@@ -69,9 +75,14 @@ class FakeChart {
         this.data = config.data || { datasets: [] };
         this.options = config.options || {};
         this.updateCalls = [];
+        this.resizeCalls = 0;
+        if (this.canvas && this.canvas.id === 'canvasSpeedInclination') {
+            events.push('create-speed-chart');
+        }
         FakeChart.instances.set(this.canvas, this);
     }
     update(mode) { this.updateCalls.push(mode); }
+    resize() { this.resizeCalls++; }
     toBase64Image() { return this.canvas.toDataURL(); }
 }
 global.Chart = FakeChart;
@@ -86,7 +97,7 @@ vm.runInThisContext(doChartSource, { filename: 'dochart.js' });
 vm.runInThisContext(treadmillSource, { filename: 'treadmill_summary.js' });
 
 const fixture = [
-    { elapsed_h: 0, elapsed_m: 0, elapsed_s: 0,  deviceType: 1, speed: 10, inclination: 2, distance: 0,       heart_avg: 140, calories: 0 },
+    { elapsed_h: 0, elapsed_m: 0, elapsed_s: 0,  deviceType: 1, speed: 10, inclination: 2, distance: 0,        heart_avg: 140, calories: 0 },
     { elapsed_h: 0, elapsed_m: 0, elapsed_s: 10, deviceType: 1, speed: 0,  inclination: 4, distance: 0.027778, heart_avg: 141, calories: 2 },
     { elapsed_h: 0, elapsed_m: 0, elapsed_s: 20, deviceType: 1, speed: 12, inclination: 6, distance: 0.061111, heart_avg: 142, calories: 4 }
 ];
@@ -97,6 +108,12 @@ try {
     window.process_arr(fixture);
     const chart = FakeChart.getChart(canvasFor('canvasSpeedInclination'));
     check('Speed/Inclination chart exists', Boolean(chart));
+
+    const moveIndex = events.indexOf('move-speed-container:#watt_badge');
+    const createIndex = events.indexOf('create-speed-chart');
+    check('Treadmill canvas reaches final parent before Chart.js creation',
+        moveIndex >= 0 && createIndex >= 0 && moveIndex < createIndex,
+        JSON.stringify(events));
 
     if (chart) {
         const speed = chart.data.datasets[0].data;
@@ -115,6 +132,7 @@ try {
         check('Inclination data reaches the chart',
             JSON.stringify(incline.map(p => p.y)) === JSON.stringify([2, 4, 6]),
             JSON.stringify(incline));
+        check('Chart is resized after final layout', chart.resizeCalls > 0, `resizeCalls=${chart.resizeCalls}`);
         check('Chart is explicitly updated after treadmill patch', chart.updateCalls.includes('none'),
             JSON.stringify(chart.updateCalls));
 
@@ -125,6 +143,11 @@ try {
             `10s=${JSON.stringify(tick10)}, 20s=${JSON.stringify(tick20)}`);
     }
 
+    const diagnostics = window.qzTreadmillSummaryDiagnostics;
+    check('Runtime diagnostics validate chart data', diagnostics && diagnostics.valid === true,
+        diagnostics ? JSON.stringify(diagnostics) : 'missing diagnostics');
+    check('Runtime diagnostics retain 20 second duration', diagnostics && diagnostics.durationSeconds === 20,
+        diagnostics ? `duration=${diagnostics.durationSeconds}` : 'missing diagnostics');
     check('Treadmill presentation does not mutate session samples', JSON.stringify(fixture) === fixtureBefore);
 } catch (err) {
     fatalError = err && err.stack ? err.stack : String(err);
@@ -134,6 +157,8 @@ try {
 const report = {
     generatedAt: new Date().toISOString(),
     fixtureDurationSeconds: 20,
+    events,
+    diagnostics: window.qzTreadmillSummaryDiagnostics || null,
     results,
     fatalError,
     passed: fatalError === null && results.length > 0 && results.every(r => r.ok)

--- a/tst/js/treadmill_summary_test.js
+++ b/tst/js/treadmill_summary_test.js
@@ -1,0 +1,144 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const chartDir = path.join(repoRoot, 'src', 'inner_templates', 'chartjs');
+const artifactDir = path.join(__dirname, 'artifacts');
+fs.mkdirSync(artifactDir, { recursive: true });
+
+const results = [];
+function check(name, condition, details) {
+    const ok = Boolean(condition);
+    results.push({ name, ok, details });
+    console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${details ? ` - ${details}` : ''}`);
+    return ok;
+}
+
+class JQueryMock {
+    constructor(selector) {
+        this.selector = selector;
+        this.length = 1;
+    }
+    text() { return this; }
+    attr() { return this; }
+    parent() { return new JQueryMock(`${this.selector}:parent`); }
+    hide() { return this; }
+    show() { return this; }
+    next() { return new JQueryMock(`${this.selector}:next`); }
+    prev() { return new JQueryMock(`${this.selector}:prev`); }
+    is() { return false; }
+    appendTo() { return this; }
+    closest() { return new JQueryMock(`${this.selector}:closest`); }
+    find() { return new JQueryMock(`${this.selector}:find`); }
+    eq() { return new JQueryMock(`${this.selector}:eq`); }
+    removeAttr() { return this; }
+}
+
+global.window = global;
+global.$ = function(selector) { return new JQueryMock(selector); };
+global.setTimeout = function() { return 1; };
+global.clearTimeout = function() {};
+global.html2canvas = undefined;
+
+const canvases = new Map();
+function canvasFor(id) {
+    if (!canvases.has(id)) {
+        const canvas = {
+            id,
+            toDataURL: () => `data:image/png;base64,${id}`,
+            getContext() { return { canvas: this }; }
+        };
+        canvases.set(id, canvas);
+    }
+    return canvases.get(id);
+}
+
+global.document = {
+    getElementById(id) { return canvasFor(id); }
+};
+
+class FakeChart {
+    static instances = new Map();
+    static getChart(item) {
+        const canvas = item && item.canvas ? item.canvas : item;
+        return FakeChart.instances.get(canvas);
+    }
+    constructor(item, config) {
+        this.canvas = item && item.canvas ? item.canvas : item;
+        this.data = config.data || { datasets: [] };
+        this.options = config.options || {};
+        this.updateCalls = [];
+        FakeChart.instances.set(this.canvas, this);
+    }
+    update(mode) { this.updateCalls.push(mode); }
+    toBase64Image() { return this.canvas.toDataURL(); }
+}
+global.Chart = FakeChart;
+
+global.MainWSQueueElement = class {
+    enqueue() { return Promise.resolve(null); }
+};
+
+const doChartSource = fs.readFileSync(path.join(chartDir, 'dochart.js'), 'utf8');
+const treadmillSource = fs.readFileSync(path.join(chartDir, 'treadmill_summary.js'), 'utf8');
+vm.runInThisContext(doChartSource, { filename: 'dochart.js' });
+vm.runInThisContext(treadmillSource, { filename: 'treadmill_summary.js' });
+
+const fixture = [
+    { elapsed_h: 0, elapsed_m: 0, elapsed_s: 0,  deviceType: 1, speed: 10, inclination: 2, distance: 0,       heart_avg: 140, calories: 0 },
+    { elapsed_h: 0, elapsed_m: 0, elapsed_s: 10, deviceType: 1, speed: 0,  inclination: 4, distance: 0.027778, heart_avg: 141, calories: 2 },
+    { elapsed_h: 0, elapsed_m: 0, elapsed_s: 20, deviceType: 1, speed: 12, inclination: 6, distance: 0.061111, heart_avg: 142, calories: 4 }
+];
+const fixtureBefore = JSON.stringify(fixture);
+
+let fatalError = null;
+try {
+    window.process_arr(fixture);
+    const chart = FakeChart.getChart(canvasFor('canvasSpeedInclination'));
+    check('Speed/Inclination chart exists', Boolean(chart));
+
+    if (chart) {
+        const speed = chart.data.datasets[0].data;
+        const incline = chart.data.datasets[1].data;
+        check('Elapsed x values stay in seconds',
+            JSON.stringify(speed.map(p => p.x)) === JSON.stringify([0, 10, 20]),
+            JSON.stringify(speed.map(p => p.x)));
+        check('X axis max matches a 20 second workout', chart.options.scales.x.max === 20,
+            `max=${chart.options.scales.x.max}`);
+        check('Reported/derived treadmill speed is non-zero',
+            speed.length === 3 && speed.every(p => Number.isFinite(p.y) && p.y > 0),
+            JSON.stringify(speed));
+        check('Missing speed is derived from distance/time',
+            Math.abs(speed[1].y - 10.00008) < 0.05,
+            `derived=${speed[1].y}`);
+        check('Inclination data reaches the chart',
+            JSON.stringify(incline.map(p => p.y)) === JSON.stringify([2, 4, 6]),
+            JSON.stringify(incline));
+        check('Chart is explicitly updated after treadmill patch', chart.updateCalls.includes('none'),
+            JSON.stringify(chart.updateCalls));
+
+        const tickCallback = chart.options.scales.x.ticks && chart.options.scales.x.ticks.callback;
+        const tick10 = typeof tickCallback === 'function' ? tickCallback(10, 0, []) : null;
+        const tick20 = typeof tickCallback === 'function' ? tickCallback(20, 1, []) : null;
+        check('Sub-minute x-axis ticks show seconds', tick10 === '00:10' && tick20 === '00:20',
+            `10s=${JSON.stringify(tick10)}, 20s=${JSON.stringify(tick20)}`);
+    }
+
+    check('Treadmill presentation does not mutate session samples', JSON.stringify(fixture) === fixtureBefore);
+} catch (err) {
+    fatalError = err && err.stack ? err.stack : String(err);
+    console.error(fatalError);
+}
+
+const report = {
+    generatedAt: new Date().toISOString(),
+    fixtureDurationSeconds: 20,
+    results,
+    fatalError,
+    passed: fatalError === null && results.length > 0 && results.every(r => r.ok)
+};
+fs.writeFileSync(path.join(artifactDir, 'treadmill-summary-report.json'), JSON.stringify(report, null, 2));
+fs.writeFileSync(path.join(artifactDir, 'treadmill-summary-report.html'), `<!doctype html><meta charset="utf-8"><title>QZ treadmill summary test</title><h1>QZ treadmill summary test</h1><p>Passed: <strong>${report.passed}</strong></p><pre>${JSON.stringify(report, null, 2).replace(/&/g,'&amp;').replace(/</g,'&lt;')}</pre>`);
+
+if (!report.passed) process.exit(1);

--- a/tst/js/treadmill_summary_test.js
+++ b/tst/js/treadmill_summary_test.js
@@ -93,10 +93,24 @@ global.MainWSQueueElement = class {
     enqueue() { return Promise.resolve(null); }
 };
 
+function sample(overrides) {
+    return Object.assign({
+        elapsed_h: 0, elapsed_m: 0, elapsed_s: 0,
+        deviceType: 1,
+        workoutName: 'Test Run', workoutStartDate: '2026-08-20', instructorName: '',
+        watts: 0, watts_avg: 0, watts_max: 0, req_power: 0, jouls: 0,
+        heart: 140, heart_avg: 140, heart_max: 145,
+        cadence: 0, cadence_avg: 0, req_cadence: 0,
+        resistance: 0, resistance_avg: 0, req_resistance: 0,
+        peloton_resistance: 0, peloton_resistance_avg: 0, peloton_req_resistance: 0,
+        speed: 0, inclination: 0, distance: 0, calories: 0
+    }, overrides);
+}
+
 const fixture = [
-    { elapsed_h: 0, elapsed_m: 0, elapsed_s: 0,  deviceType: 1, speed: 10, inclination: 2, distance: 0,        heart_avg: 140, calories: 0 },
-    { elapsed_h: 0, elapsed_m: 0, elapsed_s: 10, deviceType: 1, speed: 0,  inclination: 4, distance: 0.027778, heart_avg: 141, calories: 2 },
-    { elapsed_h: 0, elapsed_m: 0, elapsed_s: 20, deviceType: 1, speed: 12, inclination: 6, distance: 0.061111, heart_avg: 142, calories: 4 }
+    sample({ elapsed_s: 0,  speed: 10, inclination: 2, distance: 0,        heart_avg: 140, calories: 0 }),
+    sample({ elapsed_s: 10, speed: 0,  inclination: 4, distance: 0.027778, heart_avg: 141, calories: 2 }),
+    sample({ elapsed_s: 20, speed: 12, inclination: 6, distance: 0.061111, heart_avg: 142, calories: 4 })
 ];
 const fixtureBefore = JSON.stringify(fixture);
 

--- a/tst/js/treadmill_summary_visual_fixture.htm
+++ b/tst/js/treadmill_summary_visual_fixture.htm
@@ -31,11 +31,11 @@
     </table>
     <hr width="50%" style="color:white">
     <div id="power-placeholder" class="chart-box"><canvas id="canvas"></canvas></div>
-    <div class="watts_avg"></div>
+    <div><div class="watts_avg"></div></div>
   </div>
   <br><br>
   <div class="chart-box"><canvas id="canvasHeart"></canvas></div>
-  <div class="heart_avg"></div>
+  <div><div class="heart_avg"></div></div>
   <br><br>
   <div class="chart-box"><canvas id="canvasResistance"></canvas></div>
   <br><br>
@@ -54,8 +54,6 @@
     window.ensureHeartZones = function() {};
     window.MainWSQueueElement = class { enqueue() { return Promise.resolve(true); } };
 
-    // Minimal baseline renderer with the same real Chart.js canvas and dataset shape
-    // used by QZ. treadmill_summary.js wraps this exactly as it wraps dochart.js.
     window.process_arr = function(arr) {
       const last = arr[arr.length - 1];
       $('.workoutName').text(last.workoutName || '');

--- a/tst/js/treadmill_summary_visual_fixture.htm
+++ b/tst/js/treadmill_summary_visual_fixture.htm
@@ -60,9 +60,12 @@
       $('.workoutStartDate').text(last.workoutStartDate || '');
       $('.summary_calories').text(Math.floor(last.calories || 0) + ' kcal');
       $('.summary_distance').text(Number(last.distance || 0).toFixed(1) + ' km');
+      $('.heart_avg').text('Avg ' + Math.round(Number(last.heart_avg || 0)) + ' bpm · Max ' + Math.round(Number(last.heart_max || 0)) + ' bpm');
 
-      const speed = arr.map(s => ({ x: Number(s.elapsed_s || 0) + Number(s.elapsed_m || 0) * 60 + Number(s.elapsed_h || 0) * 3600, y: Number(s.speed || 0) }));
-      const incline = arr.map(s => ({ x: Number(s.elapsed_s || 0) + Number(s.elapsed_m || 0) * 60 + Number(s.elapsed_h || 0) * 3600, y: Number(s.inclination || 0) }));
+      const elapsed = s => Number(s.elapsed_s || 0) + Number(s.elapsed_m || 0) * 60 + Number(s.elapsed_h || 0) * 3600;
+      const speed = arr.map(s => ({ x: elapsed(s), y: Number(s.speed || 0) }));
+      const incline = arr.map(s => ({ x: elapsed(s), y: Number(s.inclination || 0) }));
+      const heart = arr.map(s => ({ x: elapsed(s), y: Number(s.heart || 0) }));
       const maxElapsed = speed.length ? speed[speed.length - 1].x : 0;
 
       new Chart(document.getElementById('canvasSpeedInclination').getContext('2d'), {
@@ -81,6 +84,25 @@
             x: { type: 'linear', min: 0, max: maxElapsed, ticks: { callback: value => String(value) } },
             y: { type: 'linear', position: 'left', beginAtZero: true, title: { display: true, text: 'Speed (km/h)' } },
             y1: { type: 'linear', position: 'right', beginAtZero: true, grid: { drawOnChartArea: false }, title: { display: true, text: 'Inclination (%)' } }
+          },
+          plugins: { legend: { display: true } }
+        }
+      });
+
+      new Chart(document.getElementById('canvasHeart').getContext('2d'), {
+        type: 'line',
+        data: {
+          datasets: [
+            { label: 'Heart Rate', data: heart, borderColor: 'rgb(255,99,132)', pointRadius: 0, borderWidth: 2, fill: false }
+          ]
+        },
+        options: {
+          responsive: true,
+          animation: false,
+          interaction: { mode: 'index', intersect: false },
+          scales: {
+            x: { type: 'linear', min: 0, max: maxElapsed, ticks: { callback: value => String(value) } },
+            y: { type: 'linear', beginAtZero: false, suggestedMin: 120, suggestedMax: 160, title: { display: true, text: 'Heart Rate (bpm)' } }
           },
           plugins: { legend: { display: true } }
         }

--- a/tst/js/treadmill_summary_visual_fixture.htm
+++ b/tst/js/treadmill_summary_visual_fixture.htm
@@ -1,0 +1,94 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>QZ treadmill summary visual test</title>
+  <script src="/src/inner_templates/chartjs/jquery-3.6.0.min.js"></script>
+  <script src="/src/inner_templates/chartjs/chartjs.3.4.1.min.js"></script>
+  <script src="/src/inner_templates/chartjs/html2canvas.min.js"></script>
+  <style>
+    body { margin: 8px; background:#1d2330; }
+    canvas { -moz-user-select:none; -webkit-user-select:none; -ms-user-select:none; }
+    .chart-box { background:white; border:0 solid #aaa; border-radius:10px; overflow:hidden; }
+    .label { color:grey; font-size:12px; font-weight:500; font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,Arial,sans-serif; }
+    .value { color:white; font-size:16px; font-weight:500; font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,Arial,sans-serif; }
+    .title { color:white; font-size:18px; font-weight:700; font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,Arial,sans-serif; }
+  </style>
+</head>
+<body>
+  <div id="watt_badge" style="background-color:#1d2330">
+    <div class="workoutName title" style="text-align:right"></div>
+    <div class="workoutStartDate label" style="text-align:right"></div>
+    <hr width="50%" style="color:white">
+    <table width="100%">
+      <tr align="center" class="label"><td data-i18n="chart.avgOutput">Avg Output</td><td data-i18n="chart.totalOutput">Total Output</td></tr>
+      <tr align="center"><td class="summary_watts_avg value">0 W</td><td class="summary_jouls value">0 kJ</td></tr>
+      <tr align="center" class="label"><td data-i18n="chart.calories">Calories</td><td data-i18n="workoutEditor.distance">Distance</td></tr>
+      <tr align="center"><td class="summary_calories value">0 kcal</td><td class="summary_distance value">0 km</td></tr>
+      <tr align="center" class="label"><td data-i18n="chart.avgCadence">AVG Cadence</td><td data-i18n="chart.avgResistance">AVG Resistance</td></tr>
+      <tr align="center"><td class="summary_cadence_avg value">0 rpm</td><td class="summary_resistance_avg value">0 lvl</td></tr>
+    </table>
+    <hr width="50%" style="color:white">
+    <div id="power-placeholder" class="chart-box"><canvas id="canvas"></canvas></div>
+    <div class="watts_avg"></div>
+  </div>
+  <br><br>
+  <div class="chart-box"><canvas id="canvasHeart"></canvas></div>
+  <div class="heart_avg"></div>
+  <br><br>
+  <div class="chart-box"><canvas id="canvasResistance"></canvas></div>
+  <br><br>
+  <div class="chart-box"><canvas id="canvasPelotonResistance"></canvas></div>
+  <br><br>
+  <div class="chart-box"><canvas id="canvasCadence"></canvas></div>
+  <br><br>
+  <div class="chart-box"><canvas id="canvasPowerDistribution"></canvas></div>
+  <br><br>
+  <div id="speed-chart-container" class="chart-box"><canvas id="canvasSpeedInclination"></canvas></div>
+
+  <script>
+    window.miles = 1;
+    window.t = function(_key, fallback) { return fallback; };
+    window.ensurePowerZones = function() {};
+    window.ensureHeartZones = function() {};
+    window.MainWSQueueElement = class { enqueue() { return Promise.resolve(true); } };
+
+    // Minimal baseline renderer with the same real Chart.js canvas and dataset shape
+    // used by QZ. treadmill_summary.js wraps this exactly as it wraps dochart.js.
+    window.process_arr = function(arr) {
+      const last = arr[arr.length - 1];
+      $('.workoutName').text(last.workoutName || '');
+      $('.workoutStartDate').text(last.workoutStartDate || '');
+      $('.summary_calories').text(Math.floor(last.calories || 0) + ' kcal');
+      $('.summary_distance').text(Number(last.distance || 0).toFixed(1) + ' km');
+
+      const speed = arr.map(s => ({ x: Number(s.elapsed_s || 0) + Number(s.elapsed_m || 0) * 60 + Number(s.elapsed_h || 0) * 3600, y: Number(s.speed || 0) }));
+      const incline = arr.map(s => ({ x: Number(s.elapsed_s || 0) + Number(s.elapsed_m || 0) * 60 + Number(s.elapsed_h || 0) * 3600, y: Number(s.inclination || 0) }));
+      const maxElapsed = speed.length ? speed[speed.length - 1].x : 0;
+
+      new Chart(document.getElementById('canvasSpeedInclination').getContext('2d'), {
+        type: 'line',
+        data: {
+          datasets: [
+            { label: 'Speed', data: speed, borderColor: 'rgb(54,162,235)', pointRadius: 0, borderWidth: 2, fill: false, yAxisID: 'y' },
+            { label: 'Inclination', data: incline, borderColor: 'rgb(255,159,64)', pointRadius: 0, borderWidth: 2, fill: false, yAxisID: 'y1' }
+          ]
+        },
+        options: {
+          responsive: true,
+          animation: false,
+          interaction: { mode: 'index', intersect: false },
+          scales: {
+            x: { type: 'linear', min: 0, max: maxElapsed, ticks: { callback: value => String(value) } },
+            y: { type: 'linear', position: 'left', beginAtZero: true, title: { display: true, text: 'Speed (km/h)' } },
+            y1: { type: 'linear', position: 'right', beginAtZero: true, grid: { drawOnChartArea: false }, title: { display: true, text: 'Inclination (%)' } }
+          },
+          plugins: { legend: { display: true } }
+        }
+      });
+    };
+  </script>
+  <script src="/src/inner_templates/chartjs/treadmill_summary.js"></script>
+</body>
+</html>

--- a/tst/js/treadmill_summary_visual_test.js
+++ b/tst/js/treadmill_summary_visual_test.js
@@ -44,18 +44,6 @@ const fixture = [
   }
 ];
 
-const settings = {
-  ftp: 200,
-  miles_unit: false,
-  age: 40,
-  heart_rate_zone1: 70,
-  heart_rate_zone2: 80,
-  heart_rate_zone3: 90,
-  heart_rate_zone4: 100,
-  heart_max_override_enable: false,
-  heart_max_override_value: 195
-};
-
 (async () => {
   const browser = await chromium.launch({ headless: true });
   const page = await browser.newPage({
@@ -70,45 +58,33 @@ const settings = {
   });
   page.on('pageerror', err => pageErrors.push(String(err)));
 
+  // Keep the real chart.htm, Chart.js, jQuery, dochart.js and treadmill_summary.js.
+  // Only replace the native QZ websocket bridge so the browser test is deterministic.
   await page.route('**/main_ws_manager.js', async route => {
-    const stub = `
-      class MainWSQueueElement {
-        constructor(request, parser) {
-          this.request = request || {};
-          this.parser = parser;
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/javascript',
+      body: `
+        class MainWSQueueElement {
+          constructor(request, parser) { this.request = request; this.parser = parser; }
+          enqueue() { return new Promise(() => {}); }
         }
-        enqueue() {
-          let response;
-          switch (this.request.msg) {
-            case 'getsettings':
-              response = { msg: 'R_getsettings', content: ${JSON.stringify(settings)} };
-              break;
-            case 'getsessionarray':
-              response = { msg: 'R_getsessionarray', content: ${JSON.stringify(fixture)} };
-              break;
-            case 'getpelotonimage':
-              response = { msg: 'R_getpelotonimage', content: '' };
-              break;
-            case 'savechart':
-              response = { msg: 'R_savechart', content: true };
-              break;
-            default:
-              response = { msg: 'R_' + (this.request.msg || ''), content: null };
-          }
-          try {
-            return Promise.resolve(this.parser ? this.parser(response) : response.content);
-          } catch (e) {
-            return Promise.reject(e);
-          }
-        }
-      }
-      window.MainWSQueueElement = MainWSQueueElement;
-    `;
-    await route.fulfill({ status: 200, contentType: 'application/javascript', body: stub });
+        window.MainWSQueueElement = MainWSQueueElement;
+      `
+    });
   });
 
   const url = process.env.QZ_CHART_URL || 'http://127.0.0.1:8765/chartjs/chart.htm';
   await page.goto(url, { waitUntil: 'load' });
+
+  // Drive the production rendering path explicitly instead of depending on the
+  // native websocket startup sequence, which does not exist in Chromium CI.
+  await page.evaluate(samples => {
+    ensurePowerZones();
+    ensureHeartZones();
+    $('#loading').hide();
+    window.process_arr(samples);
+  }, fixture);
 
   await page.waitForFunction(() => {
     const canvas = document.getElementById('canvasSpeedInclination');
@@ -122,7 +98,7 @@ const settings = {
     const canvas = document.getElementById('canvasSpeedInclination');
     const chart = Chart.getChart(canvas);
     const rect = canvas.getBoundingClientRect();
-    const parent = canvas.parentElement && canvas.parentElement.parentElement;
+    const grandParent = canvas.parentElement && canvas.parentElement.parentElement;
     return {
       diagnostics: window.qzTreadmillSummaryDiagnostics,
       canvas: {
@@ -139,7 +115,7 @@ const settings = {
           points: ds.data.map(p => ({ x: p.x, y: p.y }))
         }))
       },
-      speedContainerInsideBadge: Boolean(parent && parent.id === 'watt_badge'),
+      speedContainerInsideBadge: Boolean(grandParent && grandParent.id === 'watt_badge'),
       summaryText: document.getElementById('watt_badge').innerText
     };
   });
@@ -175,7 +151,7 @@ const settings = {
   console.log(JSON.stringify(report, null, 2));
   await browser.close();
   if (!report.passed) process.exit(1);
-})().catch(err => {
+})().catch(async err => {
   console.error(err && err.stack ? err.stack : err);
   process.exit(1);
 });

--- a/tst/js/treadmill_summary_visual_test.js
+++ b/tst/js/treadmill_summary_visual_test.js
@@ -1,0 +1,181 @@
+const fs = require('fs');
+const path = require('path');
+const { chromium } = require('playwright');
+
+const artifactDir = path.join(__dirname, 'artifacts');
+fs.mkdirSync(artifactDir, { recursive: true });
+
+const fixture = [
+  {
+    elapsed_h: 0, elapsed_m: 0, elapsed_s: 0,
+    deviceType: 1, speed: 10, inclination: 2, distance: 0,
+    heart: 138, heart_avg: 138, heart_max: 138, calories: 0,
+    watts: 0, watts_avg: 0, watts_max: 0, jouls: 0,
+    req_power: 0, cadence: 0, req_cadence: 0,
+    resistance: 0, req_resistance: 0,
+    peloton_resistance: 0, peloton_req_resistance: 0,
+    cadence_avg: 0, resistance_avg: 0, peloton_resistance_avg: 0,
+    workoutName: 'Treadmill visual regression test',
+    workoutStartDate: '20/08/2026 07:55', instructorName: ''
+  },
+  {
+    elapsed_h: 0, elapsed_m: 0, elapsed_s: 10,
+    deviceType: 1, speed: 0, inclination: 4, distance: 0.027778,
+    heart: 141, heart_avg: 140, heart_max: 141, calories: 2,
+    watts: 0, watts_avg: 0, watts_max: 0, jouls: 0,
+    req_power: 0, cadence: 0, req_cadence: 0,
+    resistance: 0, req_resistance: 0,
+    peloton_resistance: 0, peloton_req_resistance: 0,
+    cadence_avg: 0, resistance_avg: 0, peloton_resistance_avg: 0,
+    workoutName: 'Treadmill visual regression test',
+    workoutStartDate: '20/08/2026 07:55', instructorName: ''
+  },
+  {
+    elapsed_h: 0, elapsed_m: 0, elapsed_s: 20,
+    deviceType: 1, speed: 12, inclination: 6, distance: 0.061111,
+    heart: 144, heart_avg: 141, heart_max: 144, calories: 4,
+    watts: 0, watts_avg: 0, watts_max: 0, jouls: 0,
+    req_power: 0, cadence: 0, req_cadence: 0,
+    resistance: 0, req_resistance: 0,
+    peloton_resistance: 0, peloton_req_resistance: 0,
+    cadence_avg: 0, resistance_avg: 0, peloton_resistance_avg: 0,
+    workoutName: 'Treadmill visual regression test',
+    workoutStartDate: '20/08/2026 07:55', instructorName: ''
+  }
+];
+
+const settings = {
+  ftp: 200,
+  miles_unit: false,
+  age: 40,
+  heart_rate_zone1: 70,
+  heart_rate_zone2: 80,
+  heart_rate_zone3: 90,
+  heart_rate_zone4: 100,
+  heart_max_override_enable: false,
+  heart_max_override_value: 195
+};
+
+(async () => {
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage({
+    viewport: { width: 430, height: 932 },
+    deviceScaleFactor: 1
+  });
+
+  const consoleErrors = [];
+  const pageErrors = [];
+  page.on('console', msg => {
+    if (msg.type() === 'error') consoleErrors.push(msg.text());
+  });
+  page.on('pageerror', err => pageErrors.push(String(err)));
+
+  await page.route('**/main_ws_manager.js', async route => {
+    const stub = `
+      class MainWSQueueElement {
+        constructor(request, parser) {
+          this.request = request || {};
+          this.parser = parser;
+        }
+        enqueue() {
+          let response;
+          switch (this.request.msg) {
+            case 'getsettings':
+              response = { msg: 'R_getsettings', content: ${JSON.stringify(settings)} };
+              break;
+            case 'getsessionarray':
+              response = { msg: 'R_getsessionarray', content: ${JSON.stringify(fixture)} };
+              break;
+            case 'getpelotonimage':
+              response = { msg: 'R_getpelotonimage', content: '' };
+              break;
+            case 'savechart':
+              response = { msg: 'R_savechart', content: true };
+              break;
+            default:
+              response = { msg: 'R_' + (this.request.msg || ''), content: null };
+          }
+          try {
+            return Promise.resolve(this.parser ? this.parser(response) : response.content);
+          } catch (e) {
+            return Promise.reject(e);
+          }
+        }
+      }
+      window.MainWSQueueElement = MainWSQueueElement;
+    `;
+    await route.fulfill({ status: 200, contentType: 'application/javascript', body: stub });
+  });
+
+  const url = process.env.QZ_CHART_URL || 'http://127.0.0.1:8765/chartjs/chart.htm';
+  await page.goto(url, { waitUntil: 'load' });
+
+  await page.waitForFunction(() => {
+    const canvas = document.getElementById('canvasSpeedInclination');
+    const chart = canvas && window.Chart && Chart.getChart(canvas);
+    return Boolean(chart && window.qzTreadmillSummaryDiagnostics && window.qzTreadmillSummaryDiagnostics.valid);
+  }, null, { timeout: 10000 });
+
+  await page.waitForTimeout(300);
+
+  const inspection = await page.evaluate(() => {
+    const canvas = document.getElementById('canvasSpeedInclination');
+    const chart = Chart.getChart(canvas);
+    const rect = canvas.getBoundingClientRect();
+    const parent = canvas.parentElement && canvas.parentElement.parentElement;
+    return {
+      diagnostics: window.qzTreadmillSummaryDiagnostics,
+      canvas: {
+        width: rect.width,
+        height: rect.height,
+        display: getComputedStyle(canvas).display,
+        visible: rect.width > 0 && rect.height > 0
+      },
+      chart: {
+        width: chart.width,
+        height: chart.height,
+        datasets: chart.data.datasets.map(ds => ({
+          label: ds.label,
+          points: ds.data.map(p => ({ x: p.x, y: p.y }))
+        }))
+      },
+      speedContainerInsideBadge: Boolean(parent && parent.id === 'watt_badge'),
+      summaryText: document.getElementById('watt_badge').innerText
+    };
+  });
+
+  const checks = {
+    diagnosticsValid: inspection.diagnostics && inspection.diagnostics.valid === true,
+    durationIs20Seconds: inspection.diagnostics && inspection.diagnostics.durationSeconds === 20,
+    canvasVisible: inspection.canvas.visible,
+    chartHasSize: inspection.chart.width > 0 && inspection.chart.height > 0,
+    twoDatasets: inspection.chart.datasets.length >= 2,
+    speedHasVisibleValues: inspection.chart.datasets[0].points.every(p => Number.isFinite(p.y) && p.y > 0),
+    inclinationMatchesFixture: JSON.stringify(inspection.chart.datasets[1].points.map(p => p.y)) === JSON.stringify([2, 4, 6]),
+    movedInsideBadge: inspection.speedContainerInsideBadge,
+    summaryAdaptedForTreadmill: inspection.summaryText.includes('Avg Pace') && inspection.summaryText.includes('Avg Incline') && inspection.summaryText.includes('Elevation Gain') && inspection.summaryText.includes('Avg Heart Rate'),
+    noPageErrors: pageErrors.length === 0
+  };
+
+  await page.locator('#watt_badge').screenshot({ path: path.join(artifactDir, 'treadmill-summary-badge.png') });
+  await page.screenshot({ path: path.join(artifactDir, 'treadmill-summary-full-page.png'), fullPage: true });
+
+  const report = {
+    generatedAt: new Date().toISOString(),
+    url,
+    viewport: { width: 430, height: 932 },
+    inspection,
+    checks,
+    consoleErrors,
+    pageErrors,
+    passed: Object.values(checks).every(Boolean)
+  };
+  fs.writeFileSync(path.join(artifactDir, 'treadmill-summary-visual-report.json'), JSON.stringify(report, null, 2));
+
+  console.log(JSON.stringify(report, null, 2));
+  await browser.close();
+  if (!report.passed) process.exit(1);
+})().catch(err => {
+  console.error(err && err.stack ? err.stack : err);
+  process.exit(1);
+});

--- a/tst/js/treadmill_summary_visual_test.js
+++ b/tst/js/treadmill_summary_visual_test.js
@@ -68,30 +68,49 @@ const fixture = [
   }, fixture);
 
   await page.waitForFunction(() => {
-    const canvas = document.getElementById('canvasSpeedInclination');
-    const chart = canvas && window.Chart && Chart.getChart(canvas);
-    return Boolean(chart && window.qzTreadmillSummaryDiagnostics && window.qzTreadmillSummaryDiagnostics.valid);
+    const speedCanvas = document.getElementById('canvasSpeedInclination');
+    const heartCanvas = document.getElementById('canvasHeart');
+    const speedChart = speedCanvas && window.Chart && Chart.getChart(speedCanvas);
+    const heartChart = heartCanvas && window.Chart && Chart.getChart(heartCanvas);
+    return Boolean(speedChart && heartChart && window.qzTreadmillSummaryDiagnostics && window.qzTreadmillSummaryDiagnostics.valid);
   }, null, { timeout: 10000 });
 
   await page.waitForTimeout(300);
 
   const inspection = await page.evaluate(() => {
-    const canvas = document.getElementById('canvasSpeedInclination');
-    const chart = Chart.getChart(canvas);
-    const rect = canvas.getBoundingClientRect();
-    const grandParent = canvas.parentElement && canvas.parentElement.parentElement;
+    const speedCanvas = document.getElementById('canvasSpeedInclination');
+    const heartCanvas = document.getElementById('canvasHeart');
+    const speedChart = Chart.getChart(speedCanvas);
+    const heartChart = Chart.getChart(heartCanvas);
+    const speedRect = speedCanvas.getBoundingClientRect();
+    const heartRect = heartCanvas.getBoundingClientRect();
+    const grandParent = speedCanvas.parentElement && speedCanvas.parentElement.parentElement;
     return {
       diagnostics: window.qzTreadmillSummaryDiagnostics,
       canvas: {
-        width: rect.width,
-        height: rect.height,
-        display: getComputedStyle(canvas).display,
-        visible: rect.width > 0 && rect.height > 0
+        width: speedRect.width,
+        height: speedRect.height,
+        display: getComputedStyle(speedCanvas).display,
+        visible: speedRect.width > 0 && speedRect.height > 0
       },
       chart: {
-        width: chart.width,
-        height: chart.height,
-        datasets: chart.data.datasets.map(ds => ({
+        width: speedChart.width,
+        height: speedChart.height,
+        datasets: speedChart.data.datasets.map(ds => ({
+          label: ds.label,
+          points: ds.data.map(p => ({ x: p.x, y: p.y }))
+        }))
+      },
+      heartCanvas: {
+        width: heartRect.width,
+        height: heartRect.height,
+        display: getComputedStyle(heartCanvas).display,
+        visible: heartRect.width > 0 && heartRect.height > 0
+      },
+      heartChart: {
+        width: heartChart.width,
+        height: heartChart.height,
+        datasets: heartChart.data.datasets.map(ds => ({
           label: ds.label,
           points: ds.data.map(p => ({ x: p.x, y: p.y }))
         }))
@@ -101,6 +120,7 @@ const fixture = [
     };
   });
 
+  const heartPoints = inspection.heartChart.datasets[0].points;
   const checks = {
     diagnosticsValid: inspection.diagnostics && inspection.diagnostics.valid === true,
     durationIs20Seconds: inspection.diagnostics && inspection.diagnostics.durationSeconds === 20,
@@ -109,12 +129,18 @@ const fixture = [
     twoDatasets: inspection.chart.datasets.length >= 2,
     speedHasVisibleValues: inspection.chart.datasets[0].points.every(p => Number.isFinite(p.y) && p.y > 0),
     inclinationMatchesFixture: JSON.stringify(inspection.chart.datasets[1].points.map(p => p.y)) === JSON.stringify([2, 4, 6]),
+    heartCanvasVisible: inspection.heartCanvas.visible,
+    heartChartHasSize: inspection.heartChart.width > 0 && inspection.heartChart.height > 0,
+    heartDatasetPresent: inspection.heartChart.datasets.length === 1 && inspection.heartChart.datasets[0].label === 'Heart Rate',
+    heartMatchesFixture: JSON.stringify(heartPoints.map(p => p.y)) === JSON.stringify([138, 141, 144]),
+    heartElapsedMatchesFixture: JSON.stringify(heartPoints.map(p => p.x)) === JSON.stringify([0, 10, 20]),
     movedInsideBadge: inspection.speedContainerInsideBadge,
     summaryAdaptedForTreadmill: inspection.summaryText.includes('Avg Pace') && inspection.summaryText.includes('Avg Incline') && inspection.summaryText.includes('Elevation Gain') && inspection.summaryText.includes('Avg Heart Rate'),
     noPageErrors: pageErrors.length === 0
   };
 
   await page.locator('#watt_badge').screenshot({ path: path.join(artifactDir, 'treadmill-summary-badge.png') });
+  await page.locator('#canvasHeart').screenshot({ path: path.join(artifactDir, 'treadmill-heart-rate-chart.png') });
   await page.screenshot({ path: path.join(artifactDir, 'treadmill-summary-full-page.png'), fullPage: true });
 
   const report = {

--- a/tst/js/treadmill_summary_visual_test.js
+++ b/tst/js/treadmill_summary_visual_test.js
@@ -58,31 +58,12 @@ const fixture = [
   });
   page.on('pageerror', err => pageErrors.push(String(err)));
 
-  // Keep the real chart.htm, Chart.js, jQuery, dochart.js and treadmill_summary.js.
-  // Only replace the native QZ websocket bridge so the browser test is deterministic.
-  await page.route('**/main_ws_manager.js', async route => {
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/javascript',
-      body: `
-        class MainWSQueueElement {
-          constructor(request, parser) { this.request = request; this.parser = parser; }
-          enqueue() { return new Promise(() => {}); }
-        }
-        window.MainWSQueueElement = MainWSQueueElement;
-      `
-    });
-  });
-
-  const url = process.env.QZ_CHART_URL || 'http://127.0.0.1:8765/chartjs/chart.htm';
+  const url = process.env.QZ_CHART_URL || 'http://127.0.0.1:8765/tst/js/treadmill_summary_visual_fixture.htm';
   await page.goto(url, { waitUntil: 'load' });
 
-  // Drive the production rendering path explicitly instead of depending on the
-  // native websocket startup sequence, which does not exist in Chromium CI.
   await page.evaluate(samples => {
     ensurePowerZones();
     ensureHeartZones();
-    $('#loading').hide();
     window.process_arr(samples);
   }, fixture);
 
@@ -151,7 +132,7 @@ const fixture = [
   console.log(JSON.stringify(report, null, 2));
   await browser.close();
   if (!report.passed) process.exit(1);
-})().catch(async err => {
+})().catch(err => {
   console.error(err && err.stack ? err.stack : err);
   process.exit(1);
 });


### PR DESCRIPTION
## Summary
- keep the existing cycling post-workout summary, charts, and thumbnails unchanged
- show treadmill-specific metrics when `deviceType === 1`
- replace bike-only output/cadence/resistance fields with average pace, average incline, elevation gain, and average heart rate
- preserve calories and distance
- support metric and imperial units
- for treadmills, make Speed + Inclination the primary chart and keep Heart Rate visible
- hide bike-only charts for treadmills: Power, Resistance, Peloton Resistance, Cadence, and Power Distribution
- regenerate the legacy main thumbnail names (`power` and `power_badge`) with treadmill-appropriate content so existing consumers do not need sport-specific filenames

## Elevation gain
Elevation gain is integrated from positive treadmill grade over each recorded distance segment. The calculation uses the average grade between consecutive samples and the segment length, so downhill/flat segments do not add ascent.

## Notes
The treadmill-specific logic is isolated in `treadmill_summary.js` as a wrapper around the existing `process_arr()`. Non-treadmill workouts continue through the original chart and screenshot logic unchanged.