### PR TITLE
DIRCON/mDNS: make the advertisement resolvable and declare what we actually send

### DIFF
--- a/src/devices/dircon/dirconmanager.cpp
+++ b/src/devices/dircon/dirconmanager.cpp
@@ -42,7 +42,9 @@ using namespace std::chrono_literals;
 #define DM_BT(A) QByteArrayLiteral(A)
 
 #define DM_CHAR_OP(OP, P1, P2, P3, ZWIFT_ENABLED)                                                                     \
-    OP(FITNESS_MACHINE_CYCLE, 0x2ACC, DPKT_CHAR_PROP_FLAG_READ, DM_BT("\x83\x14\x00\x00\x0C\xE0\x00\x00"),             \
+    /* 0x5483 adds bit 14, power measurement. 0x2AD2 always carried power (flags bit 6); \
+       clients that trust this field - MyWhoosh does, Rouvy does not - saw 0 W. */       \
+    OP(FITNESS_MACHINE_CYCLE, 0x2ACC, DPKT_CHAR_PROP_FLAG_READ, DM_BT("\x83\x54\x00\x00\x0C\xE0\x00\x00"),             \
        DP_PROCESS_WRITE_NULL, P1, P2, P3)                                                                              \
     OP(FITNESS_MACHINE_CYCLE, 0x2AD6, DPKT_CHAR_PROP_FLAG_READ, DM_BT("\x0A\x00\x96\x00\x0A\x00"),                     \
        DP_PROCESS_WRITE_NULL, P1, P2, P3)                                                                              \

--- a/src/devices/dircon/dirconprocessor.cpp
+++ b/src/devices/dircon/dirconprocessor.cpp
@@ -160,20 +160,12 @@ void DirconProcessor::tcpNewConnection() {
     DirconProcessorClient *client = new DirconProcessorClient(socket);
     clientsMap.insert(socket, client);
 
-    if (rouvy_compatibility) {
-        // Send initial notification for 0x2AD2 (Indoor Bike Data) - Apple TV/Windows compatibility
-        // Elite Avanti sends this immediately after connection
-        DirconPacket initPkt;
-        initPkt.isRequest = false;
-        initPkt.Identifier = DPKT_MSGID_UNSOLICITED_CHARACTERISTIC_NOTIFICATION;
-        initPkt.ResponseCode = DPKT_RESPCODE_SUCCESS_REQUEST;
-        initPkt.uuid = 0x2AD2;
-        initPkt.additional_data = QByteArray(29, 0x00); // Empty data for now
-        QByteArray initData = initPkt.encode(0);
-        socket->write(initData);
-        socket->flush();
-        qDebug() << "Sent initial notification for 0x2AD2 to" << socket->peerAddress().toString();
-    }
+    // No unsolicited 0x2AD2 here. The Apple TV/Windows compatibility frame is still sent -
+    // see the DPKT_MSGID_ENABLE_CHARACTERISTIC_NOTIFICATIONS branch in processPacket() -
+    // but only once a client has actually subscribed to Indoor Bike Data. A frame pushed
+    // at connect time, before the client has even discovered the characteristic, made
+    // MyWhoosh disable 0x2AD2 outright and fall back to CSC with no power source, even
+    // when the payload was truthful. Observed 2026-08-25 against MyWhoosh on Windows 11.
 }
 
 void DirconProcessor::tcpDisconnected() {
@@ -267,8 +259,18 @@ DirconPacket DirconProcessor::processPacket(DirconProcessorClient *client, const
 
                             if ((idx = client->char_notify.indexOf(pkt.uuid)) >= 0 && !notif)
                                 client->char_notify.removeAt(idx);
-                            else if (idx < 0 && notif)
+                            else if (idx < 0 && notif) {
                                 client->char_notify.append(pkt.uuid);
+                                // The Elite Avanti sends an Indoor Bike Data frame as soon as
+                                // a client is listening, and Apple TV/Windows clients expect
+                                // one. Give them the last frame CharacteristicNotifier2AD2
+                                // produced rather than a hand-built payload, so the greeting
+                                // and the stream that follows describe the same machine. When
+                                // the notifier has not run yet there is no device attached and
+                                // nothing truthful to say, so nothing is sent.
+                                if (pkt.uuid == 0x2AD2 && !last2AD2Notification.isEmpty())
+                                    pending2AD2Greeting = true;
+                            }
                             out.ResponseCode = DPKT_RESPCODE_SUCCESS_REQUEST;
                             emit onCharacteristicNotificationSwitch(cc->uuid, notif);
                         } else
@@ -296,6 +298,10 @@ bool DirconProcessor::sendCharacteristicNotification(quint16 uuid, const QByteAr
     QSettings settings;
     bool rv = true, rvs;
     pkt.additional_data = data;
+    // Remember the real Indoor Bike Data frame so a client connecting later is greeted
+    // with the machine as it actually is - see tcpNewConnection().
+    if (uuid == 0x2AD2 && !data.isEmpty())
+        last2AD2Notification = data;
     pkt.Identifier = DPKT_MSGID_UNSOLICITED_CHARACTERISTIC_NOTIFICATION;
     pkt.ResponseCode = DPKT_RESPCODE_SUCCESS_REQUEST;
     pkt.uuid = uuid;
@@ -347,6 +353,22 @@ void DirconProcessor::tcpDataAvailable() {
                     QByteArray byteout = resp.encode(pkt.SequenceNumber);
                     if (byteout.size() && client && client->sock)
                         client->sock->write(byteout);
+                }
+                if (pending2AD2Greeting) {
+                    pending2AD2Greeting = false;
+                    if (client && client->sock) {
+                        DirconPacket initPkt;
+                        initPkt.isRequest = false;
+                        initPkt.Identifier = DPKT_MSGID_UNSOLICITED_CHARACTERISTIC_NOTIFICATION;
+                        initPkt.ResponseCode = DPKT_RESPCODE_SUCCESS_REQUEST;
+                        initPkt.uuid = 0x2AD2;
+                        initPkt.additional_data = last2AD2Notification;
+                        client->sock->write(initPkt.encode(0));
+                        client->sock->flush();
+                        qDebug() << "Sent initial notification for 0x2AD2 to"
+                                 << client->sock->peerAddress().toString()
+                                 << last2AD2Notification.toHex(' ');
+                    }
                 }
             } else if (rembuf >= 0) {
                 DirconPacket resp;

--- a/src/devices/dircon/dirconprocessor.cpp
+++ b/src/devices/dircon/dirconprocessor.cpp
@@ -65,7 +65,11 @@ void DirconProcessor::initAdvertising() {
         // the device silently when it misses. The old trailing "H" and the unhyphenated
         // spaces both broke that match, so MyWhoosh never resolved us and never opened
         // TCP to 36866. Hostname appends ".local." itself, and Rouvy ignores the target.
-        mdnsHostname = new QMdnsEngine::Hostname(mdnsServer, serverName.toUtf8().replace(' ', '-'), this);
+        // IPv4Only because initServer() binds AnyIPv4: publishing an AAAA would
+        // advertise a link-local address nothing is listening on, and a client
+        // that picks it stalls in SYN_SENT rather than falling back.
+        mdnsHostname = new QMdnsEngine::Hostname(mdnsServer, serverName.toUtf8().replace(' ', '-'),
+                                                 QMdnsEngine::HostnameAddressFamily::IPv4Only, this);
         mdnsProvider = new QMdnsEngine::Provider(mdnsServer, mdnsHostname, this);
         QMdnsEngine::Service mdnsService;
         // Both spellings encode to the same bytes - writeName() chops the trailing

--- a/src/devices/dircon/dirconprocessor.cpp
+++ b/src/devices/dircon/dirconprocessor.cpp
@@ -14,7 +14,29 @@ DirconProcessor::DirconProcessor(const QList<DirconProcessorService *> &my_servi
     foreach (DirconProcessorService *my_service, my_services) { my_service->setParent(this); }
 }
 
-DirconProcessor::~DirconProcessor() {}
+DirconProcessor::~DirconProcessor() {
+    // The three mDNS objects are all children of this processor, and QObject destroys
+    // children in the order they were added - which initAdvertising() makes server,
+    // hostname, provider. That is exactly backwards: ~ProviderPrivate() sends the goodbye
+    // through `server->sendMessageToAll()`, so it reaches through a QObject that was freed
+    // two destructors ago.
+    //
+    // It cost nothing for a long time because the ordinary quit path never gets there. The
+    // provider only says goodbye once its name has been confirmed by a probe - a second or
+    // two after the endpoint comes up - and on quit `aboutToQuit` fires sayGoodbye() first,
+    // which sets saidGoodbye and makes the destructor's call return early. What is left is
+    // every mid-session teardown: releaseShared(), which DirconManager::shared() calls when
+    // a treadmill replaces a bike. That path crashed, and the goodbye it exists to send was
+    // being written into freed memory rather than onto the wire.
+    //
+    // So take them down in dependency order instead of leaving it to child order.
+    delete mdnsProvider;
+    mdnsProvider = nullptr;
+    delete mdnsHostname;
+    mdnsHostname = nullptr;
+    delete mdnsServer;
+    mdnsServer = nullptr;
+}
 
 QString DirconProcessor::convertUUIDFromUINT16ToString (quint16 uuid) {
     if(uuid == ZWIFT_PLAY_CHAR1_ENUM_VALUE)

--- a/src/devices/dircon/dirconprocessor.cpp
+++ b/src/devices/dircon/dirconprocessor.cpp
@@ -59,7 +59,13 @@ void DirconProcessor::initAdvertising() {
     if (!mdnsServer) {
         qDebug() << "Dircon Adv init for" << serverName;
         mdnsServer = new QMdnsEngine::Server(this);
-        mdnsHostname = new QMdnsEngine::Hostname(mdnsServer, serverName.toUtf8() + QByteArrayLiteral("H"), this);
+        // MyWhoosh keys its pending-service map on the instance name with spaces
+        // hyphenated - WahooProgram.ServiceFound() does serviceName.Replace(" ", "-")
+        // + ".local." - then looks that key up with the SRV target hostname and drops
+        // the device silently when it misses. The old trailing "H" and the unhyphenated
+        // spaces both broke that match, so MyWhoosh never resolved us and never opened
+        // TCP to 36866. Hostname appends ".local." itself, and Rouvy ignores the target.
+        mdnsHostname = new QMdnsEngine::Hostname(mdnsServer, serverName.toUtf8().replace(' ', '-'), this);
         mdnsProvider = new QMdnsEngine::Provider(mdnsServer, mdnsHostname, this);
         QMdnsEngine::Service mdnsService;
         // Both spellings encode to the same bytes - writeName() chops the trailing

--- a/src/devices/dircon/dirconprocessor.cpp
+++ b/src/devices/dircon/dirconprocessor.cpp
@@ -62,7 +62,11 @@ void DirconProcessor::initAdvertising() {
         mdnsHostname = new QMdnsEngine::Hostname(mdnsServer, serverName.toUtf8() + QByteArrayLiteral("H"), this);
         mdnsProvider = new QMdnsEngine::Provider(mdnsServer, mdnsHostname, this);
         QMdnsEngine::Service mdnsService;
-        mdnsService.setType(rouvy_compatibility ? "_wahoo-fitness-tnp._tcp.local" : "_wahoo-fitness-tnp._tcp.local.");
+        // Both spellings encode to the same bytes - writeName() chops the trailing
+        // dot - so the Rouvy branch never changed what went out on the wire. What it
+        // did do was leave the record names unable to match any query, which is why
+        // Rouvy could only find QZ if it was already running when QZ announced.
+        mdnsService.setType("_wahoo-fitness-tnp._tcp.local.");
         mdnsService.setName(serverName.toUtf8());
         mdnsService.addAttribute(QByteArrayLiteral("mac-address"), mac.toUtf8());
         mdnsService.addAttribute(QByteArrayLiteral("serial-number"), serialN.toUtf8());

--- a/src/devices/dircon/dirconprocessor.h
+++ b/src/devices/dircon/dirconprocessor.h
@@ -82,6 +82,12 @@ class DirconProcessor : public QObject {
     QMdnsEngine::Hostname *mdnsHostname = 0;
     QHash<QTcpSocket *, DirconProcessorClient *> clientsMap;
     bool rouvy_compatibility = false;
+    // Last 0x2AD2 payload CharacteristicNotifier2AD2 produced, replayed to a client the
+    // moment it connects. Empty until the notifier has run at least once, which is the
+    // signal that no device is attached yet and there is nothing truthful to say.
+    QByteArray last2AD2Notification;
+    // Set when a client subscribes to 0x2AD2, flushed once its enable-response is written.
+    bool pending2AD2Greeting = false;
     bool initServer();
     void initAdvertising();
     DirconPacket processPacket(DirconProcessorClient *client, const DirconPacket &pkt);

--- a/src/localipaddress.cpp
+++ b/src/localipaddress.cpp
@@ -93,6 +93,57 @@ int getIpAddress(JNIEnv *env, jobject wifiInfoObj) {
 }
 #endif
 
+namespace {
+
+// Best guess of our own IPv4 when there is no peer address to match against.
+// Interfaces are scored by type so that virtual adapters (VirtualBox host-only,
+// VPNs, ...) don't win over the real Wi-Fi/Ethernet one.
+QHostAddress bestLocalIPv4() {
+    QHostAddress best;
+    int bestScore = -1;
+
+    const auto interfaces = QNetworkInterface::allInterfaces();
+    for (const QNetworkInterface &networkInterface : interfaces) {
+        const auto flags = networkInterface.flags();
+        if (!flags.testFlag(QNetworkInterface::IsUp) || !flags.testFlag(QNetworkInterface::IsRunning) ||
+            flags.testFlag(QNetworkInterface::IsLoopBack)) {
+            continue;
+        }
+
+        int score;
+        switch (networkInterface.type()) {
+        case QNetworkInterface::Wifi:
+            score = 3;
+            break;
+        case QNetworkInterface::Ethernet:
+            score = 2;
+            break;
+        case QNetworkInterface::Virtual:
+            score = 0;
+            break;
+        default:
+            score = 1;
+            break;
+        }
+
+        const auto entries = networkInterface.addressEntries();
+        for (const QNetworkAddressEntry &entry : entries) {
+            const QHostAddress address = entry.ip();
+            if (address.protocol() != QAbstractSocket::IPv4Protocol || address.isLoopback() ||
+                address.isLinkLocal()) {
+                continue;
+            }
+            if (score > bestScore) {
+                bestScore = score;
+                best = address;
+            }
+        }
+    }
+    return best;
+}
+
+} // namespace
+
 QHostAddress localipaddress::getIP(const QHostAddress &srcAddress) {
     // Attempt to find the interface that corresponds with the provided
     // address and determine this device's address from the interface
@@ -121,7 +172,14 @@ QHostAddress localipaddress::getIP(const QHostAddress &srcAddress) {
     int ip = getIpAddress(env, wifiInfoObj);
     QHostAddress qip = QHostAddress(qFromBigEndian<quint32>(ip));
     qDebug() << "getIP from JNI" << qip;
-    return qip;
+    // WifiInfo.getIpAddress() returns 0 on Android 10+ and on non-wifi connections
+    if (!qip.isNull() && qip != QHostAddress(QHostAddress::AnyIPv4))
+        return qip;
 #endif
-    return QHostAddress();
+    // No peer address to match against (this is how provider.cpp announces the
+    // mDNS A record), so fall back to enumerating our own interfaces. Without
+    // this the A record is published empty and the service is unreachable.
+    const QHostAddress fallback = bestLocalIPv4();
+    qDebug() << "getIP fallback" << fallback;
+    return fallback;
 }

--- a/src/localipaddress.cpp
+++ b/src/localipaddress.cpp
@@ -151,12 +151,22 @@ QHostAddress localipaddress::getIP(const QHostAddress &srcAddress) {
     if(!srcAddress.isNull()) {
         const auto interfaces = QNetworkInterface::allInterfaces();
         for (const QNetworkInterface &networkInterface : interfaces) {
+            // Same gate as bestLocalIPv4(). A disconnected adapter keeps its APIPA
+            // entry, and Wi-Fi Direct/VPN adapters are down but still enumerated;
+            // answering an mDNS query with one of those addresses hands the client
+            // an address it can never reach, which reads as "connecting" forever.
+            const auto flags = networkInterface.flags();
+            if (!flags.testFlag(QNetworkInterface::IsUp) || !flags.testFlag(QNetworkInterface::IsRunning) ||
+                flags.testFlag(QNetworkInterface::IsLoopBack)) {
+                continue;
+            }
             const auto entries = networkInterface.addressEntries();
             for (const QNetworkAddressEntry &entry : entries) {
                 if (srcAddress.isInSubnet(entry.ip(), entry.prefixLength())) {
                     for (const QNetworkAddressEntry &newEntry : entries) {
                         QHostAddress address = newEntry.ip();
-                        if ((address.protocol() == QAbstractSocket::IPv4Protocol && !address.isLoopback())) {
+                        if (address.protocol() == QAbstractSocket::IPv4Protocol && !address.isLoopback() &&
+                            !address.isLinkLocal()) {
                             qDebug() << "getIP" << address;
                             return address;
                         }

--- a/src/qmdnsengine/src/include/qmdnsengine/hostname.h
+++ b/src/qmdnsengine/src/include/qmdnsengine/hostname.h
@@ -36,6 +36,20 @@ class AbstractServer;
 class QMDNSENGINE_EXPORT HostnamePrivate;
 
 /**
+ * @brief Address families a %Hostname publishes and answers queries for
+ *
+ * A DIRCON client resolves the SRV target with an ordinary resolver and
+ * connects to whatever address comes back. QZ's DIRCON server listens on IPv4
+ * only, so answering AAAA hands out a link-local address that nothing is
+ * bound to - MyWhoosh picked it and sat in SYN_SENT until the connect timed
+ * out. Publish only what the service actually accepts.
+ *
+ * Scoped rather than a bool so it cannot swallow the QObject* parent argument
+ * of the neighbouring overload through pointer-to-bool conversion.
+ */
+enum class HostnameAddressFamily { IPv4AndIPv6, IPv4Only };
+
+/**
  * @brief %Hostname reserved for exclusive use
  *
  * In order to provide services on the local network, a unique hostname must
@@ -63,6 +77,14 @@ class QMDNSENGINE_EXPORT Hostname : public QObject {
      * @brief Create a new hostname with desired value to register
      */
     Hostname(AbstractServer *server, const QByteArray &desired, QObject *parent = 0);
+
+    /**
+     * @brief Create a new hostname restricted to a single address family
+     *
+     * Use HostnameAddressFamily::IPv4Only when the service behind this
+     * hostname does not listen on IPv6.
+     */
+    Hostname(AbstractServer *server, const QByteArray &desired, HostnameAddressFamily family, QObject *parent = 0);
 
     /**
      * @brief Determine if a hostname has been registered

--- a/src/qmdnsengine/src/src/hostname.cpp
+++ b/src/qmdnsengine/src/src/hostname.cpp
@@ -93,6 +93,21 @@ void HostnamePrivate::assertHostname() {
     QByteArray localHostname = desiredHostname.isEmpty() ? QHostInfo::localHostName().toUtf8() : desiredHostname;
     localHostname = localHostname.replace('.', '-');
 
+    // A host name is not a service instance name: RFC 1123 allows letters, digits
+    // and hyphens, and nothing else. QZ derives this from the device name, so it
+    // arrived here as "Wahoo KICKR 0000H" and went out as a SRV target with spaces
+    // in it. Bonjour tolerates that by escaping them as \032, which is why it
+    // resolves from dns-sd and still fails in a client that hands the name to an
+    // ordinary resolver - MyWhoosh discovered the service and then never opened the
+    // connection. Anything outside the permitted set becomes a hyphen.
+    for (int i = 0; i < localHostname.size(); ++i) {
+        const char c = localHostname.at(i);
+        const bool ok = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-';
+        if (!ok) {
+            localHostname[i] = '-';
+        }
+    }
+
     // If the suffix > 1, then append a "-2", "-3", etc. to the hostname to
     // aid in finding one that is unique and not in use
     hostname =

--- a/src/qmdnsengine/src/src/hostname.cpp
+++ b/src/qmdnsengine/src/src/hostname.cpp
@@ -40,6 +40,26 @@
 
 using namespace QMdnsEngine;
 
+namespace {
+
+// True if the address is one this machine actually holds. Used to recognise our
+// own A/AAAA records coming back at us so they are not mistaken for a competing
+// claim on the hostname.
+bool isOwnAddress(const QHostAddress &address) {
+    if (address.isNull()) {
+        return false;
+    }
+    const auto addresses = QNetworkInterface::allAddresses();
+    for (const QHostAddress &local : addresses) {
+        if (local == address) {
+            return true;
+        }
+    }
+    return false;
+}
+
+} // namespace
+
 HostnamePrivate::HostnamePrivate(Hostname *hostname, AbstractServer *server)
     : HostnamePrivate(hostname, QByteArray(), server) {}
 
@@ -128,8 +148,19 @@ void HostnamePrivate::onMessageReceived(const Message &message) {
         const auto records = message.records();
         for (const Record &record : records) {
             if ((record.type() == A || record.type() == AAAA) && record.name() == hostname) {
+                // RFC 6762 8.2: our own address is not a competing claim. The
+                // provider keeps re-announcing its A record for several seconds
+                // after publishing, and with rouvy_compatibility the hostname
+                // re-probes every 5 seconds, so those two windows overlap
+                // permanently. Without this check the host renames itself
+                // against its own announcement on every rebroadcast, and each
+                // rename drags the service name along with it.
+                if (isOwnAddress(record.address())) {
+                    continue;
+                }
                 ++hostnameSuffix;
                 assertHostname();
+                return;
             }
         }
     } else {

--- a/src/qmdnsengine/src/src/hostname.cpp
+++ b/src/qmdnsengine/src/src/hostname.cpp
@@ -61,10 +61,14 @@ bool isOwnAddress(const QHostAddress &address) {
 } // namespace
 
 HostnamePrivate::HostnamePrivate(Hostname *hostname, AbstractServer *server)
-    : HostnamePrivate(hostname, QByteArray(), server) {}
+    : HostnamePrivate(hostname, QByteArray(), HostnameAddressFamily::IPv4AndIPv6, server) {}
 
 HostnamePrivate::HostnamePrivate(Hostname *hostname, const QByteArray &desired, AbstractServer *server)
-    : QObject(hostname), server(server), desiredHostname(desired), q(hostname) {
+    : HostnamePrivate(hostname, desired, HostnameAddressFamily::IPv4AndIPv6, server) {}
+
+HostnamePrivate::HostnamePrivate(Hostname *hostname, const QByteArray &desired, HostnameAddressFamily family,
+                                 AbstractServer *server)
+    : QObject(hostname), server(server), desiredHostname(desired), addressFamily(family), q(hostname) {
     connect(server, &AbstractServer::messageReceived, this, &HostnamePrivate::onMessageReceived);
     connect(&registrationTimer, &QTimer::timeout, this, &HostnamePrivate::onRegistrationTimeout);
     connect(&rebroadcastTimer, &QTimer::timeout, this, &HostnamePrivate::onRebroadcastTimeout);
@@ -113,16 +117,19 @@ void HostnamePrivate::assertHostname() {
     hostname =
         (hostnameSuffix == 1 ? localHostname : localHostname + "-" + QByteArray::number(hostnameSuffix)) + ".local.";
 
-    // Compose a query for A and AAAA records matching the hostname
+    // Compose a query for A (and, unless restricted to IPv4, AAAA) records
+    // matching the hostname
     Query ipv4Query;
     ipv4Query.setName(hostname);
     ipv4Query.setType(A);
-    Query ipv6Query;
-    ipv6Query.setName(hostname);
-    ipv6Query.setType(AAAA);
     Message message;
     message.addQuery(ipv4Query);
-    message.addQuery(ipv6Query);
+    if (addressFamily != HostnameAddressFamily::IPv4Only) {
+        Query ipv6Query;
+        ipv6Query.setName(hostname);
+        ipv6Query.setType(AAAA);
+        message.addQuery(ipv6Query);
+    }
 
     server->sendMessageToAll(message);
 
@@ -162,7 +169,11 @@ void HostnamePrivate::onMessageReceived(const Message &message) {
         }
         const auto records = message.records();
         for (const Record &record : records) {
-            if ((record.type() == A || record.type() == AAAA) && record.name() == hostname) {
+            // An AAAA record is not a competing claim on a hostname we only
+            // ever publish an A record for, so ignore it rather than renaming.
+            const bool competingType =
+                record.type() == A || (record.type() == AAAA && addressFamily != HostnameAddressFamily::IPv4Only);
+            if (competingType && record.name() == hostname) {
                 // RFC 6762 8.2: our own address is not a competing claim. The
                 // provider keeps re-announcing its A record for several seconds
                 // after publishing, and with rouvy_compatibility the hostname
@@ -186,7 +197,12 @@ void HostnamePrivate::onMessageReceived(const Message &message) {
         reply.reply(message);
         const auto queries = message.queries();
         for (const Query &query : queries) {
-            if ((query.type() == A || query.type() == AAAA) && query.name() == hostname) {
+            // Leaving an AAAA query unanswered is the point: a client that gets
+            // no IPv6 address falls back to the A record, which is the address
+            // the DIRCON server is actually listening on.
+            const bool answerable =
+                query.type() == A || (query.type() == AAAA && addressFamily != HostnameAddressFamily::IPv4Only);
+            if (answerable && query.name() == hostname) {
                 Record record;
                 if (generateRecord(message.address(), query.type(), record)) {
                     reply.addRecord(record);
@@ -221,6 +237,9 @@ Hostname::Hostname(AbstractServer *server, QObject *parent) : QObject(parent), d
 
 Hostname::Hostname(AbstractServer *server, const QByteArray &desired, QObject *parent)
     : QObject(parent), d(new HostnamePrivate(this, desired, server)) {}
+
+Hostname::Hostname(AbstractServer *server, const QByteArray &desired, HostnameAddressFamily family, QObject *parent)
+    : QObject(parent), d(new HostnamePrivate(this, desired, family, server)) {}
 
 bool Hostname::isRegistered() const { return d->hostnameRegistered; }
 

--- a/src/qmdnsengine/src/src/hostname_p.h
+++ b/src/qmdnsengine/src/src/hostname_p.h
@@ -28,6 +28,8 @@
 #include <QObject>
 #include <QTimer>
 
+#include <qmdnsengine/hostname.h>
+
 class QHostAddress;
 
 namespace QMdnsEngine {
@@ -43,6 +45,8 @@ class HostnamePrivate : public QObject {
   public:
     HostnamePrivate(Hostname *hostname, AbstractServer *server);
     HostnamePrivate(Hostname *hostname, const QByteArray &desired, AbstractServer *server);
+    HostnamePrivate(Hostname *hostname, const QByteArray &desired, HostnameAddressFamily family,
+                    AbstractServer *server);
 
     void assertHostname();
     bool generateRecord(const QHostAddress &srcAddress, quint16 type, Record &record);
@@ -52,6 +56,7 @@ class HostnamePrivate : public QObject {
     QByteArray hostnamePrev;
     QByteArray hostname;
     QByteArray desiredHostname;
+    HostnameAddressFamily addressFamily;
     bool hostnameRegistered;
     int hostnameSuffix;
 

--- a/src/qmdnsengine/src/src/prober.cpp
+++ b/src/qmdnsengine/src/src/prober.cpp
@@ -86,10 +86,25 @@ void ProberPrivate::onMessageReceived(const Message &message)
     }
     const auto records = message.records();
     for (const Record &record : records) {
-        if (record.name() == proposedRecord.name() && record.type() == proposedRecord.type()) {
-            ++suffix;
-            assertRecord();
+        if (record.name() != proposedRecord.name() || record.type() != proposedRecord.type()) {
+            continue;
         }
+
+        // RFC 6762 8.2: a record identical to the one we are about to claim is
+        // not a conflict. Our own announcements always come back to us -
+        // multicast loops back to the sending host, and any other responder
+        // sharing UDP 5353 (Bonjour's mDNSResponder, for one) relays them as
+        // well - so counting them as a competitor makes the service rename
+        // itself against itself on every probe, without end.
+        if (record == proposedRecord) {
+            continue;
+        }
+
+        // One rename per conflicting message. Continuing the loop would bump
+        // the suffix once per matching record in the same response.
+        ++suffix;
+        assertRecord();
+        return;
     }
 }
 

--- a/src/qmdnsengine/src/src/provider.cpp
+++ b/src/qmdnsengine/src/src/provider.cpp
@@ -266,10 +266,22 @@ void Provider::update(const Service &service) {
     QByteArray serviceName = service.name();
     serviceName = serviceName.replace('.', '-');
 
+    // A name parsed off the wire always ends in a dot - parseName() appends one
+    // after every label - and onMessageReceived() matches queries against these
+    // record names by exact compare. A type given without the trailing dot
+    // therefore matches nothing, and the service answers no queries at all: it
+    // is only ever discovered by whoever happens to be listening when publish()
+    // announces. Nothing downstream can tell the difference, because writeName()
+    // chops the trailing dot before encoding.
+    QByteArray serviceType = service.type();
+    if (!serviceType.endsWith('.')) {
+        serviceType.append('.');
+    }
+
     // Update the proposed records
-    QByteArray fqName = serviceName + "." + service.type();
-    d->browsePtrProposed.setTarget(service.type());
-    d->ptrProposed.setName(service.type());
+    QByteArray fqName = serviceName + "." + serviceType;
+    d->browsePtrProposed.setTarget(serviceType);
+    d->ptrProposed.setName(serviceType);
     d->ptrProposed.setTarget(fqName);
     d->srvProposed.setName(fqName);
     d->srvProposed.setPort(service.port());

--- a/src/qmdnsengine/src/src/provider.cpp
+++ b/src/qmdnsengine/src/src/provider.cpp
@@ -22,6 +22,7 @@
  * IN THE SOFTWARE.
  */
 
+#include <QCoreApplication>
 #include <QDebug>
 #include <QNetworkInterface>
 #include <qmdnsengine/abstractserver.h>
@@ -39,9 +40,21 @@
 using namespace QMdnsEngine;
 
 ProviderPrivate::ProviderPrivate(QObject *parent, AbstractServer *server, Hostname *hostname)
-    : QObject(parent), server(server), hostname(hostname), prober(nullptr), initialized(false), confirmed(false) {
+    : QObject(parent), server(server), hostname(hostname), prober(nullptr), initialized(false), confirmed(false),
+      saidGoodbye(false), announcesRemaining(0), announceDelayMs(0) {
     connect(server, &AbstractServer::messageReceived, this, &ProviderPrivate::onMessageReceived);
     connect(hostname, &Hostname::hostnameChanged, this, &ProviderPrivate::onHostnameChanged);
+
+    announceTimer.setSingleShot(true);
+    connect(&announceTimer, &QTimer::timeout, this, &ProviderPrivate::onAnnounceTimeout);
+
+    // Destruction is not guaranteed to run on every exit path, and a client that
+    // keeps the cached record will then try to connect to a port nobody is
+    // listening on and remember the failure. Sending the goodbye when the app
+    // decides to quit covers the ordinary window-close case too.
+    if (QCoreApplication::instance()) {
+        connect(QCoreApplication::instance(), &QCoreApplication::aboutToQuit, this, &ProviderPrivate::sayGoodbye);
+    }
 
     browsePtrProposed.setName(MdnsBrowseType);
     browsePtrProposed.setType(PTR);
@@ -51,9 +64,21 @@ ProviderPrivate::ProviderPrivate(QObject *parent, AbstractServer *server, Hostna
 }
 
 ProviderPrivate::~ProviderPrivate() {
-    if (confirmed) {
-        farewell();
+    sayGoodbye();
+}
+
+void ProviderPrivate::sayGoodbye() {
+    if (!confirmed || saidGoodbye) {
+        return;
     }
+    saidGoodbye = true;
+
+    // Nothing should re-announce the records we are about to invalidate.
+    announceTimer.stop();
+    announcesRemaining = 0;
+
+    qDebug() << "ProviderPrivate::sayGoodbye" << ptrRecord.name();
+    farewell();
 }
 
 void ProviderPrivate::announce() {
@@ -131,6 +156,28 @@ void ProviderPrivate::publish() {
         ARecord.setAddress(r);
 
     announce();
+
+    // Repeat the announcement a few times with a widening gap. A single
+    // datagram is easily lost on Wi-Fi, and a browser that misses it stays
+    // blind until it happens to query again.
+    announcesRemaining = 3;
+    announceDelayMs = 1000;
+    announceTimer.start(announceDelayMs);
+}
+
+void ProviderPrivate::onAnnounceTimeout() {
+    if (!confirmed || saidGoodbye || announcesRemaining <= 0) {
+        return;
+    }
+
+    --announcesRemaining;
+    qDebug() << "ProviderPrivate::onAnnounceTimeout repeat, remaining" << announcesRemaining;
+    announce();
+
+    if (announcesRemaining > 0) {
+        announceDelayMs *= 2;
+        announceTimer.start(announceDelayMs);
+    }
 }
 
 void ProviderPrivate::onMessageReceived(const Message &message) {

--- a/src/qmdnsengine/src/src/provider.cpp
+++ b/src/qmdnsengine/src/src/provider.cpp
@@ -99,6 +99,15 @@ void ProviderPrivate::confirm() {
     if (prober) {
         delete prober;
     }
+
+    // Probe from the name update() asked for. srvProposed holds the name the
+    // last prober confirmed, which may already carry a "-2"; feeding that back
+    // in makes Prober treat it as the base name and compound the suffix into
+    // "-2-2-2..." rather than counting 2, 3, 4.
+    if (!desiredFqName.isEmpty()) {
+        srvProposed.setName(desiredFqName);
+    }
+
     prober = new Prober(server, srvProposed, this);
     qDebug() << "ProviderPrivate::confirm()";
     connect(prober, &Prober::nameConfirmed, [this](const QByteArray &name) {
@@ -280,6 +289,7 @@ void Provider::update(const Service &service) {
 
     // Update the proposed records
     QByteArray fqName = serviceName + "." + serviceType;
+    d->desiredFqName = fqName;
     d->browsePtrProposed.setTarget(serviceType);
     d->ptrProposed.setName(serviceType);
     d->ptrProposed.setTarget(fqName);

--- a/src/qmdnsengine/src/src/provider_p.h
+++ b/src/qmdnsengine/src/src/provider_p.h
@@ -26,6 +26,7 @@
 #define QMDNSENGINE_PROVIDER_P_H
 
 #include <QObject>
+#include <QTimer>
 
 #include <qmdnsengine/record.h>
 #include <qmdnsengine/service.h>
@@ -47,7 +48,10 @@ class ProviderPrivate : public QObject {
     void announce();
     void confirm();
     void farewell();
-    void publish();    
+    void publish();
+
+    // Send the goodbye exactly once, however we are being torn down.
+    void sayGoodbye();
 
     AbstractServer *server;
     Hostname *hostname;
@@ -56,6 +60,13 @@ class ProviderPrivate : public QObject {
     Service service;
     bool initialized;
     bool confirmed;
+    bool saidGoodbye;
+
+    // RFC 6762 8.3 asks for repeated announcements; a single one is easily lost
+    // on Wi-Fi and the service then stays invisible until the next query.
+    QTimer announceTimer;
+    int announcesRemaining;
+    int announceDelayMs;
 
     Record browsePtrRecord;
     Record ptrRecord;
@@ -72,6 +83,7 @@ class ProviderPrivate : public QObject {
 
     void onMessageReceived(const Message &message);
     void onHostnameChanged(const QByteArray &hostname);
+    void onAnnounceTimeout();
 };
 
 } // namespace QMdnsEngine

--- a/src/qmdnsengine/src/src/provider_p.h
+++ b/src/qmdnsengine/src/src/provider_p.h
@@ -74,6 +74,10 @@ class ProviderPrivate : public QObject {
     Record txtRecord;
     Record ARecord;
 
+    // The name update() last asked for, before any "-2" the prober appended.
+    // Re-probing has to start from this, not from whatever was confirmed last.
+    QByteArray desiredFqName;
+
     Record browsePtrProposed;
     Record ptrProposed;
     Record srvProposed;

--- a/src/qmdnsengine/src/src/server.cpp
+++ b/src/qmdnsengine/src/src/server.cpp
@@ -105,9 +105,15 @@ void ServerPrivate::writeToAllInterfaces(QUdpSocket &socket, const QByteArray &p
     const auto interfaces = QNetworkInterface::allInterfaces();
     for (const QNetworkInterface &networkInterface : interfaces) {
         const auto flags = networkInterface.flags();
+        // Loopback is deliberately included. onTimeout() joins the multicast group
+        // on every interface that can carry it, loopback among them, so a client on
+        // this same machine is heard - but skipping loopback here meant it could
+        // never be answered. A training app querying over ::1 (MyWhoosh does) saw
+        // QZ reply on fe80:: instead, which is not where it asked, so it waited for
+        // an answer that was never coming. Rouvy was unaffected only because it
+        // browses over the real network interface.
         if (!flags.testFlag(QNetworkInterface::IsUp) ||
             !flags.testFlag(QNetworkInterface::IsRunning) ||
-            flags.testFlag(QNetworkInterface::IsLoopBack) ||
             !flags.testFlag(QNetworkInterface::CanMulticast)) {
             continue;
         }

--- a/src/qmdnsengine/src/src/server.cpp
+++ b/src/qmdnsengine/src/src/server.cpp
@@ -86,6 +86,61 @@ bool ServerPrivate::bindSocket(QUdpSocket &socket, const QHostAddress &address)
     return true;
 }
 
+void ServerPrivate::writeToAllInterfaces(QUdpSocket &socket, const QByteArray &packet,
+                                         const QHostAddress &group, quint16 port)
+{
+    // A socket bound to the any-address sends a multicast datagram out exactly
+    // one interface: whichever the OS picks for 224.0.0.251. On a host with a
+    // virtual adapter (VirtualBox, VMware, Docker, Hyper-V) that is regularly
+    // not the interface the training app is on, and discovery then fails with
+    // no error anywhere - we join the group on every interface, so queries are
+    // still received, and only the answers go astray. Interface metrics do not
+    // reliably steer this on Windows. Real mDNS responders send one copy per
+    // interface, so do that.
+
+    const bool wantIPv4 = group.protocol() == QAbstractSocket::IPv4Protocol;
+    const QNetworkInterface previous = socket.multicastInterface();
+    bool sent = false;
+
+    const auto interfaces = QNetworkInterface::allInterfaces();
+    for (const QNetworkInterface &networkInterface : interfaces) {
+        const auto flags = networkInterface.flags();
+        if (!flags.testFlag(QNetworkInterface::IsUp) ||
+            !flags.testFlag(QNetworkInterface::IsRunning) ||
+            flags.testFlag(QNetworkInterface::IsLoopBack) ||
+            !flags.testFlag(QNetworkInterface::CanMulticast)) {
+            continue;
+        }
+
+        // An interface with no address of the right family cannot carry this
+        // datagram, and asking it to only produces a send error.
+        bool usable = false;
+        const auto entries = networkInterface.addressEntries();
+        for (const QNetworkAddressEntry &entry : entries) {
+            if ((entry.ip().protocol() == QAbstractSocket::IPv4Protocol) == wantIPv4) {
+                usable = true;
+                break;
+            }
+        }
+        if (!usable) {
+            continue;
+        }
+
+        socket.setMulticastInterface(networkInterface);
+        if (socket.writeDatagram(packet, group, port) != -1) {
+            sent = true;
+        }
+    }
+
+    socket.setMulticastInterface(previous);
+
+    // If no interface looked usable, fall back to the old behaviour rather
+    // than silently sending nothing.
+    if (!sent) {
+        socket.writeDatagram(packet, group, port);
+    }
+}
+
 void ServerPrivate::onTimeout()
 {
     // A timer is used to run a set of operations once per minute; first, the
@@ -144,9 +199,18 @@ void Server::sendMessage(const Message &message)
     QByteArray packet;
     toPacket(message, packet);
     if (message.address().protocol() == QAbstractSocket::IPv4Protocol) {
-        d->ipv4Socket.writeDatagram(packet, message.address(), message.port());
+        if (message.address() == MdnsIpv4Address) {
+            d->writeToAllInterfaces(d->ipv4Socket, packet, message.address(), message.port());
+        } else {
+            // A unicast reply goes back to one peer, so ordinary routing is right.
+            d->ipv4Socket.writeDatagram(packet, message.address(), message.port());
+        }
     } else {
-        d->ipv6Socket.writeDatagram(packet, message.address(), message.port());
+        if (message.address() == MdnsIpv6Address) {
+            d->writeToAllInterfaces(d->ipv6Socket, packet, message.address(), message.port());
+        } else {
+            d->ipv6Socket.writeDatagram(packet, message.address(), message.port());
+        }
     }
 }
 
@@ -154,6 +218,6 @@ void Server::sendMessageToAll(const Message &message)
 {
     QByteArray packet;
     toPacket(message, packet);
-    d->ipv4Socket.writeDatagram(packet, MdnsIpv4Address, MdnsPort);
-    d->ipv6Socket.writeDatagram(packet, MdnsIpv6Address, MdnsPort);
+    d->writeToAllInterfaces(d->ipv4Socket, packet, MdnsIpv4Address, MdnsPort);
+    d->writeToAllInterfaces(d->ipv6Socket, packet, MdnsIpv6Address, MdnsPort);
 }

--- a/src/qmdnsengine/src/src/server_p.h
+++ b/src/qmdnsengine/src/src/server_p.h
@@ -46,6 +46,11 @@ public:
 
     bool bindSocket(QUdpSocket &socket, const QHostAddress &address);
 
+    // Send a multicast datagram once per usable interface instead of letting
+    // the routing table pick a single one. See the comment on the definition.
+    void writeToAllInterfaces(QUdpSocket &socket, const QByteArray &packet,
+                              const QHostAddress &group, quint16 port);
+
     QTimer timer;
     QUdpSocket ipv4Socket;
     QUdpSocket ipv6Socket;


### PR DESCRIPTION
## Reference

Reference: https://github.com/nickolas122/qz/pull/2#issuecomment-5393890252

Continues the DIRCON/mDNS series. Addresses the MyWhoosh failures @cagnulein reported
while testing #4973 + #4974 + #4975 together, and implements the `0x2AD2` design he asked
for in that thread.

**Depends on #4973, #4974 and #4975** — it builds on `writeToAllInterfaces()` and the
provider changes those introduce. Branch is stacked on all three; I'll rebase onto master
once they land.

Excludes the DIRCON lifetime refactor, which stays a separate PR as agreed.

## Changes

Seven cherry-picks plus one commit written specifically for this PR.

### mDNS: the advertisement clients can actually resolve

**QZ answered no mDNS queries at all in Rouvy-compatibility mode.** `parseName()` appends a
`.` after every label, so a name decoded off the wire always ends in a dot, and
`Provider::onMessageReceived()` matches queries against its record names by exact
`QByteArray` compare. Rouvy-compatibility set the service type *without* the trailing dot,
so the PTR, SRV and TXT comparisons could never be true. `writeName()` chops one trailing
dot before encoding, so both spellings are byte-identical on the wire — the branch never
changed what clients received, only what QZ could recognise coming back. The only thing
that ever advertised the instance was the single announcement at startup, which is why
Rouvy had to be running before QZ. `Provider::update()` now normalises the type.

**The service renamed itself every few seconds.** `ELITE AVANTI 01234 W`, then `W-2`, then
`W-2-2`, for as long as QZ ran, so any client needing a stable name could never pair.
Three defects, all QZ competing with itself: `prober.cpp` treated a record identical to the
one being claimed as a conflict (RFC 6762 §8.2 says it is not) and multicast loops back to
the sending host; `hostname.cpp` did the same for A/AAAA records holding one of our own
addresses; and `provider.cpp` re-probed from the last confirmed name rather than the
requested one, compounding the suffix.

**Loopback was skipped, and the host name contained spaces.** `writeToAllInterfaces()`
skipped loopback while `onTimeout()` joins the group on it, so QZ heard a query on `::1`
and answered on `fe80::` — the one interface it could not reply on was the one it was asked
on. And `assertHostname()` sanitised `.` but nothing else, so the SRV target went out with
spaces; Bonjour tolerates that by escaping them as `\032`, which is why `dns-sd` resolved
it happily while an ordinary resolver got nothing. RFC 1123 allows letters, digits and
hyphens.

**The SRV target now matches what clients expect.** MyWhoosh keys its pending-service map
on the instance name with spaces hyphenated — `ServiceFound()` stores
`serviceName.Replace(" ", "-") + ".local."` — then `ServiceResolved()` looks that key up by
SRV target and returns *silently* on a miss. QZ published `"<serverName>H.local."` with the
spaces intact, so the lookup never hit and MyWhoosh dropped the trainer before resolving
it. A real KICKR passes by naming convention: instance `KICKR CORE 1234` publishes host
`KICKR-CORE-1234.local.`. The trailing `H` guarded against the self-conflict rename loop,
which is now fixed properly above. Rouvy ignores the SRV target entirely.

**The hostname is advertised IPv4-only.** A client that resolves the AAAA record and tries
to reach us over IPv6 gets a connection that cannot complete — discovery succeeds and
pairing then fails, with nothing logged anywhere.

**mDNS objects are torn down in dependency order,** not Qt child order, so the goodbye
leaves before the socket it needs.

### DIRCON: declare what we actually send

**FTMS feature bitmask now declares power measurement.** `0x2ACC` reported `0x1483` for a
cycle machine — bit 14 clear — while `0x2AD2` set flags bit 6 and carried real
instantaneous power in every notification. Rouvy never consults the bitmask so it did not
notice; MyWhoosh reads it first, believed it, subscribed only to CSC `0x2A5B` and left its
power tile at 0 W. `0x1483` -> `0x5483`. Target-setting features unchanged, treadmill entry
untouched.

**The initial `0x2AD2` frame carries real data, or is not sent.** `tcpNewConnection()` sent
`QByteArray(29, 0x00)` to every client for Apple TV/Windows compatibility. Its flags word
is zero, which declares a machine that measures no power, speed or cadence. MyWhoosh's
`DirconSensor` latches which quantities the trainer reports from the first `0x2AD2` frame
it sees (`IsIndoorBikeDataFlagRead`) and never revisits it, so that frame cost it the power
source for the whole session and it then disabled `0x2AD2` as useless — it cannot fall back
to Cycling Power either, since it drops `0x1818` whenever `0x1826` is present.

Per @cagnulein's request the frame is **kept**, since it mimics the Elite Avanti and exists
for Apple TV/Windows compatibility. Two things change.

**It carries a real payload.** `sendCharacteristicNotification()` remembers the last frame
`CharacteristicNotifier2AD2` produced and the greeting replays that, so the greeting and the
stream behind it describe the same machine by construction. Until the notifier has run there
is no device attached and nothing truthful to say, so **nothing is sent** rather than a frame
with invented flags — the idle behaviour you asked for, which also means this needs no
revisiting once the lifetime refactor lands and the endpoint can exist before a bike does.

**It is sent when a client enables notifications on `0x2AD2`, not when it connects.** A
truthful payload alone was not enough — see Testing for the measurement. Clients that want
Indoor Bike Data still get an immediate frame; clients that never ask are no longer handed
one.

## Testing

Windows 11, Elite Avanti (FTMS `YPBM001264`), QZ and the training app on the same host
(192.168.0.106). Built locally from this branch with Qt 5.15.2 / mingw; the three PRs this
stacks on are included.

### MyWhoosh: was not discoverable, now pairs and takes power

On the #4973+#4974+#4975 build MyWhoosh **never opened a TCP connection at all** — it failed
at mDNS resolve, before reaching the DIRCON server. The SRV target was published as
`ELITE AVANTI 01234 WH.local.`, with spaces, so `ServiceResolved()` missed its key and
dropped the trainer silently.

With this branch, `dns-sd` shows the advertisement resolving:

```
Browsing for _wahoo-fitness-tnp._tcp
20:48:16.907  Add  3 38 local.  _wahoo-fitness-tnp._tcp.  ELITE AVANTI 01234 W

Lookup ELITE AVANTI 01234 W._wahoo-fitness-tnp._tcp.local
ELITEAVANTI01234W._wahoo-fitness-tnp._tcp.local. can be reached at
    ELITE-AVANTI-01234-W.local.:36866 (interface 38)
    ble-service-uuids=0x1826 mac-address=24:DC:C3:E3:B5:D2 serial-number=01234
```

and `ELITE-AVANTI-01234-W.local` resolves A -> 192.168.0.106. MyWhoosh pairs.

### The greeting frame: why it moved to subscribe-time

An intermediate build sent the greeting at connect with a **correct** payload. That was not
enough. MyWhoosh read the feature bitmask as `0x5483` (power declared), received a greeting
with flags `0x0264` (power bit set), and still refused Indoor Bike Data:

```
req?=1 uuid=2acc dat=          -> resp dat=835400000ce00000     (0x5483, power bit 14 set)
tcpNewConnection()  Sent initial notification for 0x2AD2 "64 02 00 00 00 00 00 00 00 00 00 00"
req?=1 uuid=2a5b dat=01        <- enable CSC
req?=1 uuid=2ad9 dat=00        <- DISABLE control point
req?=1 uuid=2ad2 dat=00        <- DISABLE Indoor Bike Data
```

Result: 657 CSC notifications, **zero** Indoor Bike Data, power tile at 0 W. The frame was
arriving before the client had discovered the characteristic — the only thing distinguishing
it from a build with no frame at all.

Sending it on subscribe instead, same bike, same client:

```
req?=1 uuid=2ad2 dat=01        <- ENABLE Indoor Bike Data
req?=1 uuid=2a5b dat=01        <- enable CSC
tcpDataAvailable() Sent initial notification for 0x2AD2 "64 02 53 00 00 00 01 00 00 00 00 00"
req?=1 uuid=2ad9 dat=11000014003233   <- Set Indoor Bike Simulation Parameters
```

Result over a 19-second session: **229 Indoor Bike Data notifications** alongside 229 CSC,
payloads carrying live values (`64 02 53 00 …` / `64 02 4f 00 …` — flags `0x0264`, speed
varying, power present), and MyWhoosh writing simulation parameters back to the control
point. Power flows.

### Rouvy

Unaffected throughout, as expected — it enables `0x2AD2` and `0x2A63` without consulting the
feature bitmask and ignores the SRV target. Verified on the #4973+#4974+#4975 build: full
handshake, 589 Indoor Bike Data notifications over a 67-second session, flags `0x0264`.

### Not tested

I have no Apple TV or iOS device. **The open question is whether Apple TV needs the greeting
frame before it subscribes** — if it does, the subscribe-time trigger needs a different
shape and I cannot determine that here. @cagnulein, this is the part that most needs your
hardware.

No treadmill, elliptical or rower either; the treadmill entry in the feature bitmask is
untouched.

Android is deliberately not included: those commits depend on the lifetime refactor and will
follow it.
