### PR TITLE
Ignore Computrainer cadence when external cadence sensor is enabled

### DIFF
--- a/src/devices/computrainerbike/computrainerbike.cpp
+++ b/src/devices/computrainerbike/computrainerbike.cpp
@@ -229,6 +229,8 @@ void computrainerbike::update() {
             settings.value(QZSettings::heart_rate_belt_name, QZSettings::default_heart_rate_belt_name).toString();
         bool disable_hr_frommachinery =
             settings.value(QZSettings::heart_ignore_builtin, QZSettings::default_heart_ignore_builtin).toBool();
+        bool cadenceSensorEnabled =
+            settings.value(QZSettings::bike_cadence_sensor, QZSettings::default_bike_cadence_sensor).toBool();
 
         int Buttons, Status;
         bool calibration;
@@ -242,12 +244,14 @@ void computrainerbike::update() {
         Distance += ((Speed.value() / 3600000.0) *
                      ((double)lastRefreshCharacteristicChanged.msecsTo(QDateTime::currentDateTime())));
         emit debug("Current Distance: " + QString::number(Distance.value()));
-        Cadence = cadence;
-        emit debug(QStringLiteral("Current Cadence: ") + QString::number(Cadence.value()));
-        if (Cadence.value() > 0) {
-            CrankRevs++;
-            LastCrankEventTime += (uint16_t)(1024.0 / (((double)(Cadence.value())) / 60.0));
+        if (!cadenceSensorEnabled) {
+            Cadence = cadence;
+            if (Cadence.value() > 0) {
+                CrankRevs++;
+                LastCrankEventTime += (uint16_t)(1024.0 / (((double)(Cadence.value())) / 60.0));
+            }
         }
+        emit debug(QStringLiteral("Current Cadence: ") + QString::number(Cadence.value()));
 
         m_watt = Power;
         emit debug(QStringLiteral("Current Watt: ") + QString::number(watts()));


### PR DESCRIPTION
## Summary
- do not overwrite `Cadence` with Computrainer USB telemetry when `bike_cadence_sensor` is enabled
- avoid updating Computrainer-derived crank revolution/event timing in that case
- preserve the existing behavior when the external cadence sensor setting is disabled

This keeps the external cadence sensor as the authoritative cadence source when configured.