### PR TITLE
DIRCON: give the endpoint process lifetime and bring it up at launch

### DIFF
--- a/src/characteristics/characteristicnotifier.h
+++ b/src/characteristics/characteristicnotifier.h
@@ -6,14 +6,28 @@
 #define CN_INVALID -1
 #define CN_OK 0
 
+class bluetoothdevice;
+
 class CharacteristicNotifier : public QObject {
     Q_OBJECT
     quint16 my_uuid;
 
+  protected:
+    // The device every subclass reads its values from. Held in the base so that
+    // DirconManager::setDevice() can rebind the whole notifier chain in one pass;
+    // subclasses that used to declare their own `Bike` now inherit this one.
+    bluetoothdevice *Bike = nullptr;
+
   public:
-    explicit CharacteristicNotifier(quint16 uuid, QObject *parent = nullptr) : QObject(parent), my_uuid(uuid) {}
+    explicit CharacteristicNotifier(quint16 uuid, bluetoothdevice *device, QObject *parent = nullptr)
+        : QObject(parent), my_uuid(uuid), Bike(device) {}
     virtual int notify(QByteArray &out) = 0;
     quint16 uuid() const { return my_uuid; }
+
+    // May be called with nullptr: notify() implementations must tolerate a null
+    // device once the DIRCON endpoint outlives the bike.
+    virtual void setDevice(bluetoothdevice *device) { Bike = device; }
+    bluetoothdevice *device() const { return Bike; }
   signals:
 };
 

--- a/src/characteristics/characteristicnotifier0002.cpp
+++ b/src/characteristics/characteristicnotifier0002.cpp
@@ -4,8 +4,7 @@
 #include <QList>
 
 CharacteristicNotifier0002::CharacteristicNotifier0002(bluetoothdevice *bike, QObject *parent)
-    : CharacteristicNotifier(0x0002, parent) {
-    Bike = bike;
+    : CharacteristicNotifier(0x0002, bike, parent) {
     answerList = QList<QByteArray>();  // Initialize empty list
 }
 

--- a/src/characteristics/characteristicnotifier0002.h
+++ b/src/characteristics/characteristicnotifier0002.h
@@ -7,7 +7,6 @@
 
 class CharacteristicNotifier0002 : public CharacteristicNotifier {
     Q_OBJECT
-    bluetoothdevice* Bike = nullptr;    
     QList<QByteArray> answerList;
 
 public:

--- a/src/characteristics/characteristicnotifier0004.cpp
+++ b/src/characteristics/characteristicnotifier0004.cpp
@@ -4,8 +4,7 @@
 #include <QList>
 
 CharacteristicNotifier0004::CharacteristicNotifier0004(bluetoothdevice *bike, QObject *parent)
-    : CharacteristicNotifier(0x0004, parent) {
-    Bike = bike;
+    : CharacteristicNotifier(0x0004, bike, parent) {
     answerList = QList<QByteArray>();
 }
 

--- a/src/characteristics/characteristicnotifier0004.h
+++ b/src/characteristics/characteristicnotifier0004.h
@@ -7,7 +7,6 @@
 
 class CharacteristicNotifier0004 : public CharacteristicNotifier {
     Q_OBJECT
-    bluetoothdevice* Bike = nullptr;    
     QList<QByteArray> answerList;
 
 public:

--- a/src/characteristics/characteristicnotifier2a37.cpp
+++ b/src/characteristics/characteristicnotifier2a37.cpp
@@ -1,7 +1,7 @@
 #include "characteristicnotifier2a37.h"
 
 CharacteristicNotifier2A37::CharacteristicNotifier2A37(bluetoothdevice *Bike, QObject *parent)
-    : CharacteristicNotifier(0x2a37, parent), Bike(Bike) {}
+    : CharacteristicNotifier(0x2a37, Bike, parent) {}
 
 int CharacteristicNotifier2A37::notify(QByteArray &valueHR) {
     valueHR.append(char(0));                                  // Flags that specify the format of the value.

--- a/src/characteristics/characteristicnotifier2a37.h
+++ b/src/characteristics/characteristicnotifier2a37.h
@@ -5,7 +5,6 @@
 #include "characteristicnotifier.h"
 
 class CharacteristicNotifier2A37 : public CharacteristicNotifier {
-    bluetoothdevice *Bike;
 
   public:
     explicit CharacteristicNotifier2A37(bluetoothdevice *Bike, QObject *parent = nullptr);

--- a/src/characteristics/characteristicnotifier2a53.cpp
+++ b/src/characteristics/characteristicnotifier2a53.cpp
@@ -2,7 +2,7 @@
 #include "devices/treadmill.h"
 
 CharacteristicNotifier2A53::CharacteristicNotifier2A53(bluetoothdevice *Bike, QObject *parent)
-    : CharacteristicNotifier(0x2a53, parent), Bike(Bike) {}
+    : CharacteristicNotifier(0x2a53, Bike, parent) {}
 
 int CharacteristicNotifier2A53::notify(QByteArray &value) {
     BLUETOOTH_TYPE dt = Bike->deviceType();

--- a/src/characteristics/characteristicnotifier2a53.h
+++ b/src/characteristics/characteristicnotifier2a53.h
@@ -5,7 +5,6 @@
 #include "characteristicnotifier.h"
 
 class CharacteristicNotifier2A53 : public CharacteristicNotifier {
-    bluetoothdevice *Bike;
 
   public:
     explicit CharacteristicNotifier2A53(bluetoothdevice *Bike, QObject *parent = nullptr);

--- a/src/characteristics/characteristicnotifier2a5b.cpp
+++ b/src/characteristics/characteristicnotifier2a5b.cpp
@@ -2,7 +2,7 @@
 #include <QSettings>
 
 CharacteristicNotifier2A5B::CharacteristicNotifier2A5B(bluetoothdevice *Bike, QObject *parent)
-    : CharacteristicNotifier(0x2a5b, parent), Bike(Bike) {
+    : CharacteristicNotifier(0x2a5b, Bike, parent) {
     QSettings settings;
     bike_wheel_revs = settings.value(QZSettings::bike_wheel_revs, QZSettings::default_bike_wheel_revs).toBool();
 }

--- a/src/characteristics/characteristicnotifier2a5b.h
+++ b/src/characteristics/characteristicnotifier2a5b.h
@@ -5,7 +5,6 @@
 #include "characteristicnotifier.h"
 
 class CharacteristicNotifier2A5B : public CharacteristicNotifier {
-    bluetoothdevice *Bike;
     uint16_t lastWheelTime = 0;
     uint32_t wheelRevs = 0;
     bool bike_wheel_revs;

--- a/src/characteristics/characteristicnotifier2a63.cpp
+++ b/src/characteristics/characteristicnotifier2a63.cpp
@@ -1,7 +1,7 @@
 #include "characteristicnotifier2a63.h"
 
 CharacteristicNotifier2A63::CharacteristicNotifier2A63(bluetoothdevice *Bike, QObject *parent)
-    : CharacteristicNotifier(0x2a63, parent), Bike(Bike) {}
+    : CharacteristicNotifier(0x2a63, Bike, parent) {}
 
 int CharacteristicNotifier2A63::notify(QByteArray &value) {
     double normalizeWattage = Bike->wattsMetricforUI();

--- a/src/characteristics/characteristicnotifier2a63.h
+++ b/src/characteristics/characteristicnotifier2a63.h
@@ -5,7 +5,6 @@
 #include "characteristicnotifier.h"
 
 class CharacteristicNotifier2A63 : public CharacteristicNotifier {
-    bluetoothdevice *Bike;
 
   public:
     explicit CharacteristicNotifier2A63(bluetoothdevice *Bike, QObject *parent = nullptr);

--- a/src/characteristics/characteristicnotifier2acc.cpp
+++ b/src/characteristics/characteristicnotifier2acc.cpp
@@ -3,7 +3,7 @@
 #include <qmath.h>
 
 CharacteristicNotifier2ACC::CharacteristicNotifier2ACC(bluetoothdevice *Bike, QObject *parent)
-    : CharacteristicNotifier(0x2ACC, parent), Bike(Bike) {}
+    : CharacteristicNotifier(0x2ACC, Bike, parent) {}
 
 int CharacteristicNotifier2ACC::notify(QByteArray &value) {
     value.append((char)0x83); // average speed, cadence and resistance level supported

--- a/src/characteristics/characteristicnotifier2acc.h
+++ b/src/characteristics/characteristicnotifier2acc.h
@@ -5,7 +5,6 @@
 #include "characteristicnotifier.h"
 
 class CharacteristicNotifier2ACC : public CharacteristicNotifier {
-    bluetoothdevice *Bike;
 
   public:
     explicit CharacteristicNotifier2ACC(bluetoothdevice *Bike, QObject *parent = nullptr);

--- a/src/characteristics/characteristicnotifier2acd.cpp
+++ b/src/characteristics/characteristicnotifier2acd.cpp
@@ -4,7 +4,7 @@
 #include <QTime> // Include QTime for Bike->elapsedTime()
 
 CharacteristicNotifier2ACD::CharacteristicNotifier2ACD(bluetoothdevice *Bike, QObject *parent)
-    : CharacteristicNotifier(0x2acd, parent), Bike(Bike) {}
+    : CharacteristicNotifier(0x2acd, Bike, parent) {}
 
 int CharacteristicNotifier2ACD::notify(QByteArray &value) {
     BLUETOOTH_TYPE dt = Bike->deviceType();

--- a/src/characteristics/characteristicnotifier2acd.h
+++ b/src/characteristics/characteristicnotifier2acd.h
@@ -4,7 +4,6 @@
 #include "characteristicnotifier.h"
 
 class CharacteristicNotifier2ACD : public CharacteristicNotifier {
-    bluetoothdevice *Bike;
 
   public:
     explicit CharacteristicNotifier2ACD(bluetoothdevice *Bike, QObject *parent = nullptr);

--- a/src/characteristics/characteristicnotifier2ad2.cpp
+++ b/src/characteristics/characteristicnotifier2ad2.cpp
@@ -5,7 +5,7 @@
 #include <QSettings>
 
 CharacteristicNotifier2AD2::CharacteristicNotifier2AD2(bluetoothdevice *Bike, QObject *parent)
-    : CharacteristicNotifier(0x2ad2, parent), Bike(Bike) {}
+    : CharacteristicNotifier(0x2ad2, Bike, parent) {}
 
 int CharacteristicNotifier2AD2::notify(QByteArray &value) {
     BLUETOOTH_TYPE dt = Bike->deviceType();

--- a/src/characteristics/characteristicnotifier2ad2.h
+++ b/src/characteristics/characteristicnotifier2ad2.h
@@ -5,7 +5,6 @@
 #include "characteristicnotifier.h"
 
 class CharacteristicNotifier2AD2 : public CharacteristicNotifier {
-    bluetoothdevice *Bike;
 
   public:
     explicit CharacteristicNotifier2AD2(bluetoothdevice *Bike, QObject *parent = nullptr);

--- a/src/characteristics/characteristicnotifier2ad9.cpp
+++ b/src/characteristics/characteristicnotifier2ad9.cpp
@@ -2,7 +2,7 @@
 #include "devices/ftmsbike/ftmsbike.h"
 
 CharacteristicNotifier2AD9::CharacteristicNotifier2AD9(bluetoothdevice *Bike, QObject *parent)
-    : CharacteristicNotifier(0x2ad9, parent), Bike(Bike) {}
+    : CharacteristicNotifier(0x2ad9, Bike, parent) {}
 
 int CharacteristicNotifier2AD9::notify(QByteArray &value) {
     if(answer.length()) {

--- a/src/characteristics/characteristicnotifier2ad9.h
+++ b/src/characteristics/characteristicnotifier2ad9.h
@@ -5,7 +5,6 @@
 #include "characteristicnotifier.h"
 
 class CharacteristicNotifier2AD9 : public CharacteristicNotifier {
-    bluetoothdevice *Bike;
 
   public:    
     explicit CharacteristicNotifier2AD9(bluetoothdevice *Bike, QObject *parent = nullptr);

--- a/src/characteristics/characteristicwriteprocessor.h
+++ b/src/characteristics/characteristicwriteprocessor.h
@@ -18,6 +18,13 @@ class CharacteristicWriteProcessor : public QObject {
 
     explicit CharacteristicWriteProcessor(double bikeResistanceGain, int8_t bikeResistanceOffset,
                                           bluetoothdevice *bike, QObject *parent = nullptr);
+
+    // Rebind the control path when the DIRCON endpoint outlives the bike it was
+    // built for. May be called with nullptr; writeProcess(), changePower() and
+    // changeSlope() all dereference Bike, so callers must not drive a processor
+    // whose device is null.
+    virtual void setDevice(bluetoothdevice *bike) { Bike = bike; }
+
     virtual int writeProcess(quint16 uuid, const QByteArray &data, QByteArray &out) = 0;
     virtual void changePower(uint16_t power);
     virtual void changeSlope(int16_t iresistance, uint8_t crr, uint8_t cw);

--- a/src/characteristics/characteristicwriteprocessor0003.cpp
+++ b/src/characteristics/characteristicwriteprocessor0003.cpp
@@ -193,6 +193,10 @@ QByteArray CharacteristicWriteProcessor0003::buildCurrentHubRidingData() {
 }
 
 int CharacteristicWriteProcessor0003::writeProcess(quint16 uuid, const QByteArray &data, QByteArray &reply) {
+    if (!Bike) {
+        qDebug() << "CharacteristicWriteProcessor0003: write with no device attached, ignoring";
+        return CP_INVALID;
+    }
     static const QByteArray expectedHexArray = QByteArray::fromHex("52696465 4F6E02");
     static const QByteArray expectedHexArray2 = QByteArray::fromHex("410805");
     static const QByteArray expectedHexArray3 = QByteArray::fromHex("00088804");

--- a/src/characteristics/characteristicwriteprocessor2ad9.cpp
+++ b/src/characteristics/characteristicwriteprocessor2ad9.cpp
@@ -12,6 +12,12 @@ CharacteristicWriteProcessor2AD9::CharacteristicWriteProcessor2AD9(double bikeRe
     : CharacteristicWriteProcessor(bikeResistanceGain, bikeResistanceOffset, bike, parent), notifier(notifier) {}
 
 int CharacteristicWriteProcessor2AD9::writeProcess(quint16 uuid, const QByteArray &data, QByteArray &reply) {
+    if (!Bike) {
+        // The DIRCON endpoint outlives the bike, so a client can write while nothing
+        // is attached. Refuse rather than dereference a device that is not there.
+        qDebug() << "CharacteristicWriteProcessor2AD9: write with no device attached, ignoring";
+        return CP_INVALID;
+    }
     if (data.size()) {
         BLUETOOTH_TYPE dt = Bike->deviceType();
         QSettings settings;

--- a/src/characteristics/characteristicwriteprocessore005.cpp
+++ b/src/characteristics/characteristicwriteprocessore005.cpp
@@ -12,6 +12,10 @@ CharacteristicWriteProcessorE005::CharacteristicWriteProcessorE005(double bikeRe
     : CharacteristicWriteProcessor(bikeResistanceGain, bikeResistanceOffset, bike, parent) {}
 
 int CharacteristicWriteProcessorE005::writeProcess(quint16 uuid, const QByteArray &data, QByteArray &reply) {
+    if (!Bike) {
+        qDebug() << "CharacteristicWriteProcessorE005: write with no device attached, ignoring";
+        return CP_INVALID;
+    }
     if (data.size()) {
         BLUETOOTH_TYPE dt = Bike->deviceType();
         if (dt == BIKE) {

--- a/src/devices/dircon/dirconmanager.cpp
+++ b/src/devices/dircon/dirconmanager.cpp
@@ -204,10 +204,11 @@ DirconManager::DirconManager(bluetoothdevice *Bike, int8_t bikeResistanceOffset,
     QSettings settings;
     DirconProcessorService *service;
     QList<DirconProcessorService *> services, proc_services;
-    BLUETOOTH_TYPE dt = Bike->deviceType();
     bt = Bike;
-    uint8_t type = dt == TREADMILL || dt == ELLIPTICAL ? DM_MACHINE_TYPE_TREADMILL
-                                                                                         : DM_MACHINE_TYPE_BIKE;
+    // Bike may be null: the endpoint is built at launch, before anything is connected,
+    // so that a client which caches discovery results always finds a live port.
+    uint8_t type = machineTypeFor(Bike);
+    machineType = type;
     qDebug() << "Building Dircom Manager";
     uint16_t server_base_port =
         settings.value(QZSettings::dircon_server_base_port, QZSettings::default_dircon_server_base_port).toUInt();
@@ -249,10 +250,15 @@ DirconManager::DirconManager(bluetoothdevice *Bike, int8_t bikeResistanceOffset,
         DM_MACHINE_OP(DM_MACHINE_INIT_OP, services, proc_services, type)
     }
     
-    if (zwift_play_emulator || settings.value(QZSettings::race_mode, QZSettings::default_race_mode).toBool())
-        bikeTimer.start(50ms);
-    else
-        bikeTimer.start(1s);
+    bikeTimerInterval = (zwift_play_emulator || settings.value(QZSettings::race_mode, QZSettings::default_race_mode).toBool())
+                            ? 50
+                            : 1000;
+
+    // Only tick while something is attached. Built at launch there is no device yet,
+    // and a 50ms timer whose handler returns immediately is pure waste.
+    if (bt) {
+        bikeTimer.start(bikeTimerInterval);
+    }
 }
 
 #define DM_CHAR_NOTIF_SETDEVICE_OP(UUID, P1, P2, P3)                                                                   \
@@ -281,6 +287,14 @@ void DirconManager::setDevice(bluetoothdevice *t) {
         writePE005->setDevice(t);
     if (writeP0003)
         writeP0003->setDevice(t);
+
+    // The listener and the advertisement are untouched either way - only the data
+    // production follows the device.
+    if (!t) {
+        bikeTimer.stop();
+    } else if (!bikeTimer.isActive()) {
+        bikeTimer.start(bikeTimerInterval);
+    }
 }
 
 void DirconManager::setResistanceParameters(int8_t bikeResistanceOffset, double bikeResistanceGain) {
@@ -298,7 +312,28 @@ void DirconManager::setResistanceParameters(int8_t bikeResistanceOffset, double 
     }
 }
 
+uint8_t DirconManager::machineTypeFor(bluetoothdevice *t) {
+    // With nothing attached the profile has to be decided up front, and the endpoint
+    // exists for bikes. A treadmill or elliptical that turns up later cannot be served
+    // by rebinding: the listening port is derived from the machine type
+    // (server_base_port + DM_MACHINE_##DESC), so it needs its own endpoint.
+    if (!t) {
+        return DM_MACHINE_TYPE_BIKE;
+    }
+    const BLUETOOTH_TYPE dt = t->deviceType();
+    return dt == TREADMILL || dt == ELLIPTICAL ? DM_MACHINE_TYPE_TREADMILL : DM_MACHINE_TYPE_BIKE;
+}
+
 DirconManager *DirconManager::shared(bluetoothdevice *t, int8_t bikeResistanceOffset, double bikeResistanceGain) {
+    if (sharedDirconManager && sharedDirconManager->machineType != machineTypeFor(t)) {
+        // The advertised service set and the listening port both follow the machine
+        // type, so a device of the other kind cannot reuse this endpoint. Withdraw it
+        // properly - the destructor sends the mDNS goodbye - and build the right one.
+        qDebug() << "Shared Dircon endpoint was built for machine type" << sharedDirconManager->machineType
+                 << "but the new device needs" << machineTypeFor(t) << "- rebuilding";
+        releaseShared();
+    }
+
     if (sharedDirconManager) {
         qDebug() << "Reusing the shared Dircon manager for a new virtual device";
         sharedDirconManager->setResistanceParameters(bikeResistanceOffset, bikeResistanceGain);
@@ -315,6 +350,25 @@ DirconManager *DirconManager::shared(bluetoothdevice *t, int8_t bikeResistanceOf
 }
 
 DirconManager *DirconManager::sharedIfAny() { return sharedDirconManager; }
+
+void DirconManager::startIdleEndpoint() {
+    QSettings settings;
+    if (!settings.value(QZSettings::dircon_yes, QZSettings::default_dircon_yes).toBool()) {
+        return;
+    }
+
+    if (sharedDirconManager) {
+        return;
+    }
+
+    const int bikeResistanceOffset =
+        settings.value(QZSettings::bike_resistance_offset, QZSettings::default_bike_resistance_offset).toInt();
+    const double bikeResistanceGain =
+        settings.value(QZSettings::bike_resistance_gain_f, QZSettings::default_bike_resistance_gain_f).toDouble();
+
+    qDebug() << "Starting the Dircon endpoint at launch, with no device attached yet";
+    shared(nullptr, bikeResistanceOffset, bikeResistanceGain);
+}
 
 void DirconManager::releaseShared() {
     if (!sharedDirconManager) {

--- a/src/devices/dircon/dirconmanager.cpp
+++ b/src/devices/dircon/dirconmanager.cpp
@@ -249,6 +249,34 @@ DirconManager::DirconManager(bluetoothdevice *Bike, int8_t bikeResistanceOffset,
         bikeTimer.start(1s);
 }
 
+#define DM_CHAR_NOTIF_SETDEVICE_OP(UUID, P1, P2, P3)                                                                   \
+    if (notif##UUID)                                                                                                   \
+        notif##UUID->setDevice(P1);
+
+void DirconManager::setDevice(bluetoothdevice *t) {
+    if (bt == t)
+        return;
+
+    qDebug() << "DirconManager::setDevice rebinding from" << (void *)bt << "to" << (void *)t;
+
+    bt = t;
+
+    // Every notifier built by DM_CHAR_NOTIF_BUILD_OP holds its own copy of the
+    // pointer; the macro list is the same one used to build them, so this cannot
+    // drift out of sync with the constructor.
+    DM_CHAR_NOTIF_OP(DM_CHAR_NOTIF_SETDEVICE_OP, t, 0, 0)
+
+    // The write processors are the control path. A stale pointer here turns a
+    // client's power or resistance write into a use-after-free, not a stale
+    // reading, so they are rebound in the same pass.
+    if (writeP2AD9)
+        writeP2AD9->setDevice(t);
+    if (writePE005)
+        writePE005->setDevice(t);
+    if (writeP0003)
+        writeP0003->setDevice(t);
+}
+
 #define DM_CHAR_NOTIF_NOTIF1_OP(UUID, P1, P2, P3)                                                                      \
     QByteArray all##UUID;                                                                                              \
     int rv##UUID = notif##UUID ? notif##UUID->notify(all##UUID) : 0;

--- a/src/devices/dircon/dirconmanager.cpp
+++ b/src/devices/dircon/dirconmanager.cpp
@@ -1,8 +1,14 @@
 #include "devices/dircon/dirconmanager.h"
 #include "devices/bike.h"
+#include <QCoreApplication>
 #include <QNetworkInterface>
+#include <QPointer>
 #include <QSettings>
 #include <chrono>
+
+// The one endpoint for the process. A QPointer so that teardown of the application
+// object clears it instead of leaving a dangling pointer behind.
+static QPointer<DirconManager> sharedDirconManager;
 
 using namespace std::chrono_literals;
 
@@ -277,6 +283,49 @@ void DirconManager::setDevice(bluetoothdevice *t) {
         writeP0003->setDevice(t);
 }
 
+void DirconManager::setResistanceParameters(int8_t bikeResistanceOffset, double bikeResistanceGain) {
+    if (writeP2AD9) {
+        writeP2AD9->bikeResistanceOffset = bikeResistanceOffset;
+        writeP2AD9->bikeResistanceGain = bikeResistanceGain;
+    }
+    if (writePE005) {
+        writePE005->bikeResistanceOffset = bikeResistanceOffset;
+        writePE005->bikeResistanceGain = bikeResistanceGain;
+    }
+    if (writeP0003) {
+        writeP0003->bikeResistanceOffset = bikeResistanceOffset;
+        writeP0003->bikeResistanceGain = bikeResistanceGain;
+    }
+}
+
+DirconManager *DirconManager::shared(bluetoothdevice *t, int8_t bikeResistanceOffset, double bikeResistanceGain) {
+    if (sharedDirconManager) {
+        qDebug() << "Reusing the shared Dircon manager for a new virtual device";
+        sharedDirconManager->setResistanceParameters(bikeResistanceOffset, bikeResistanceGain);
+        sharedDirconManager->setDevice(t);
+        return sharedDirconManager;
+    }
+
+    // Parented to the application object rather than to the virtual device that
+    // happened to ask for it first: setVirtualDevice() deletes the outgoing virtual
+    // device outright, and taking the listener and the advertisement down with it is
+    // exactly the failure this refactor removes.
+    sharedDirconManager = new DirconManager(t, bikeResistanceOffset, bikeResistanceGain, QCoreApplication::instance());
+    return sharedDirconManager;
+}
+
+DirconManager *DirconManager::sharedIfAny() { return sharedDirconManager; }
+
+void DirconManager::releaseShared() {
+    if (!sharedDirconManager) {
+        return;
+    }
+
+    qDebug() << "Releasing the shared Dircon endpoint";
+    delete sharedDirconManager.data();
+    sharedDirconManager = nullptr;
+}
+
 #define DM_CHAR_NOTIF_NOTIF1_OP(UUID, P1, P2, P3)                                                                      \
     QByteArray all##UUID;                                                                                              \
     int rv##UUID = notif##UUID ? notif##UUID->notify(all##UUID) : 0;
@@ -286,6 +335,14 @@ void DirconManager::setDevice(bluetoothdevice *t) {
         P1->sendCharacteristicNotification(0x##UUID, all##UUID);
 
 void DirconManager::bikeProvider() {
+    // The manager now outlives the bike, so it can tick with nothing attached. Every
+    // CharacteristicNotifier dereferences its device, so there is nothing to send
+    // until one is bound. The listener and the advertisement stay up regardless -
+    // that is the point.
+    if (!bt) {
+        return;
+    }
+
     QSettings settings;
     bool zwift_play_emulator = settings.value(QZSettings::zwift_play_emulator, QZSettings::default_zwift_play_emulator).toBool();
 

--- a/src/devices/dircon/dirconmanager.h
+++ b/src/devices/dircon/dirconmanager.h
@@ -29,6 +29,9 @@
 class DirconManager : public QObject {
     Q_OBJECT
     QTimer bikeTimer;
+    // Milliseconds, decided at construction from zwift_play_emulator / race_mode.
+    // Kept so the timer can be stopped while idle and restarted on setDevice().
+    int bikeTimerInterval = 1000;
     CharacteristicWriteProcessor2AD9 *writeP2AD9 = 0;
     CharacteristicWriteProcessor0003 *writeP0003 = 0;
     CharacteristicWriteProcessorE005 *writePE005 = 0;
@@ -36,6 +39,9 @@ class DirconManager : public QObject {
     QList<DirconProcessor *> processors;
     static QString getMacAddress();
     bluetoothdevice* bt = 0;
+    // Which DM_MACHINE_TYPE_* this endpoint was built for. It fixes both the advertised
+    // service set and the listening port, so it cannot be changed by rebinding.
+    uint8_t machineType = 0;
 
   public:
     double currentGear();
@@ -81,6 +87,26 @@ class DirconManager : public QObject {
     static DirconManager *shared(bluetoothdevice *t, int8_t bikeResistanceOffset = 4,
                                  double bikeResistanceGain = 1.0);
     static DirconManager *sharedIfAny();
+
+    /**
+     * @brief Bring the endpoint up at launch, before any device is connected.
+     *
+     * This is the point of the whole refactor. A client that caches discovery results
+     * and does not retry a failed connect - Rouvy does both - will otherwise latch on
+     * to a record for a port nobody is listening on, and stay broken until its cache is
+     * cleared by hand. Listening from launch means a cached record is always
+     * connectable.
+     *
+     * Guarded by `dircon_yes` and idempotent. The endpoint serves the bike profile;
+     * see machineTypeFor().
+     */
+    static void startIdleEndpoint();
+
+    /**
+     * @brief The DM_MACHINE_TYPE_* an endpoint for @p t has to be built as.
+     * Returns the bike profile for a null device.
+     */
+    static uint8_t machineTypeFor(bluetoothdevice *t);
 
     /**
      * @brief Tear the shared endpoint down, freeing its ports and withdrawing its

--- a/src/devices/dircon/dirconmanager.h
+++ b/src/devices/dircon/dirconmanager.h
@@ -41,6 +41,21 @@ class DirconManager : public QObject {
     double currentGear();
     explicit DirconManager(bluetoothdevice *t, int8_t bikeResistanceOffset = 4, double bikeResistanceGain = 1.0,
                            QObject *parent = nullptr);
+
+    /**
+     * @brief Rebind every consumer of the bound device in one pass.
+     *
+     * The device pointer is copied into three places when the manager is built:
+     * `bt`, the CharacteristicNotifier chain, and the write processors. Rebinding
+     * only some of them leaves a live object dereferencing a freed device, so this
+     * is the only supported way to change it.
+     *
+     * Neither the TCP listener nor the mDNS advertisement is touched: swapping the
+     * device must stay invisible to a connected client, which is the whole point of
+     * giving the endpoint a lifetime longer than the bike's.
+     */
+    void setDevice(bluetoothdevice *t);
+    bluetoothdevice *device() const { return bt; }
   private slots:
     void bikeProvider();
   signals:

--- a/src/devices/dircon/dirconmanager.h
+++ b/src/devices/dircon/dirconmanager.h
@@ -56,6 +56,42 @@ class DirconManager : public QObject {
      */
     void setDevice(bluetoothdevice *t);
     bluetoothdevice *device() const { return bt; }
+
+    /**
+     * @brief Keep the resistance conversion in step with the device.
+     *
+     * Previously a fresh manager was built per virtual device, so these came along
+     * with the constructor. The shared manager is built once, so a later device
+     * carrying different settings has to push them in.
+     */
+    void setResistanceParameters(int8_t bikeResistanceOffset, double bikeResistanceGain);
+
+    /**
+     * @brief The process-lifetime DIRCON endpoint, created on first use.
+     *
+     * The TCP listener and the mDNS advertisement must outlive any single virtual
+     * device: destroying and rebuilding them mid-session leaves clients that cache
+     * discovery results (Rouvy) holding a record for a port nobody is listening on.
+     * The instance is parented to the application object, so no virtual device owns
+     * it and `bluetoothdevice::setVirtualDevice()` cannot take it down.
+     *
+     * Subsequent calls rebind the existing manager to @p t rather than building a
+     * second one, which would collide on the listening port.
+     */
+    static DirconManager *shared(bluetoothdevice *t, int8_t bikeResistanceOffset = 4,
+                                 double bikeResistanceGain = 1.0);
+    static DirconManager *sharedIfAny();
+
+    /**
+     * @brief Tear the shared endpoint down, freeing its ports and withdrawing its
+     * advertisement.
+     *
+     * Only for callers that need to build a DIRCON endpoint with a different service
+     * profile - today that means `virtualtreadmill`, whose machine type maps to the
+     * same base port. Destroying the manager sends the mDNS goodbye through
+     * `~ProviderPrivate()`, so clients are told before the socket disappears.
+     */
+    static void releaseShared();
   private slots:
     void bikeProvider();
   signals:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,6 +13,7 @@
 #include <QLocale>
 #include "logwriter.h"
 #include "bluetooth.h"
+#include "devices/dircon/dirconmanager.h"
 #include "devices/domyostreadmill/domyostreadmill.h"
 #include "homeform.h"
 #include "mainwindow.h"
@@ -978,6 +979,11 @@ int main(int argc, char *argv[]) {
 
         engine.load(url);
         homeform *h = new homeform(&engine, &bl);
+
+        // Bring the DIRCON endpoint up now rather than when a bike connects. A client
+        // that caches discovery results and does not retry a failed connect will
+        // otherwise hold a record for a port nobody is listening on.
+        DirconManager::startIdleEndpoint();
         QObject::connect(app.data(), &QCoreApplication::aboutToQuit, h,
                          &homeform::aboutToQuit); // NOTE: clazy-unneeded-cast
 

--- a/src/virtualdevices/virtualbike.cpp
+++ b/src/virtualdevices/virtualbike.cpp
@@ -53,7 +53,9 @@ virtualbike::virtualbike(bluetoothdevice *t, bool noWriteResistance, bool noHear
     if (existingDirconManager) {
         attachDirconManager(existingDirconManager);
     } else if (settings.value(QZSettings::dircon_yes, QZSettings::default_dircon_yes).toBool()) {
-        attachDirconManager(new DirconManager(Bike, bikeResistanceOffset, bikeResistanceGain, this));
+        // Borrowed, not owned: the endpoint has process lifetime so that a client
+        // holding a cached discovery record always finds someone listening.
+        attachDirconManager(DirconManager::shared(Bike, bikeResistanceOffset, bikeResistanceGain));
     }
     if (!settings.value(QZSettings::virtual_device_bluetooth, QZSettings::default_virtual_device_bluetooth).toBool())
         return;
@@ -774,6 +776,18 @@ virtualbike::virtualbike(bluetoothdevice *t, bool noWriteResistance, bool noHear
 virtualbike::~virtualbike() {
     bikeTimer.stop();
 
+    // The manager outlives this virtual device. If nothing detached it, there is no
+    // successor taking over, and our device is on its way out too - ~bluetoothdevice()
+    // deletes its virtual device - so drop the binding before it dangles. A bridge
+    // switch calls detachDirconManager() first, so dirconManager is already null here
+    // and the incoming virtual device keeps the endpoint bound. The device check
+    // guards the case where a successor has already rebound it to something else.
+    if (dirconManager && dirconManager->device() == Bike) {
+        qDebug() << "virtualbike: releasing the shared Dircon device binding";
+        dirconManager->setDevice(nullptr);
+    }
+    dirconManager = nullptr;
+
 #ifdef Q_OS_ANDROID
     QAndroidJniObject::callStaticMethod<void>("org/cagnulen/qdomyoszwift/BleAdvertiser", "stopAdvertising",
                                               "(Landroid/content/Context;)V",
@@ -795,7 +809,10 @@ void virtualbike::attachDirconManager(DirconManager *manager) {
     }
 
     dirconManager = manager;
-    dirconManager->setParent(this);
+    // Deliberately not re-parented. The manager is owned by the application object;
+    // adopting it here would put it back under bluetoothdevice::setVirtualDevice(),
+    // which deletes the outgoing virtual device and would take the listener and the
+    // mDNS advertisement down with it on the next bridge switch.
     connect(dirconManager, SIGNAL(changeInclination(double, double)), this,
             SIGNAL(changeInclination(double, double)));
     connect(dirconManager, SIGNAL(ftmsCharacteristicChanged(QLowEnergyCharacteristic, QByteArray)), this,
@@ -810,7 +827,9 @@ DirconManager *virtualbike::detachDirconManager() {
     }
 
     disconnect(dirconManager, nullptr, this, nullptr);
-    dirconManager->setParent(nullptr);
+    // No re-parenting to undo - see attachDirconManager(). Handing the pointer back
+    // is what stops ~virtualbike() from releasing the device binding out from under
+    // the virtual device that is about to take over.
     auto preservedDirconManager = dirconManager;
     dirconManager = nullptr;
     return preservedDirconManager;

--- a/src/virtualdevices/virtualtreadmill.cpp
+++ b/src/virtualdevices/virtualtreadmill.cpp
@@ -23,6 +23,11 @@ virtualtreadmill::virtualtreadmill(bluetoothdevice *t, bool noHeartService) {
     bool bike_cadence_sensor = settings.value(QZSettings::bike_cadence_sensor, QZSettings::default_bike_cadence_sensor).toBool();
     this->noHeartService = noHeartService;
     if (settings.value(QZSettings::dircon_yes, QZSettings::default_dircon_yes).toBool()) {
+        // Treadmills are out of scope for the DIRCON lifetime refactor and keep the
+        // old per-virtual-device ownership. A shared endpoint left over from a bike
+        // earlier in the session would still hold the same base port, so hand it back
+        // first rather than failing to listen.
+        DirconManager::releaseShared();
         dirconManager = new DirconManager(t, bikeResistanceOffset, bikeResistanceGain, this);
         connect(dirconManager, SIGNAL(changeInclination(double, double)), this,
                 SIGNAL(changeInclination(double, double)));


### PR DESCRIPTION
## Reference

Reference: https://github.com/nickolas122/qz/pull/2#issuecomment-5393890252

The DIRCON lifetime refactor, kept separate from the protocol/mDNS work as agreed.

Based directly on master, no dependencies — #4983 merged as af909053a and carried the rest
of the protocol/mDNS series in with it. Three commits, no conflicts. What remains after this
is the Android-specific work, which builds on this PR and will follow.

## The problem

QZ's DIRCON endpoint is **ephemeral**. Both the TCP listener and the mDNS advertisement are
created when a bike connects and destroyed when it goes away:

```
virtualbike::virtualbike(...)  ->  new DirconManager(Bike, ...)   // only if dircon_yes
bluetoothdevice::setVirtualDevice(...)  ->  delete the outgoing virtual device
                                        ->  and the DirconManager parented to it
```

That produces three failures, all of which look to the user like "the trainer disappeared":

1. **Before a bike is connected there is nothing listening on 36866.** A client that browses
   mDNS at its own startup finds nothing, caches that, and does not retry. Rouvy does both,
   which is why the documented workaround has been to connect the bike in QZ *first*.
2. **A bike disconnecting takes the endpoint down with it.** Reconnecting rebuilds it from
   scratch: new probe, new announcement, and any client holding the old record is pointing
   at a closed port.
3. **Switching the virtual-device bridge deletes the endpoint mid-session,** because the
   manager is parented to the virtual device that `setVirtualDevice()` destroys.

## The change

Three commits, deliberately ordered so each is reviewable on its own and the risky one is
last.

### 1. `setDevice()` — pure refactor, nothing calls it yet

The device pointer was copied into three places. They now rebind together:
`DirconManager::bt`, the ten `CharacteristicNotifier` objects, and the write processors
`2AD9`/`E005`/`0003`.

Each notifier subclass declared its own `bluetoothdevice *Bike`; that member is hoisted into
the base class. Subclass constructor signatures are unchanged, so every call site in
`virtualbike` and `virtualtreadmill` is untouched and the subclass bodies keep referring to
`Bike` — it just resolves to the inherited member now. `setDevice()` drives the notifier
chain through `DM_CHAR_NOTIF_OP`, the same macro list that builds them, so the two cannot
drift apart.

The write processors matter most: a stale pointer there turns a client's power or
resistance write into a use-after-free rather than a stale reading.

This has to land before ownership moves. A manager that outlives the bike keeps serving
whichever device it was built for, and `bluetooth::restart()` — reachable from
`selectGymModeDevice()` — deletes and rebuilds the device objects underneath it.

### 2. Process lifetime instead of the bike's

`DirconManager::shared()` owns the endpoint, parented to the application object. Created on
first use, rebound on every later call rather than built a second time, which would collide
on the listening port.

`virtualbike` borrows it: `attachDirconManager()` no longer re-parents, so
`setVirtualDevice()` deleting the outgoing virtual device no longer takes the endpoint with
it. `~virtualbike()` drops the device binding, but only when nothing detached the manager
first and it is still bound to that virtual device's own bike — the bridge switches detach
before building the successor, so they hand the endpoint over untouched.

The manager can now tick with nothing attached, so every path that dereferences the device
is guarded: `bikeProvider()` returns early, and `writeProcess()` on `2AD9`/`E005`/`0003`
refuses the write.

### 3. Up at launch

`DirconManager::startIdleEndpoint()` is called from `main.cpp` once the app is up, guarded
by `dircon_yes` and idempotent. The constructor no longer requires a device — it took the
machine type from `Bike->deviceType()`, now `machineTypeFor()`, which returns the bike
profile when nothing is attached.

**What an idle endpoint serves:** discovery, characteristic discovery and reads — the read
values in the `DM_CHAR_OP` table are static byte arrays, not device readings, so they
already work with nothing bound. It sends **no notifications** until a device attaches.
Fabricating zeroed frames would mean null-handling inside all ten
`CharacteristicNotifier::notify()` implementations, and a stream of 0 W is not obviously
better than silence — a client can latch on to it as real trainer data. This is the same
reasoning behind withholding the `0x2AD2` greeting in #4983 until the notifier has produced
a real frame; that logic is already on master, and the two agree by construction rather than
by coincidence.

The tick timer is stopped while nothing is attached and restarted by `setDevice()`, rather
than firing every 50 ms into a handler that returns immediately.

## Scope

**Bikes only.** Treadmills keep the old per-virtual-device ownership. Because both machine
types map to `WAHOO_KICKR` and the listening port is derived from the machine type
(`server_base_port + DM_MACHINE_##DESC`), a shared endpoint left over from a bike earlier in
the session would stop a treadmill from listening — so `virtualtreadmill` calls
`releaseShared()` first, which sends the mDNS goodbye through `~ProviderPrivate()` before
the socket goes.

`shared()` also checks the recorded machine type, so an elliptical arriving through
`virtualbike` gets the old endpoint withdrawn and the right one built rather than being
served a bike profile.

The design is extensible to treadmills — `shared()` already keys on machine type — but I
have no treadmill to test against, so I left it where I can verify it.

**Android:** `startIdleEndpoint()` is not platform-guarded, so the endpoint comes up early
there too. Android's mDNS needs a multicast lock held for the endpoint's lifetime, which is
exactly why that work depends on this PR and follows it; until then Android behaves as it
does today, just earlier in the run.

## Testing

Windows 11, Elite Avanti (FTMS `YPBM001264`), QZ and the training app on the same host.
Built locally from this branch, Qt 5.15.2 / mingw, clean.

### A client discovers and holds an endpoint that has never had a bike

QZ started with no bike present, so `setDevice()` never runs anywhere in this log.

```
20:50:31  startIdleEndpoint()  ->  Building Dircom Manager        (no device)
20:50:35  ProviderPrivate::publish QHostAddress("192.168.0.106")
20:50:48  tcpNewConnection from 192.168.0.106:65067
          req uuid=0000  -> uuids=[1826,1818,1816]
          req uuid=1826  -> uuids=[2acc,2ad6,2ad9,e005,2ad2,2ad3]
          req uuid=2acc  -> dat=835400000ce00000
          req uuid=2ad2 dat=01     req uuid=2a63 dat=01
          req uuid=2a5b dat=01     req uuid=2ad9 dat=01
20:55:04  tcpDisconnected
```

Rouvy walked the full service and characteristic tree, read the FTMS feature bitmask off
the static table, and subscribed to all four characteristics — against an endpoint with no
device behind it. It then **held the connection for 4 minutes 16 seconds**, 244 keepalives,
and disconnected on its own terms rather than being dropped. QZ kept running afterwards and
sent the mDNS goodbye only at quit.

**Zero notifications and no `0x2AD2` greeting were sent in that window**, which is the
intended idle behaviour: `last2AD2Notification` is empty until the notifier has run, so the
greeting added in #4983 never arms. The two changes agree by construction.

This answers the question commit 3 leaves open — at least for this client, a silent
endpoint that answers discovery is enough, and the notifier null-handling fallback is not
needed.

### A bike attaching to that idle endpoint serves a live ride

```
20:59:49  startIdleEndpoint()  ->  Building Dircom Manager        (no device)
20:59:49  Reusing the shared Dircon manager for a new virtual device
20:59:49  setDevice rebinding from 0x0 to 0x1efd06fdca0
21:00:02  tcpNewConnection from 192.168.0.106:56117
21:00:03  Sent initial notification for 0x2AD2  "64 02 00 00 00 00 01 00 00 00 00 00"
          866 x 2AD2   866 x 2A63   866 x 2A5B   over ~68 s
21:01:10  tcpDisconnected
21:01:21  sayGoodbye -> aboutToQuit
```

One `Building Dircom Manager` for the whole run: the endpoint built at launch is the one
that served the ride, rebound rather than rebuilt, with no second probe and no
re-announcement. Payloads carry real work — `64 02 a2 00 34 00 01 00 10 00 00 00` is flags
`0x0264`, cadence `0x0034` = 26 rpm, power `0x0010` = 16 W — varying across the session.

The greeting is all zeros because it fired one second after connect, before pedalling
started, and it replays the last frame the notifier actually produced. That is the point of
replaying it rather than hand-building one.

### mDNS while idle

With no bike ever attached, the provider confirms its name without a rename loop, publishes
`192.168.0.106`, and announces three times on the RFC 6762 §8.3 schedule. Two idle runs show
25 and 31 inbound query messages reaching `ProviderPrivate::onMessageReceived()` past its
`confirmed && !isResponse` gate. The goodbye fires only on quit, immediately before
`aboutToQuit()` — never on a bike going away.


## Not tested

Three gaps, named rather than left for review to find.

**The junction in a single session** — a client that subscribed *while idle*, then a bike
attaching, then data reaching that already-connected client. Both halves are measured above
but in separate runs. It is blocked on Windows rather than skipped: `bluetooth::finished()`
ends with `startDiscovery()` and is connected `#ifndef Q_OS_WIN`, so discovery here is
one-shot at launch and the bike must already be advertising before QZ starts. QZ therefore
attaches it within a second of launch, while the client needs 13-17 s to discover the
endpoint, and no ordering opens the window. I expect it to work — client subscriptions live
per-`DirconProcessor` and `setDevice()` only rebinds pointers and restarts the tick timer —
but that is reasoning, not a measurement. Trivial to confirm on a platform whose discovery
restarts.

**A bike disconnecting mid-session.** The endpoint surviving that is failure 2 in the list
above, and the runs here all ended with the bike still connected.

**The `writeProcess()` guards with no device attached.** Rouvy subscribed to `2AD9` while
idle but never wrote to it, so the three early returns added in commit 2 are verified by
inspection only.

No Apple TV, iOS device, treadmill, elliptical or rower here.
