### PR TITLE
Preserve FTMS rower power across split data frames

### DIFF
--- a/src/devices/ftmsrower/ftmsrower.cpp
+++ b/src/devices/ftmsrower/ftmsrower.cpp
@@ -453,9 +453,9 @@ void ftmsrower::characteristicChanged(const QLowEnergyCharacteristic &characteri
             if((DFIT_L_R && Cadence.value() > 0) || !DFIT_L_R)
                 m_watt = watt;
         }        
-    } else if(!PM5) {
+    } else if(!PM5 && Flags.instantPace) {
         qDebug() << "rower doesn't send wattage, let's calculate it...";
-        if(Speed.value() > 0)
+        if(instantPace > 0 && instantPace != 65535)
             m_watt = rower::calculateWattsFromPace(instantPace);
         else
             m_watt = 0;
@@ -747,7 +747,6 @@ void ftmsrower::descriptorWritten(const QLowEnergyDescriptor &descriptor, const 
 void ftmsrower::descriptorRead(const QLowEnergyDescriptor &descriptor, const QByteArray &newValue) {
     qDebug() << QStringLiteral("descriptorRead ") << descriptor.name() << descriptor.uuid() << newValue.toHex(' ');
 }
-
 void ftmsrower::characteristicWritten(const QLowEnergyCharacteristic &characteristic, const QByteArray &newValue) {
 
     Q_UNUSED(characteristic);


### PR DESCRIPTION
### Motivation
A user debug log showed FTMS Rower Data (`0x2AD1`) arriving as consecutive frames with different flag sets. One frame contained `Instantaneous Power` and correctly set the rower to 19 W; the following frame did not contain power or instantaneous pace, but QZ treated the absence of the power field as if the rower did not report wattage and recalculated from a frame-local `instantPace` value of 0, overwriting the valid 19 W with 0.

Observed user sequence:
- `ff 00 ... 13 00 ...` -> `Current Watt: 19`
- following `00 0b ...` frame has no instantaneous power/pace -> `rower doesn't send wattage...` -> `Current Watt: 0`

The same split-frame pattern repeats throughout the supplied log, causing the watt value to alternate between the real reported value and 0.

### Root cause
`ftmsrower::characteristicChanged()` used `else if (!PM5)` whenever the current packet did not advertise `Flags.instantPower`. This confused "this packet has no power field" with "this rower does not provide power". Since `instantPace` is initialized to 0 for every notification, a secondary packet without pace could overwrite the previously parsed watt value with 0.

### Fix
Only use the pace-based watt fallback when the current FTMS packet actually contains `Instantaneous Pace`. Packets containing neither power nor pace now leave the existing `m_watt` value untouched.

This preserves the existing fallback behavior for rowers that really provide pace instead of wattage while preventing secondary/split FTMS frames from clobbering a valid power reading.

### Validation
Compared the branch against `master`: only `src/devices/ftmsrower/ftmsrower.cpp` is modified. The change is intentionally limited to the fallback condition and its invalid-pace guard. Device validation should confirm that the user case keeps the reported watt value across the following `0x0b00` frame instead of dropping to zero.