### PR TITLE
Add lint for settings property ordering

### DIFF
--- a/.github/workflows/settings-property-order.yml
+++ b/.github/workflows/settings-property-order.yml
@@ -1,0 +1,31 @@
+name: Settings property order
+
+on:
+  pull_request:
+    paths:
+      - 'src/settings.qml'
+      - 'tools/check_settings_property_order.py'
+      - '.github/workflows/settings-property-order.yml'
+  workflow_dispatch:
+
+jobs:
+  check-settings-property-order:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch pull request base
+        if: github.event_name == 'pull_request'
+        run: git fetch origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
+
+      - name: Check persistent settings property order
+        if: github.event_name == 'pull_request'
+        run: python3 tools/check_settings_property_order.py "origin/${{ github.base_ref }}"
+
+      - name: Check script on manual run
+        if: github.event_name == 'workflow_dispatch'
+        run: python3 tools/check_settings_property_order.py "HEAD^"

--- a/tools/check_settings_property_order.py
+++ b/tools/check_settings_property_order.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+SETTINGS_PATH = Path("src/settings.qml")
+PROPERTY_RE = re.compile(r"^\s*property\s+\S+\s+([A-Za-z_][A-Za-z0-9_]*)\s*:")
+
+
+def read_base_file(base_ref: str) -> str:
+    try:
+        return subprocess.check_output(
+            ["git", "show", f"{base_ref}:{SETTINGS_PATH.as_posix()}"],
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(
+            f"Unable to read {SETTINGS_PATH} from base ref {base_ref}"
+        ) from exc
+
+
+def strip_strings_and_line_comments(line: str) -> str:
+    out = []
+    quote = None
+    escaped = False
+    i = 0
+
+    while i < len(line):
+        ch = line[i]
+
+        if quote is not None:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == quote:
+                quote = None
+            out.append(" ")
+            i += 1
+            continue
+
+        if ch in ('"', "'"):
+            quote = ch
+            out.append(" ")
+            i += 1
+            continue
+
+        if ch == "/" and i + 1 < len(line) and line[i + 1] == "/":
+            break
+
+        out.append(ch)
+        i += 1
+
+    return "".join(out)
+
+
+def settings_properties(text: str) -> list[str]:
+    lines = text.splitlines()
+    settings_start = None
+
+    for i, line in enumerate(lines):
+        if re.match(r"^\s*Settings\s*\{\s*$", line):
+            lookahead = "\n".join(lines[i + 1 : i + 8])
+            if re.search(r"^\s*id\s*:\s*settings\s*$", lookahead, re.MULTILINE):
+                settings_start = i
+                break
+
+    if settings_start is None:
+        raise RuntimeError("Could not find the persistent Settings { id: settings } block")
+
+    depth = 0
+    properties = []
+
+    for line in lines[settings_start:]:
+        clean = strip_strings_and_line_comments(line)
+
+        # Direct children of the Settings block are at depth 1 before this line.
+        if depth == 1:
+            match = PROPERTY_RE.match(line)
+            if match:
+                properties.append(match.group(1))
+
+        depth += clean.count("{")
+        depth -= clean.count("}")
+
+        if depth == 0 and properties:
+            break
+
+    if not properties:
+        raise RuntimeError("No persistent settings properties found")
+
+    return properties
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <base-git-ref>", file=sys.stderr)
+        return 2
+
+    base_ref = sys.argv[1]
+    current_text = SETTINGS_PATH.read_text(encoding="utf-8")
+    base_text = read_base_file(base_ref)
+
+    base_properties = settings_properties(base_text)
+    current_properties = settings_properties(current_text)
+
+    prefix = current_properties[: len(base_properties)]
+    if prefix == base_properties:
+        added = current_properties[len(base_properties) :]
+        if added:
+            print("OK: new settings properties were appended at the end:")
+            for name in added:
+                print(f"  + {name}")
+        else:
+            print("OK: persistent settings property order is unchanged")
+        return 0
+
+    mismatch = next(
+        (
+            i
+            for i, (old, new) in enumerate(zip(base_properties, prefix))
+            if old != new
+        ),
+        min(len(base_properties), len(prefix)),
+    )
+
+    expected = base_properties[mismatch] if mismatch < len(base_properties) else "<end>"
+    actual = current_properties[mismatch] if mismatch < len(current_properties) else "<missing>"
+
+    print(
+        "ERROR: persistent settings properties in src/settings.qml must never be "
+        "inserted, removed, renamed, or reordered. New properties must be appended "
+        "after all existing properties.",
+        file=sys.stderr,
+    )
+    print(
+        f"First mismatch at property #{mismatch + 1}: expected '{expected}', got '{actual}'.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except (OSError, RuntimeError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(2)


### PR DESCRIPTION
## Summary

Add a QZ-specific lint check for the persistent `Settings { id: settings }` block in `src/settings.qml`.

The check enforces the compatibility rule already documented in the file: existing persistent properties must keep their exact order, and new properties must only be appended at the end.

It rejects:
- inserting a new property in the middle
- removing an existing property
- renaming an existing property
- reordering existing properties

It accepts one or more new properties appended after all existing properties.

## CI

A dedicated GitHub Actions workflow runs the check on pull requests that modify `src/settings.qml` (or the lint itself).