### PR TITLE
mDNS: send announcements on every interface, not just the OS-chosen one

### DIFF
--- a/src/qmdnsengine/src/src/server.cpp
+++ b/src/qmdnsengine/src/src/server.cpp
@@ -86,6 +86,61 @@ bool ServerPrivate::bindSocket(QUdpSocket &socket, const QHostAddress &address)
     return true;
 }
 
+void ServerPrivate::writeToAllInterfaces(QUdpSocket &socket, const QByteArray &packet,
+                                         const QHostAddress &group, quint16 port)
+{
+    // A socket bound to the any-address sends a multicast datagram out exactly
+    // one interface: whichever the OS picks for 224.0.0.251. On a host with a
+    // virtual adapter (VirtualBox, VMware, Docker, Hyper-V) that is regularly
+    // not the interface the training app is on, and discovery then fails with
+    // no error anywhere - we join the group on every interface, so queries are
+    // still received, and only the answers go astray. Interface metrics do not
+    // reliably steer this on Windows. Real mDNS responders send one copy per
+    // interface, so do that.
+
+    const bool wantIPv4 = group.protocol() == QAbstractSocket::IPv4Protocol;
+    const QNetworkInterface previous = socket.multicastInterface();
+    bool sent = false;
+
+    const auto interfaces = QNetworkInterface::allInterfaces();
+    for (const QNetworkInterface &networkInterface : interfaces) {
+        const auto flags = networkInterface.flags();
+        if (!flags.testFlag(QNetworkInterface::IsUp) ||
+            !flags.testFlag(QNetworkInterface::IsRunning) ||
+            flags.testFlag(QNetworkInterface::IsLoopBack) ||
+            !flags.testFlag(QNetworkInterface::CanMulticast)) {
+            continue;
+        }
+
+        // An interface with no address of the right family cannot carry this
+        // datagram, and asking it to only produces a send error.
+        bool usable = false;
+        const auto entries = networkInterface.addressEntries();
+        for (const QNetworkAddressEntry &entry : entries) {
+            if ((entry.ip().protocol() == QAbstractSocket::IPv4Protocol) == wantIPv4) {
+                usable = true;
+                break;
+            }
+        }
+        if (!usable) {
+            continue;
+        }
+
+        socket.setMulticastInterface(networkInterface);
+        if (socket.writeDatagram(packet, group, port) != -1) {
+            sent = true;
+        }
+    }
+
+    socket.setMulticastInterface(previous);
+
+    // If no interface looked usable, fall back to the old behaviour rather
+    // than silently sending nothing.
+    if (!sent) {
+        socket.writeDatagram(packet, group, port);
+    }
+}
+
 void ServerPrivate::onTimeout()
 {
     // A timer is used to run a set of operations once per minute; first, the
@@ -144,9 +199,18 @@ void Server::sendMessage(const Message &message)
     QByteArray packet;
     toPacket(message, packet);
     if (message.address().protocol() == QAbstractSocket::IPv4Protocol) {
-        d->ipv4Socket.writeDatagram(packet, message.address(), message.port());
+        if (message.address() == MdnsIpv4Address) {
+            d->writeToAllInterfaces(d->ipv4Socket, packet, message.address(), message.port());
+        } else {
+            // A unicast reply goes back to one peer, so ordinary routing is right.
+            d->ipv4Socket.writeDatagram(packet, message.address(), message.port());
+        }
     } else {
-        d->ipv6Socket.writeDatagram(packet, message.address(), message.port());
+        if (message.address() == MdnsIpv6Address) {
+            d->writeToAllInterfaces(d->ipv6Socket, packet, message.address(), message.port());
+        } else {
+            d->ipv6Socket.writeDatagram(packet, message.address(), message.port());
+        }
     }
 }
 
@@ -154,6 +218,6 @@ void Server::sendMessageToAll(const Message &message)
 {
     QByteArray packet;
     toPacket(message, packet);
-    d->ipv4Socket.writeDatagram(packet, MdnsIpv4Address, MdnsPort);
-    d->ipv6Socket.writeDatagram(packet, MdnsIpv6Address, MdnsPort);
+    d->writeToAllInterfaces(d->ipv4Socket, packet, MdnsIpv4Address, MdnsPort);
+    d->writeToAllInterfaces(d->ipv6Socket, packet, MdnsIpv6Address, MdnsPort);
 }

--- a/src/qmdnsengine/src/src/server_p.h
+++ b/src/qmdnsengine/src/src/server_p.h
@@ -46,6 +46,11 @@ public:
 
     bool bindSocket(QUdpSocket &socket, const QHostAddress &address);
 
+    // Send a multicast datagram once per usable interface instead of letting
+    // the routing table pick a single one. See the comment on the definition.
+    void writeToAllInterfaces(QUdpSocket &socket, const QByteArray &packet,
+                              const QHostAddress &group, quint16 port);
+
     QTimer timer;
     QUdpSocket ipv4Socket;
     QUdpSocket ipv6Socket;


### PR DESCRIPTION
## Reference

Reference: https://github.com/nickolas122/qz/pull/2#issuecomment-5393890252

Part of the DIRCON/mDNS series invited by @cagnulein in https://github.com/nickolas122/qz/pull/2#issuecomment-5393890252 — "protocol/mDNS fixes first; then the DIRCON lifetime refactor separately."

Independent of the other PRs in the series — this one touches only `qmdnsengine/server.cpp`
and `server_p.h`, so it can be reviewed and merged in any order relative to them.

## Changes

qmdnsengine *joins* the multicast group on every interface, so queries were always
received. But it *sent* from a socket bound to the any-address, so answers left by
whichever single interface the OS picked for 224.0.0.251. On a host with a virtual adapter
— VirtualBox host-only, Tailscale, Docker, Hyper-V — that adapter regularly outranks Wi-Fi
on interface metric, so answers went where nothing was listening, and nothing anywhere
reported an error.

Observed on Windows 11: with VirtualBox host-only enabled the announcements left via
192.168.56.1. Disabling it promoted Tailscale (metric 5) ahead of Wi-Fi (metric 35) and
they left via the tunnel instead. Demoting the adapter with `Set-NetIPInterface` did not
move it — Windows had cached a best-interface for the group.

`writeToAllInterfaces()` sets `setMulticastInterface()` and sends one copy per usable
interface, restoring the previous interface afterwards. This is what a real mDNS responder
does. Unicast replies keep ordinary routing. If no interface qualifies it falls back to the
old single write rather than sending nothing, so the worst case is current behaviour.

## Testing

Windows 11, Elite Avanti (FTMS), Rouvy and MyWhoosh. Verified by packet capture that
announcements now leave via every usable interface rather than one, with the VirtualBox and
Tailscale adapters both present. Rouvy discovers the trainer with either adapter enabled,
which it did not before.

Desktop and Android only — I have no iOS device or Apple TV.
