### PR TITLE
Map standalone gear changes to ERG target power

### DIFF
--- a/src/devices/bike.cpp
+++ b/src/devices/bike.cpp
@@ -220,8 +220,9 @@ void bike::setGears(double gears) {
     qDebug() << "setGears" << gears;
 
     virtualbike *virtualBike = VirtualBike();
+    const qint64 lastFtmsFrame = virtualBike ? virtualBike->whenLastFTMSFrameReceived() : 0;
     const bool externalControllerActive =
-        virtualBike && (virtualBike->connected() || virtualBike->ftmsDeviceConnected());
+        lastFtmsFrame > 0 && QDateTime::currentMSecsSinceEpoch() <= lastFtmsFrame + 2000;
     if (!externalControllerActive && RequestedPower.value() > 0 && homeform::singleton()) {
         if (gears > m_gears) {
             qDebug() << "Standalone ERG: translating gear up to target power jog";
@@ -709,7 +710,7 @@ void bike::updateSlopeTargetPower(bool force) {
     // Apply gear offset to grade (0.5 scaling factor)
     double grade = m_currentSlopePercent + (gearsModifier() / 2.0);
 
-    // Get current speed (with fallback to cadence-based estimation)
+    // Get current speed for slope calculations with fallback to cadence-based estimation
     double speedKmh = getCurrentSpeedForSlope();
 
     // Compute required power using physics model

--- a/src/devices/bike.cpp
+++ b/src/devices/bike.cpp
@@ -76,7 +76,7 @@ void bike::changeResistance(resistance_t resistance) {
 void bike::changeInclination(double grade, double percentage) {
     qDebug() << QStringLiteral("bike::changeInclination") << autoResistanceEnable << grade << percentage;
     lastRawRequestedInclinationValue = grade;
-    if (autoResistanceEnable) {
+    if (autoResistanceEnable) {        
         requestInclination = grade;
     }
     emit inclinationChanged(grade, percentage);
@@ -110,20 +110,20 @@ void bike::changePower(int32_t power) {
         settings.value(QZSettings::zwift_erg_filter, QZSettings::default_zwift_erg_filter).toDouble();
     double erg_filter_lower =
         settings.value(QZSettings::zwift_erg_filter_down, QZSettings::default_zwift_erg_filter_down).toDouble();
-
+    
     // Apply bike power offset
     int bike_power_offset = settings.value(QZSettings::bike_power_offset, QZSettings::default_bike_power_offset).toInt();
     power += bike_power_offset;
     qDebug() << QStringLiteral("changePower: original power with offset applied: ") + QString::number(power) + QStringLiteral(" (offset: ") + QString::number(bike_power_offset) + QStringLiteral(")");
 
     requestPower = power; // used by some bikes that have ERG mode builtin
-
+    
     if(power_sensor && ergModeSupported && m_rawWatt.value() > 0 && m_watt.value() > 0 && fabs(requestPower - m_watt.average5s()) < qMax(erg_filter_upper, erg_filter_lower)) {
         qDebug() << "applying delta watt to power request m_rawWatt" << m_rawWatt.average5s() << "watt" << m_watt.average5s() << "req" << requestPower;
         // the concept here is to trying to add or decrease the delta from the power sensor
         requestPower += (requestPower - m_watt.average5s());
     }
-
+        
     bool force_resistance =
         settings.value(QZSettings::virtualbike_forceresistance, QZSettings::default_virtualbike_forceresistance)
             .toBool();
@@ -238,7 +238,7 @@ void bike::setGears(double gears) {
     // - If we're trying to set a gear outside valid range AND we're already at a valid gear,
     //   reject the change (normal case: user at gear 1 tries to go to 0.5, should fail)
     // - If we're trying to set a gear outside valid range BUT we're currently below minimum,
-    //   clamp to valid range (startup case: system starts at 0, first gearUp with 0.5 gain
+    //   clamp to valid range (startup case: system starts at 0, first gearUp with 0.5 gain 
     //   goes to 0.5, should be clamped to 1 to allow the system to reach valid state)
     // This prevents the system from getting stuck below minGears due to fractional gains
     // while preserving normal boundary rejection behavior for users at valid gear positions
@@ -301,6 +301,7 @@ void bike::setGears(double gears) {
         homeform::singleton()->updateGearsValue();
     }
 
+    
     if (MyWhooshLink::instance() && MyWhooshLink::instance()->isEnabled() &&
         !qFuzzyCompare(previousGears + 1.0, m_gears + 1.0)) {
         const bool uiAligned = settings.value(QZSettings::zwift_gear_ui_aligned,
@@ -370,7 +371,7 @@ void bike::clearStats() {
     WattKg.clear(false);
     for(int i=0; i<maxHeartZone(); i++) {
         hrZonesSeconds[i].clear(false);
-    }
+    }    
 }
 
 void bike::setPaused(bool p) {
@@ -397,7 +398,7 @@ void bike::setPaused(bool p) {
     WattKg.setPaused(p);
     for(int i=0; i<maxHeartZone(); i++) {
         hrZonesSeconds[i].setPaused(p);
-    }
+    }    
 }
 
 void bike::setLap() {
@@ -410,7 +411,6 @@ void bike::setLap() {
     Distance1s.setLap(true);
     Heart.setLap(false);
     m_jouls.setLap(true);
-    elevationAcc = 0;
     m_watt.setLap(false);
     m_rawWatt.setLap(false);
     WeightLoss.setLap(false);
@@ -425,7 +425,7 @@ void bike::setLap() {
     Resistance.setLap(false);
     for(int i=0; i<maxHeartZone(); i++) {
         hrZonesSeconds[i].setLap(false);
-    }
+    }    
 }
 
 int bike::metricValueForSetting(const QString &setting) {

--- a/src/devices/bike.cpp
+++ b/src/devices/bike.cpp
@@ -76,7 +76,7 @@ void bike::changeResistance(resistance_t resistance) {
 void bike::changeInclination(double grade, double percentage) {
     qDebug() << QStringLiteral("bike::changeInclination") << autoResistanceEnable << grade << percentage;
     lastRawRequestedInclinationValue = grade;
-    if (autoResistanceEnable) {        
+    if (autoResistanceEnable) {
         requestInclination = grade;
     }
     emit inclinationChanged(grade, percentage);
@@ -110,20 +110,20 @@ void bike::changePower(int32_t power) {
         settings.value(QZSettings::zwift_erg_filter, QZSettings::default_zwift_erg_filter).toDouble();
     double erg_filter_lower =
         settings.value(QZSettings::zwift_erg_filter_down, QZSettings::default_zwift_erg_filter_down).toDouble();
-    
+
     // Apply bike power offset
     int bike_power_offset = settings.value(QZSettings::bike_power_offset, QZSettings::default_bike_power_offset).toInt();
     power += bike_power_offset;
     qDebug() << QStringLiteral("changePower: original power with offset applied: ") + QString::number(power) + QStringLiteral(" (offset: ") + QString::number(bike_power_offset) + QStringLiteral(")");
 
     requestPower = power; // used by some bikes that have ERG mode builtin
-    
+
     if(power_sensor && ergModeSupported && m_rawWatt.value() > 0 && m_watt.value() > 0 && fabs(requestPower - m_watt.average5s()) < qMax(erg_filter_upper, erg_filter_lower)) {
         qDebug() << "applying delta watt to power request m_rawWatt" << m_rawWatt.average5s() << "watt" << m_watt.average5s() << "req" << requestPower;
         // the concept here is to trying to add or decrease the delta from the power sensor
         requestPower += (requestPower - m_watt.average5s());
     }
-        
+
     bool force_resistance =
         settings.value(QZSettings::virtualbike_forceresistance, QZSettings::default_virtualbike_forceresistance)
             .toBool();
@@ -219,11 +219,26 @@ void bike::setGears(double gears) {
     }
     qDebug() << "setGears" << gears;
 
+    virtualbike *virtualBike = VirtualBike();
+    const bool externalControllerActive =
+        virtualBike && (virtualBike->connected() || virtualBike->ftmsDeviceConnected());
+    if (!externalControllerActive && RequestedPower.value() > 0 && homeform::singleton()) {
+        if (gears > m_gears) {
+            qDebug() << "Standalone ERG: translating gear up to target power jog";
+            homeform::singleton()->keyboardPlus(QStringLiteral("target_power"));
+            return;
+        } else if (gears < m_gears) {
+            qDebug() << "Standalone ERG: translating gear down to target power jog";
+            homeform::singleton()->keyboardMinus(QStringLiteral("target_power"));
+            return;
+        }
+    }
+
     // Gear boundary handling with smart clamping logic:
     // - If we're trying to set a gear outside valid range AND we're already at a valid gear,
     //   reject the change (normal case: user at gear 1 tries to go to 0.5, should fail)
     // - If we're trying to set a gear outside valid range BUT we're currently below minimum,
-    //   clamp to valid range (startup case: system starts at 0, first gearUp with 0.5 gain 
+    //   clamp to valid range (startup case: system starts at 0, first gearUp with 0.5 gain
     //   goes to 0.5, should be clamped to 1 to allow the system to reach valid state)
     // This prevents the system from getting stuck below minGears due to fractional gains
     // while preserving normal boundary rejection behavior for users at valid gear positions
@@ -286,7 +301,6 @@ void bike::setGears(double gears) {
         homeform::singleton()->updateGearsValue();
     }
 
-    
     if (MyWhooshLink::instance() && MyWhooshLink::instance()->isEnabled() &&
         !qFuzzyCompare(previousGears + 1.0, m_gears + 1.0)) {
         const bool uiAligned = settings.value(QZSettings::zwift_gear_ui_aligned,
@@ -356,7 +370,7 @@ void bike::clearStats() {
     WattKg.clear(false);
     for(int i=0; i<maxHeartZone(); i++) {
         hrZonesSeconds[i].clear(false);
-    }    
+    }
 }
 
 void bike::setPaused(bool p) {
@@ -383,7 +397,7 @@ void bike::setPaused(bool p) {
     WattKg.setPaused(p);
     for(int i=0; i<maxHeartZone(); i++) {
         hrZonesSeconds[i].setPaused(p);
-    }    
+    }
 }
 
 void bike::setLap() {
@@ -396,6 +410,7 @@ void bike::setLap() {
     Distance1s.setLap(true);
     Heart.setLap(false);
     m_jouls.setLap(true);
+    elevationAcc = 0;
     m_watt.setLap(false);
     m_rawWatt.setLap(false);
     WeightLoss.setLap(false);
@@ -410,7 +425,7 @@ void bike::setLap() {
     Resistance.setLap(false);
     for(int i=0; i<maxHeartZone(); i++) {
         hrZonesSeconds[i].setLap(false);
-    }    
+    }
 }
 
 int bike::metricValueForSetting(const QString &setting) {


### PR DESCRIPTION
## Summary

When QZ is running standalone with an active requested power target, translate gear changes into target-power +/- adjustments instead of changing the virtual gear.

This is intentionally implemented in the shared `bike::setGears()` path, so it applies to Zwift Play/Click and other controllers that already dispatch gear changes through QZ.

## Behavior

A gear change is redirected only when:

- `RequestedPower` is active (`> 0`)
- no FTMS/Dircon control frame has been received in the last 2 seconds

In that case:

- gear up -> `keyboardPlus("target_power")`
- gear down -> `keyboardMinus("target_power")`

This reuses QZ's existing target-power jog path and therefore the existing 5 W `powerJog` value, instead of duplicating a watt step in the bike/controller code.

A plain BLE connection to the VirtualBike is not enough to mark QZ as externally controlled. Only recent FTMS/Dircon control traffic suppresses the standalone ERG redirect. The 2-second window matches the existing recent-frame logic already used by `virtualbike::bikeProvider()`.

## Motivation

This addresses the use case discussed in Discussion #4952: using hardware gear controls such as Zwift Play while QZ itself is running an ERG target standalone.

It also follows the same existing concept used by PR #4850, where Stages SB20 handlebar buttons route through the target-power +/- UI path.

The first test log on this PR showed the VirtualBike BLE peripheral in `ConnectedState` while `whenLastFTMSFrameReceived()` remained `0`. That made the original connection-state check incorrectly classify QZ as externally controlled, so the gear-to-power redirect never ran.

## Scope

- one file changed (`src/devices/bike.cpp`)
- no new settings
- no controller-specific code
- no duplicated 5 W constant

## Test plan

- Start a standalone QZ workout/ERG target so `RequestedPower > 0`
- With no recent FTMS/Dircon control traffic, press gear up/down on Zwift Play/Click and verify target power changes by +/-5 W while gear remains unchanged
- Connect an external app and send FTMS/Dircon control commands, then verify gear controls retain their existing behavior
- Disconnect/stop external control, wait more than 2 seconds, and verify gear controls return to standalone target-power adjustment
- Verify gear controls behave normally when no requested power target is active