### PR TITLE
Fix FTMS target power routing with Zwift Play

### DIFF
--- a/src/devices/ftmsbike/ftmsbike.cpp
+++ b/src/devices/ftmsbike/ftmsbike.cpp
@@ -94,7 +94,9 @@ bool ftmsbike::writeCharacteristic(uint8_t *data, uint8_t data_len, const QStrin
         return false;
     }
     
-    if(zwiftPlayService && gears_zwift_ratio) {
+    const bool isPowerTarget = data_len > 0 && data[0] == FTMS_SET_TARGET_POWER;
+
+    if(zwiftPlayService && gears_zwift_ratio && !isPowerTarget) {
         qDebug() << QStringLiteral("zwiftPlayService is present!");
         return false;
     }


### PR DESCRIPTION
## Reference

Reference: [Development request to preserve FTMS ERG target power routing when the Zwift Play service is active.](https://www.facebook.com/groups/149984563348738/permalink/1325067689173747/?rdid=E5Ly98RGaDOECx77#)

## Changes

- Detect `FTMS_SET_TARGET_POWER` packets in `ftmsbike::writeCharacteristic()`.
- Keep the existing early return when Zwift Play + `gears_zwift_ratio` are active only for non-target-power FTMS packets.
- Guard access to `data[0]` with `data_len > 0`.

This allows ERG target power commands to continue reaching the FTMS Control Point while keeping the existing Zwift Play routing behavior for other commands.

## Testing

- Verified the branch is one commit ahead of `master`.
- Verified the diff only modifies `src/devices/ftmsbike/ftmsbike.cpp` (3 additions, 1 deletion).
- No hardware test performed.