### PR TITLE
Align Garmin IF/TSS with Normalized Power and expose FTP

### DIFF
--- a/src/qfit.cpp
+++ b/src/qfit.cpp
@@ -276,32 +276,14 @@ void qfit::save(const QString &filename, QList<SessionLine> session, BLUETOOTH_T
         qDebug() << "average speed from the fit file" << speed_avg;
     }
 
-    // Calculate training load: TSS for cycling with power, TRIMP otherwise
+    // Training load remains TRIMP-first for Garmin load/Training Effect compatibility.
+    // IF/TSS are calculated separately from Normalized Power below.
     float training_load = 0.0f;
-    float tss = 0.0f;  // Training Stress Score (for cycling with power)
+    float tss = 0.0f;
+    float intensity_factor = 0.0f;
+    float ftp = settings.value(QZSettings::ftp, QZSettings::default_ftp).toFloat();
     uint32_t duration_seconds = session.last().elapsedTime;
     bool has_tss = false;
-
-    // For cycling with power data, calculate TSS (Training Stress Score)
-    if (type == BIKE && watt_count > 0) {
-        double avg_watt = watt_sum / watt_count;
-        float ftp = settings.value(QZSettings::ftp, QZSettings::default_ftp).toFloat();
-
-        if (ftp > 0 && avg_watt > 0) {
-            // TSS formula: (duration_seconds × average_power × IF) / (FTP × 36)
-            // where IF (Intensity Factor) = average_power / FTP
-            double intensity_factor = avg_watt / ftp;
-            tss = (duration_seconds * avg_watt * intensity_factor) / (ftp * 36.0);
-            training_load = tss;  // Use TSS as training load in the worst scenario
-            has_tss = true;
-
-            qDebug() << "Training Load (TSS) calculated:" << tss
-                     << "Duration:" << (duration_seconds / 60) << "min"
-                     << "Avg Power:" << avg_watt << "W"
-                     << "FTP:" << ftp << "W"
-                     << "IF:" << intensity_factor;
-        }
-    }
 
     // Always calculate TRIMP if we have HR data (fallback or additional metric)
     if (hr_count > 0 && user_max_hr > user_resting_hr) {
@@ -358,22 +340,39 @@ void qfit::save(const QString &filename, QList<SessionLine> session, BLUETOOTH_T
         }
     }
 
-    // Normalized Power: 30-second rolling average → 4th-power mean → 4th root
+    // Normalized Power: use complete 30-s rolling windows only, then
+    // fourth-power mean and fourth root. This is the value used by IF/TSS.
     uint16_t normalized_power = 0;
     if (np_power_samples.size() >= 30) {
         std::vector<double> rolling30;
-        rolling30.reserve(np_power_samples.size());
-        for (size_t idx = 0; idx < np_power_samples.size(); idx++) {
+        rolling30.reserve(np_power_samples.size() - 29);
+        for (size_t idx = 29; idx < np_power_samples.size(); idx++) {
             double sum = 0;
-            size_t start = idx >= 29 ? idx - 29 : 0;
-            for (size_t j = start; j <= idx; j++)
+            for (size_t j = idx - 29; j <= idx; j++)
                 sum += np_power_samples[j];
-            rolling30.push_back(sum / (idx - start + 1));
+            rolling30.push_back(sum / 30.0);
         }
         double sum4 = 0;
         for (double v : rolling30)
             sum4 += std::pow(v, 4.0);
         normalized_power = (uint16_t)std::pow(sum4 / rolling30.size(), 0.25);
+    }
+
+    // TSS was originally added in January 2026 before qfit had a Normalized Power
+    // calculation, so it used average power as an approximation. NP was added later
+    // for Garmin Endurance Score support; use it now for the canonical IF/TSS formulas.
+    if (type == BIKE && ftp > 0 && normalized_power > 0) {
+        intensity_factor = normalized_power / ftp;
+        tss = (duration_seconds * normalized_power * intensity_factor) / (ftp * 36.0f);
+        has_tss = true;
+        if (training_load == 0.0f)
+            training_load = tss;
+
+        qDebug() << "TSS calculated from Normalized Power:" << tss
+                 << "Duration:" << (duration_seconds / 60) << "min"
+                 << "NP:" << normalized_power << "W"
+                 << "FTP:" << ftp << "W"
+                 << "IF:" << intensity_factor;
     }
 
     // Training Effect (aerobic + anaerobic) from HR zones and power
@@ -422,9 +421,9 @@ void qfit::save(const QString &filename, QList<SessionLine> session, BLUETOOTH_T
 
         // Anaerobic TE: from power if available, else from time in Z4+Z5
         if (watt_count > 0) {
-            float ftp = settings.value(QZSettings::ftp, QZSettings::default_ftp).toFloat();
-            if (ftp > 0) {
-                double threshold_w = ftp * 1.05;
+            float ftp_for_te = settings.value(QZSettings::ftp, QZSettings::default_ftp).toFloat();
+            if (ftp_for_te > 0) {
+                double threshold_w = ftp_for_te * 1.05;
                 double time_above = 0, intensity_above = 0;
                 for (int i = firstRealIndex; i < session.length(); i++) {
                     if (session.at(i).watt > threshold_w) {
@@ -459,9 +458,9 @@ void qfit::save(const QString &filename, QList<SessionLine> session, BLUETOOTH_T
         zonesTargetMesg.SetMaxHeartRate(user_max_hr);
         float zone3_pct = settings.value(QZSettings::heart_rate_zone3, QZSettings::default_heart_rate_zone3).toFloat();
         zonesTargetMesg.SetThresholdHeartRate((uint8_t)(zone3_pct / 100.0f * user_max_hr));
-        uint16_t ftp = (uint16_t)settings.value(QZSettings::ftp, QZSettings::default_ftp).toFloat();
-        if (ftp > 0)
-            zonesTargetMesg.SetFunctionalThresholdPower(ftp);
+        uint16_t ftp_target = (uint16_t)settings.value(QZSettings::ftp, QZSettings::default_ftp).toFloat();
+        if (ftp_target > 0)
+            zonesTargetMesg.SetFunctionalThresholdPower(ftp_target);
         zonesTargetMesg.SetHrCalcType(FIT_HR_ZONE_CALC_PERCENT_MAX_HR);
         zonesTargetMesg.SetPwrCalcType(FIT_PWR_ZONE_CALC_PERCENT_FTP);
         encode.Write(zonesTargetMesg);
@@ -568,20 +567,10 @@ void qfit::save(const QString &filename, QList<SessionLine> session, BLUETOOTH_T
     if (workoutFeel >= 0)
         sessionMesg.SetWorkoutFeel(static_cast<FIT_UINT8>(workoutFeel));
 
-    // Set training load in FIT file
-    // Always set training_load_peak (Garmin uses this for acute training load)
-    // COMMENTED OUT: Garmin Connect doesn't properly reflect these values
-    // Moving to developer data message instead
+    // Keep training_load_peak disabled: #4200/#4202 showed that Garmin Connect did
+    // not reflect this field reliably. TSS/IF/FTP below are independent cycling stats.
     if (training_load > 0) {
-        //sessionMesg.SetTrainingLoadPeak(training_load);
-        qDebug() << "Training load will be stored in developer data:" << training_load;
-    }
-
-    // For cycling with power, also set training_stress_score (TSS)
-    // COMMENTED OUT: Moving to developer data message
-    if (has_tss) {
-        //sessionMesg.SetTrainingStressScore(tss);
-        qDebug() << "TSS will be stored in developer data:" << tss;
+        qDebug() << "Training load remains calculated but training_load_peak is not written:" << training_load;
     }
 
     const FIT_SPORT treadmill_activity_sport =
@@ -677,6 +666,15 @@ void qfit::save(const QString &filename, QList<SessionLine> session, BLUETOOTH_T
             sessionMesg.SetNormalizedPower(normalized_power);
         if (total_work_joules > 0)
             sessionMesg.SetTotalWork(total_work_joules);
+    }
+    if (type == BIKE && ftp > 0) {
+        sessionMesg.SetThresholdPower((uint16_t)ftp);
+        if (has_tss) {
+            sessionMesg.SetIntensityFactor(intensity_factor);
+            sessionMesg.SetTrainingStressScore(tss);
+            qDebug() << "Writing cycling stats to FIT: FTP" << ftp
+                     << "IF" << intensity_factor << "TSS" << tss;
+        }
     }
     if (max_speed_ms > 0) {
         sessionMesg.SetEnhancedMaxSpeed((float)max_speed_ms);
@@ -1051,7 +1049,7 @@ void qfit::save(const QString &filename, QList<SessionLine> session, BLUETOOTH_T
             newRecord.SetStanceTime(sl.groundContactMS);
         }
 
-               // Add custom developer fields for temperature data
+        // Add custom developer fields for temperature data
         if (sl.coreTemp) {
             fit::DeveloperField coreTemperatureField(coreTemperatureFieldDesc, coreDevIdMesg);
             coreTemperatureField.SetFLOAT32Value((float)sl.coreTemp);
@@ -1084,8 +1082,8 @@ void qfit::save(const QString &filename, QList<SessionLine> session, BLUETOOTH_T
             newRecord.AddDeveloperField(heatStrainIndexField);
         }
 
-               // if a gps track contains a point without the gps information, it has to be discarded, otherwise the database
-               // structure is corrupted and 2 tracks are saved in the FIT file causing mapping issue.
+        // if a gps track contains a point without the gps information, it has to be discarded, otherwise the database
+        // structure is corrupted and 2 tracks are saved in the FIT file causing mapping issue.
         if (!sl.coordinate.isValid() && gps_data) {
             continue;
         }
@@ -1098,9 +1096,9 @@ void qfit::save(const QString &filename, QList<SessionLine> session, BLUETOOTH_T
             newRecord.SetAltitude(sl.elevationGain);
         }
 
-               // using just the start point as reference in order to avoid pause time
-               // strava ignore the elapsed field
-               // this workaround could leads an accuracy issue.
+        // using just the start point as reference in order to avoid pause time
+        // strava ignore the elapsed field
+        // this workaround could leads an accuracy issue.
         newRecord.SetTimestamp(date.GetTimeStamp() + i);
 
         if (sl.coreTemp > 0) {


### PR DESCRIPTION
## Summary

This PR aligns the cycling power metrics written by `qfit.cpp` with the standard Garmin/TrainingPeaks definitions so that QZ activities can be compared more directly with activities recorded by a Garmin Edge.

It:

- calculates **Intensity Factor (IF)** from **Normalized Power / FTP**;
- calculates **Training Stress Score (TSS)** from **Normalized Power**, rather than average power;
- writes the standard FIT session fields for **FTP (`threshold_power`)**, **IF (`intensity_factor`)**, and **TSS (`training_stress_score`)**;
- keeps `training_load_peak` disabled because of the previous Garmin Connect compatibility problem;
- changes the QZ Normalized Power calculation to use only complete 30-second rolling windows instead of including partial 1–29 second windows at the beginning of the activity.

## Why this change exists

This came from the mail thread **“QZ app - Endurance Score in Garmin Connect”** with Tomas Gawlowski. After the recent Endurance Score / Training Effect work started behaving well, Tomas compared Garmin Edge statistics with QZ and asked whether QZ could also expose **IF, TSS and FTP**, which would make the two sets of activity statistics directly comparable.

Looking at the current code showed that QZ already had almost all of the required pieces, but they were added at different points in time and were never connected together.

## History / how we got here

### January 15, 2026 — initial TSS/TRIMP implementation

Commit `e6cbc43e3b18d5b69dfa1efec7e478af9469de42` / PR #4159 added the first acute training-load support to FIT files.

At that time `qfit.cpp` did **not yet calculate Normalized Power**. Therefore the initial TSS implementation used average power as an approximation:

```text
IF = average_power / FTP
TSS = duration_seconds * average_power * IF / (FTP * 36)
```

That was not a later Garmin-specific tuning decision; it was simply the data available to the first implementation.

A few hours later, commit `da92d8711f1d926cabbd29c079217f673cf0fd31` separated TSS from the HR-based training load calculation. The average-power TSS formula itself was left unchanged.

### January 21–24, 2026 — Garmin Connect compatibility problem (#4200 / #4202)

PR #4200 investigated the fact that Training Load was not being reflected correctly in Garmin Connect.

PR #4202 (`e5532ca04ec66c4633b1b0aa97f7c52fa93d7d8a`) superseded it and deliberately disabled both:

```cpp
sessionMesg.SetTrainingLoadPeak(training_load);
sessionMesg.SetTrainingStressScore(tss);
```

The PR description states that those values were being written to the session but were not properly recognized by Garmin Connect. At the same time, QZ developer metadata was moved away from the session message to avoid conflicts and improve Garmin compatibility.

This is important context: TSS was **not removed because the metric was unwanted or because average-power TSS had proven more accurate**. It was removed from the native FIT session fields because of Garmin Connect interpretation problems at that time.

This PR therefore does **not** blindly revert #4202. `training_load_peak` remains disabled. Only the cycling statistics requested here are written, now with the standard/correct definitions and with the FIT/session structure that QZ uses today.

### July 20–22, 2026 — Normalized Power arrives for Endurance Score (#4169)

PR #4169 was later revived specifically because of the same **“QZ app - Endurance Score in Garmin Connect”** mail investigation.

The July commit (`993b357f827d49027ecf2ef95ef17d75b76414ee`, merged as `f544d8ba625d95d9a6562e360a9c8d68d294c894`) enriched the FIT session with the physiological and workout context Garmin needed to classify the activity:

- user max/resting HR and height;
- `zones_target`, including FTP and HR/power zone calculation types;
- aerobic and anaerobic Training Effect;
- avg/max HR and power;
- **Normalized Power**;
- total work, cadence and speed statistics.

The commit explicitly says that NP is computed from a 30-second rolling average followed by the fourth-power mean / fourth root method.

However, the old January TSS calculation was not revisited when NP was added. So QZ ended up with:

- a proper NP value written to the FIT file;
- an older TSS calculation still based on average power;
- no native IF field;
- no native threshold-power field in the session;
- the native TSS setter still disabled from the January Garmin workaround.

That is the historical mismatch this PR resolves.

### July/August 2026 — Training Effect / Endurance Score refinements

The Garmin-related path has subsequently been improved further, including accumulated/per-sample TRIMP work (for example #4847 and #4858). Those changes are HR/training-load related and are intentionally kept separate here.

This PR does **not** replace the current TRIMP logic with TSS. TRIMP remains the primary `training_load` value when HR data exists, preserving the recent Garmin Training Effect / Endurance Score behavior.

## Formula change

Old approximation:

```text
IF = average_power / FTP
TSS = duration_seconds * average_power * IF / (FTP * 36)
```

New standard calculation:

```text
IF = normalized_power / FTP
TSS = duration_seconds * normalized_power * IF / (FTP * 36)
```

This is equivalent to the usual form:

```text
TSS = duration_seconds * NP * IF / (FTP * 3600) * 100
```

## Normalized Power detail

The NP implementation added in July included the first 29 samples by calculating partial rolling windows of 1, 2, 3, ... 29 seconds before reaching a full 30-second window.

For better agreement with Edge-style NP/IF/TSS values, this PR only feeds **complete 30-s rolling windows** into the fourth-power mean.

QZ still assumes the power sample vector represents approximately one sample per second, as the existing FIT/session generation does. If we later find devices/session sources where `SessionLine` timing is not 1 Hz, NP should be made elapsed-time based as a separate improvement.

## FIT fields written

For bike activities with a valid FTP:

- `normalized_power` — already written by QZ;
- `threshold_power` — FTP;
- `intensity_factor` — NP / FTP;
- `training_stress_score` — NP-based TSS.

`training_load_peak` intentionally remains disabled because that is the field directly tied to the #4200/#4202 Garmin Connect regression.

## Validation

The main validation target is a paired QZ / Garmin Edge activity using the same power source and FTP. We should compare:

1. Normalized Power;
2. Intensity Factor;
3. TSS;
4. Garmin Connect Training Effect / Exercise Load / Endurance Score behavior after upload.

The last item is especially important because #4202 showed that Garmin Connect may interpret native session fields differently from simply displaying their raw FIT values.

## Related

- #4159 — initial TRIMP/TSS work
- #4169 — Garmin FIT session enrichment / Normalized Power / Endurance Score
- #4200 — Training Load not reflected in Garmin Connect
- #4202 — Garmin compatibility workaround; disabled native Training Load/TSS setters
- #4847 / #4858 — later Training Effect / accumulated TRIMP refinements
- User report: Tomas Gawlowski, mail thread “QZ app - Endurance Score in Garmin Connect”