### PR TITLE
mDNS: send a goodbye on quit, and repeat announcements per RFC 6762 8.3

### DIFF
--- a/src/qmdnsengine/src/src/provider.cpp
+++ b/src/qmdnsengine/src/src/provider.cpp
@@ -22,6 +22,7 @@
  * IN THE SOFTWARE.
  */
 
+#include <QCoreApplication>
 #include <QDebug>
 #include <QNetworkInterface>
 #include <qmdnsengine/abstractserver.h>
@@ -39,9 +40,21 @@
 using namespace QMdnsEngine;
 
 ProviderPrivate::ProviderPrivate(QObject *parent, AbstractServer *server, Hostname *hostname)
-    : QObject(parent), server(server), hostname(hostname), prober(nullptr), initialized(false), confirmed(false) {
+    : QObject(parent), server(server), hostname(hostname), prober(nullptr), initialized(false), confirmed(false),
+      saidGoodbye(false), announcesRemaining(0), announceDelayMs(0) {
     connect(server, &AbstractServer::messageReceived, this, &ProviderPrivate::onMessageReceived);
     connect(hostname, &Hostname::hostnameChanged, this, &ProviderPrivate::onHostnameChanged);
+
+    announceTimer.setSingleShot(true);
+    connect(&announceTimer, &QTimer::timeout, this, &ProviderPrivate::onAnnounceTimeout);
+
+    // Destruction is not guaranteed to run on every exit path, and a client that
+    // keeps the cached record will then try to connect to a port nobody is
+    // listening on and remember the failure. Sending the goodbye when the app
+    // decides to quit covers the ordinary window-close case too.
+    if (QCoreApplication::instance()) {
+        connect(QCoreApplication::instance(), &QCoreApplication::aboutToQuit, this, &ProviderPrivate::sayGoodbye);
+    }
 
     browsePtrProposed.setName(MdnsBrowseType);
     browsePtrProposed.setType(PTR);
@@ -51,9 +64,21 @@ ProviderPrivate::ProviderPrivate(QObject *parent, AbstractServer *server, Hostna
 }
 
 ProviderPrivate::~ProviderPrivate() {
-    if (confirmed) {
-        farewell();
+    sayGoodbye();
+}
+
+void ProviderPrivate::sayGoodbye() {
+    if (!confirmed || saidGoodbye) {
+        return;
     }
+    saidGoodbye = true;
+
+    // Nothing should re-announce the records we are about to invalidate.
+    announceTimer.stop();
+    announcesRemaining = 0;
+
+    qDebug() << "ProviderPrivate::sayGoodbye" << ptrRecord.name();
+    farewell();
 }
 
 void ProviderPrivate::announce() {
@@ -131,6 +156,28 @@ void ProviderPrivate::publish() {
         ARecord.setAddress(r);
 
     announce();
+
+    // Repeat the announcement a few times with a widening gap. A single
+    // datagram is easily lost on Wi-Fi, and a browser that misses it stays
+    // blind until it happens to query again.
+    announcesRemaining = 3;
+    announceDelayMs = 1000;
+    announceTimer.start(announceDelayMs);
+}
+
+void ProviderPrivate::onAnnounceTimeout() {
+    if (!confirmed || saidGoodbye || announcesRemaining <= 0) {
+        return;
+    }
+
+    --announcesRemaining;
+    qDebug() << "ProviderPrivate::onAnnounceTimeout repeat, remaining" << announcesRemaining;
+    announce();
+
+    if (announcesRemaining > 0) {
+        announceDelayMs *= 2;
+        announceTimer.start(announceDelayMs);
+    }
 }
 
 void ProviderPrivate::onMessageReceived(const Message &message) {

--- a/src/qmdnsengine/src/src/provider_p.h
+++ b/src/qmdnsengine/src/src/provider_p.h
@@ -26,6 +26,7 @@
 #define QMDNSENGINE_PROVIDER_P_H
 
 #include <QObject>
+#include <QTimer>
 
 #include <qmdnsengine/record.h>
 #include <qmdnsengine/service.h>
@@ -47,7 +48,10 @@ class ProviderPrivate : public QObject {
     void announce();
     void confirm();
     void farewell();
-    void publish();    
+    void publish();
+
+    // Send the goodbye exactly once, however we are being torn down.
+    void sayGoodbye();
 
     AbstractServer *server;
     Hostname *hostname;
@@ -56,6 +60,13 @@ class ProviderPrivate : public QObject {
     Service service;
     bool initialized;
     bool confirmed;
+    bool saidGoodbye;
+
+    // RFC 6762 8.3 asks for repeated announcements; a single one is easily lost
+    // on Wi-Fi and the service then stays invisible until the next query.
+    QTimer announceTimer;
+    int announcesRemaining;
+    int announceDelayMs;
 
     Record browsePtrRecord;
     Record ptrRecord;
@@ -72,6 +83,7 @@ class ProviderPrivate : public QObject {
 
     void onMessageReceived(const Message &message);
     void onHostnameChanged(const QByteArray &hostname);
+    void onAnnounceTimeout();
 };
 
 } // namespace QMdnsEngine


### PR DESCRIPTION
## Reference

Reference: https://github.com/nickolas122/qz/pull/2#issuecomment-5393890252

Part of the DIRCON/mDNS series invited by @cagnulein in https://github.com/nickolas122/qz/pull/2#issuecomment-5393890252 — "protocol/mDNS fixes first; then the DIRCON lifetime refactor separately."

Independent of the other PRs in the series — this one touches only `qmdnsengine/provider.cpp`
and `provider_p.h`, so it can be reviewed and merged in any order relative to them.

## Changes

Two ways a client ends up holding a record that points at nothing.

**The goodbye was only sent from `~ProviderPrivate()`,** which does not run on every exit
path. Rouvy caches the discovery result, tries to connect to a port nobody is listening on,
and remembers the failure — it does not retry after a failed connect, so the trainer stays
unpairable until its cache is cleared by hand. `sayGoodbye()` is now also wired to
`aboutToQuit`, and is idempotent, so the destructor path still works and cannot send twice.

**The service was announced exactly once.** A lost datagram — routine on Wi-Fi — left the
service invisible until the browser next queried. RFC 6762 §8.3 asks for repeated
announcements, so `publish()` now repeats three times, at 1s, 2s and 4s. The timer is
stopped by `sayGoodbye()` so nothing re-announces records that were just invalidated.

This does not remove the underlying race: the DIRCON server and its advertisement are both
created when a bike connects and destroyed when it goes away, so the endpoint only exists
for part of the session. Decoupling the server from the bike is the real fix, and is
deliberately not attempted here — that is the lifetime refactor we agreed to keep separate.

## Testing

Windows 11, Elite Avanti, Rouvy and MyWhoosh. Verified by capture that a goodbye now leaves
on normal quit, and that the three repeat announcements are sent. The specific failure this
removes — quit QZ, restart it, Rouvy still holding a dead record — no longer reproduces.
