### PR TITLE
mDNS: resolve our own IP by interface enumeration instead of returning null

### DIFF
--- a/src/localipaddress.cpp
+++ b/src/localipaddress.cpp
@@ -93,6 +93,57 @@ int getIpAddress(JNIEnv *env, jobject wifiInfoObj) {
 }
 #endif
 
+namespace {
+
+// Best guess of our own IPv4 when there is no peer address to match against.
+// Interfaces are scored by type so that virtual adapters (VirtualBox host-only,
+// VPNs, ...) don't win over the real Wi-Fi/Ethernet one.
+QHostAddress bestLocalIPv4() {
+    QHostAddress best;
+    int bestScore = -1;
+
+    const auto interfaces = QNetworkInterface::allInterfaces();
+    for (const QNetworkInterface &networkInterface : interfaces) {
+        const auto flags = networkInterface.flags();
+        if (!flags.testFlag(QNetworkInterface::IsUp) || !flags.testFlag(QNetworkInterface::IsRunning) ||
+            flags.testFlag(QNetworkInterface::IsLoopBack)) {
+            continue;
+        }
+
+        int score;
+        switch (networkInterface.type()) {
+        case QNetworkInterface::Wifi:
+            score = 3;
+            break;
+        case QNetworkInterface::Ethernet:
+            score = 2;
+            break;
+        case QNetworkInterface::Virtual:
+            score = 0;
+            break;
+        default:
+            score = 1;
+            break;
+        }
+
+        const auto entries = networkInterface.addressEntries();
+        for (const QNetworkAddressEntry &entry : entries) {
+            const QHostAddress address = entry.ip();
+            if (address.protocol() != QAbstractSocket::IPv4Protocol || address.isLoopback() ||
+                address.isLinkLocal()) {
+                continue;
+            }
+            if (score > bestScore) {
+                bestScore = score;
+                best = address;
+            }
+        }
+    }
+    return best;
+}
+
+} // namespace
+
 QHostAddress localipaddress::getIP(const QHostAddress &srcAddress) {
     // Attempt to find the interface that corresponds with the provided
     // address and determine this device's address from the interface
@@ -121,7 +172,14 @@ QHostAddress localipaddress::getIP(const QHostAddress &srcAddress) {
     int ip = getIpAddress(env, wifiInfoObj);
     QHostAddress qip = QHostAddress(qFromBigEndian<quint32>(ip));
     qDebug() << "getIP from JNI" << qip;
-    return qip;
+    // WifiInfo.getIpAddress() returns 0 on Android 10+ and on non-wifi connections
+    if (!qip.isNull() && qip != QHostAddress(QHostAddress::AnyIPv4))
+        return qip;
 #endif
-    return QHostAddress();
+    // No peer address to match against (this is how provider.cpp announces the
+    // mDNS A record), so fall back to enumerating our own interfaces. Without
+    // this the A record is published empty and the service is unreachable.
+    const QHostAddress fallback = bestLocalIPv4();
+    qDebug() << "getIP fallback" << fallback;
+    return fallback;
 }

--- a/src/localipaddress.cpp
+++ b/src/localipaddress.cpp
@@ -151,12 +151,22 @@ QHostAddress localipaddress::getIP(const QHostAddress &srcAddress) {
     if(!srcAddress.isNull()) {
         const auto interfaces = QNetworkInterface::allInterfaces();
         for (const QNetworkInterface &networkInterface : interfaces) {
+            // Same gate as bestLocalIPv4(). A disconnected adapter keeps its APIPA
+            // entry, and Wi-Fi Direct/VPN adapters are down but still enumerated;
+            // answering an mDNS query with one of those addresses hands the client
+            // an address it can never reach, which reads as "connecting" forever.
+            const auto flags = networkInterface.flags();
+            if (!flags.testFlag(QNetworkInterface::IsUp) || !flags.testFlag(QNetworkInterface::IsRunning) ||
+                flags.testFlag(QNetworkInterface::IsLoopBack)) {
+                continue;
+            }
             const auto entries = networkInterface.addressEntries();
             for (const QNetworkAddressEntry &entry : entries) {
                 if (srcAddress.isInSubnet(entry.ip(), entry.prefixLength())) {
                     for (const QNetworkAddressEntry &newEntry : entries) {
                         QHostAddress address = newEntry.ip();
-                        if ((address.protocol() == QAbstractSocket::IPv4Protocol && !address.isLoopback())) {
+                        if (address.protocol() == QAbstractSocket::IPv4Protocol && !address.isLoopback() &&
+                            !address.isLinkLocal()) {
                             qDebug() << "getIP" << address;
                             return address;
                         }


### PR DESCRIPTION
## Reference

Reference: https://github.com/nickolas122/qz/pull/2#issuecomment-5393890252

Invited by @cagnulein in https://github.com/nickolas122/qz/pull/2#issuecomment-5393890252 — "feel free to open PRs directly against
cagnulein/qdomyos-zwift ... protocol/mDNS fixes first; then the DIRCON lifetime refactor
separately."

This is the first of that series. Roadmap, in dependency order:

1. **Resolve our own IP by interface enumeration** ← this PR
2. Announce mDNS on every interface
3. mDNS goodbye on quit, and repeated announcements
4. Stop the mDNS service renaming itself every five seconds
5. SRV/hostname: publish the name clients expect
6. FTMS feature bits and the unsolicited `0x2AD2` frame
7. mDNS teardown ordering
8. Android: multicast lock, A record, interface selection
9. DIRCON endpoint lifetime (separate, as discussed)

## Changes

`localipaddress::getIP()` returned a null `QHostAddress` on every desktop platform, so the
mDNS A record for the DIRCON endpoint was published empty and no client could resolve us.
It only appeared to work because iOS and Android reach the address by a different path.

Two commits:

- **Fall back to interface enumeration when resolving our own IP.** When the existing
  lookup yields nothing, walk `QNetworkInterface` and pick a usable IPv4 address instead of
  returning a null one.
- **Hold `getIP()` to the same interface rules as `bestLocalIPv4()`.** The two functions
  disagreed about which interfaces were acceptable — `getIP()` would return addresses that
  `bestLocalIPv4()` rejects (loopback, down interfaces). They now apply the same filter, so
  the address we advertise and the address we bind agree.

Nothing else in the tree calls into this path differently, and the behaviour when the
original lookup succeeds is unchanged — this only replaces a null return.

## Testing

Windows 11, Elite Avanti (FTMS), against Rouvy and MyWhoosh. Before: the A record in the
mDNS response is empty and Rouvy lists the trainer but cannot connect. After: the record
carries the LAN address and both apps resolve and connect.

Also exercised on Android (Wi-Fi) as part of the later Android work in this series.

I do not have an Apple TV, an iOS device, or a treadmill/elliptical/rower, so this is
tested on desktop and Android only. The change is platform-independent — it is in the
generic fallback, not in a platform `#ifdef`.
