### PR TITLE
Require a reference for pull requests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Reference
+
+<!-- Required: link an issue, discussion, ticket, support request, or provide a short textual reference explaining where this change comes from. Avoid including personal data from support emails. -->
+
+Reference:
+
+## Changes
+
+Describe the changes made.
+
+## Testing
+
+Describe how this was tested.

--- a/.github/workflows/pr-reference-check.yml
+++ b/.github/workflows/pr-reference-check.yml
@@ -1,0 +1,47 @@
+name: PR Reference Check
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  reference:
+    name: PR reference
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Validate PR reference
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          python3 - <<'PY'
+          import os
+          import re
+          import sys
+
+          body = os.environ.get("PR_BODY", "") or ""
+
+          # Ignore template comments so an untouched template does not pass.
+          body = re.sub(r"<!--.*?-->", "", body, flags=re.DOTALL)
+
+          # Accept a one-line or multi-line value after `Reference:` and stop
+          # at the next Markdown heading.
+          match = re.search(
+              r"(?ims)^\s*Reference\s*:\s*(.*?)(?=^\s*#{1,6}\s|\Z)",
+              body,
+          )
+
+          if not match or not match.group(1).strip():
+              print("ERROR: this pull request must contain a non-empty 'Reference:' field.")
+              print("Examples:")
+              print("  Reference: #4967")
+              print("  Reference: Discussion #4823")
+              print("  Reference: support request about FTMS bike resistance")
+              print("  Reference: textual description of the source/request")
+              sys.exit(1)
+
+          print("PR reference found:", match.group(1).strip().splitlines()[0])
+          PY


### PR DESCRIPTION
## Reference

Reference: repository owner request to require every pull request to include a ticket or textual source/reference.

## Changes

- add a pull request template with a required `Reference:` field
- accept issues, discussions, tickets, support requests, or free-text references
- add a lightweight `PR reference` GitHub Actions check
- ignore HTML template comments so an untouched template cannot pass
- use `pull_request_target` without checking out PR code, so external contributors cannot bypass the validator by changing the workflow in their branch
- avoid encouraging personal data from support emails in public PR descriptions

## Testing

- verified both new files on the feature branch
- compared the branch against `master`: only the PR template and reference-check workflow are added

After this PR is merged, `PR reference` can be added as a required status check in the repository ruleset/branch protection for `master`.