### PR TITLE
Exclude JFBK5.0UI from JFBK FTMS workaround

### DIFF
--- a/src/devices/ftmsbike/ftmsbike.cpp
+++ b/src/devices/ftmsbike/ftmsbike.cpp
@@ -2097,7 +2097,9 @@ void ftmsbike::deviceDiscovered(const QBluetoothDeviceInfo &device) {
         } else if(bluetoothDevice.name().toUpper().startsWith("DIRETO XR")) {
             qDebug() << QStringLiteral("DIRETO XR found");
             DIRETO_XR = true;
-        } else if(bluetoothDevice.name().toUpper().startsWith("JFBK5.0") || bluetoothDevice.name().toUpper().startsWith("JFBK7.0")) {
+        } else if(bluetoothDevice.name().toUpper().startsWith("JFBK5.0IC") ||
+                  bluetoothDevice.name().toUpper().startsWith("JFBK5.0R") ||
+                  bluetoothDevice.name().toUpper().startsWith("JFBK7.0")) {
             qDebug() << QStringLiteral("JFBK5.0 found");
             resistance_lvl_mode = true;
             ergModeSupported = false;

--- a/src/devices/ftmsbike/ftmsbike.cpp
+++ b/src/devices/ftmsbike/ftmsbike.cpp
@@ -1985,7 +1985,7 @@ void ftmsbike::characteristicWritten(const QLowEnergyCharacteristic &characteris
 }
 
 void ftmsbike::characteristicRead(const QLowEnergyCharacteristic &characteristic, const QByteArray &newValue) {
-    qDebug() << QStringLiteral("characteristicRead ") << characteristic.uuid() << newValue.toHex(' ');
+    qDebug() << QStringLiteral("characteristicRead ") << characteristic.name() << newValue.toHex(' ');
 }
 
 void ftmsbike::serviceScanDone(void) {
@@ -2026,7 +2026,7 @@ void ftmsbike::serviceScanDone(void) {
 }
 
 void ftmsbike::errorService(QLowEnergyService::ServiceError err) {
-    QMetaEnum metaEnum = QMetaEnum::fromType<QLowEnergyService::ServiceError>();
+    QMetaEnum metaEnum = QMetaEnum::fromType<QLowEnergyService::ServiceState>();
     emit debug(QStringLiteral("ftmsbike::errorService") + QString::fromLocal8Bit(metaEnum.valueToKey(err)) +
                m_control->errorString());
 }
@@ -2097,9 +2097,9 @@ void ftmsbike::deviceDiscovered(const QBluetoothDeviceInfo &device) {
         } else if(bluetoothDevice.name().toUpper().startsWith("DIRETO XR")) {
             qDebug() << QStringLiteral("DIRETO XR found");
             DIRETO_XR = true;
-        } else if(bluetoothDevice.name().toUpper().startsWith("JFBK5.0IC") ||
-                  bluetoothDevice.name().toUpper().startsWith("JFBK5.0R") ||
-                  bluetoothDevice.name().toUpper().startsWith("JFBK7.0")) {
+        } else if(bluetoothDevice.name().toUpper().startsWith("JFBK5.0UI")) {
+            qDebug() << QStringLiteral("JFBK5.0UI found - using standard FTMS handling");
+        } else if(bluetoothDevice.name().toUpper().startsWith("JFBK5.0") || bluetoothDevice.name().toUpper().startsWith("JFBK7.0")) {
             qDebug() << QStringLiteral("JFBK5.0 found");
             resistance_lvl_mode = true;
             ergModeSupported = false;

--- a/src/devices/ftmsbike/ftmsbike.cpp
+++ b/src/devices/ftmsbike/ftmsbike.cpp
@@ -1985,7 +1985,7 @@ void ftmsbike::characteristicWritten(const QLowEnergyCharacteristic &characteris
 }
 
 void ftmsbike::characteristicRead(const QLowEnergyCharacteristic &characteristic, const QByteArray &newValue) {
-    qDebug() << QStringLiteral("characteristicRead ") << characteristic.name() << newValue.toHex(' ');
+    qDebug() << QStringLiteral("characteristicRead ") << characteristic.uuid() << newValue.toHex(' ');
 }
 
 void ftmsbike::serviceScanDone(void) {
@@ -2026,7 +2026,7 @@ void ftmsbike::serviceScanDone(void) {
 }
 
 void ftmsbike::errorService(QLowEnergyService::ServiceError err) {
-    QMetaEnum metaEnum = QMetaEnum::fromType<QLowEnergyService::ServiceState>();
+    QMetaEnum metaEnum = QMetaEnum::fromType<QLowEnergyService::ServiceError>();
     emit debug(QStringLiteral("ftmsbike::errorService") + QString::fromLocal8Bit(metaEnum.valueToKey(err)) +
                m_control->errorString());
 }


### PR DESCRIPTION
## Summary
- keep the existing `JFBK5.0*` and `JFBK7.0*` matching behavior unchanged
- add a specific `JFBK5.0UI*` case before the generic JFBK workaround
- let `JFBK5.0UI` use the standard FTMS behavior instead of forcing resistance-level mode

## Context
A user debug log reported `JFBK5.0UI`. The generic `JFBK5.0` prefix was incorrectly enabling the JFBK resistance-level workaround for this device.

Using a specific exception is intentionally conservative so existing JFBK 5.0 variants continue to behave exactly as before.

Mail from Stefan Vo

## Testing
Not hardware-tested; final diff only adds the `JFBK5.0UI` exception before the existing JFBK condition.