### PR TITLE
Add license and profile save reminder toasts

### DIFF
--- a/src/homeform.cpp
+++ b/src/homeform.cpp
@@ -11225,9 +11225,18 @@ int homeform::preview_workout_points() {
 void homeform::licenseReply(QNetworkReply *reply) {
     QString r = reply->readAll();
     qDebug() << r;
+    static std::chrono::steady_clock::time_point lastNoAckToast;
     if (r.contains("OK")) {
         tLicense.stop();
+        lastNoAckToast = std::chrono::steady_clock::time_point{};
+        setToastRequested(tr("License ACK received"));
     } else {
+        const auto now = std::chrono::steady_clock::now();
+        if (lastNoAckToast == std::chrono::steady_clock::time_point{} ||
+            now - lastNoAckToast >= std::chrono::minutes(5)) {
+            setToastRequested(tr("License ACK not received"));
+            lastNoAckToast = now;
+        }
         licenseRequest();
     }
 }

--- a/src/main.qml
+++ b/src/main.qml
@@ -952,6 +952,12 @@ ApplicationWindow {
             font.pixelSize: Qt.application.font.pixelSize * 1.6
             onClicked: {
                 if (stackView.depth > 1) {
+                    var remindToSaveProfile = headerToolbar.settingsPageActive &&
+                            stackView.currentItem &&
+                            typeof stackView.currentItem.profileSaveReminderNeeded === "function" &&
+                            stackView.currentItem.profileSaveReminderNeeded()
+                    var activeProfileName = settings.profile_name
+
                     if(window.settings_restart_to_apply === true) {
                         window.settings_restart_to_apply = false;
                         popupRestartApp.visible = true;
@@ -961,6 +967,9 @@ ApplicationWindow {
                     toolButtonLoadSettings.visible = false;
                     toolButtonSaveSettings.visible = false;
                     rootItem.sortTiles()
+                    if (remindToSaveProfile) {
+                        toast.show(qsTr("Remember to save profile \"%1\" if you want to keep these changes.").arg(activeProfileName))
+                    }
                 } else {
                     drawer.open()
                 }

--- a/src/settings.qml
+++ b/src/settings.qml
@@ -35,6 +35,7 @@ import AndroidStatusBar 1.0
         property bool settingsSearchVisible: false
         property bool settingsSearchActive: false
         property bool settingsSearchPending: false
+        property string initialProfileSettingsSnapshot: ""
 
         function showSettingsSearch() {
             settingsSearchVisible = true
@@ -57,6 +58,26 @@ import AndroidStatusBar 1.0
             garminOptionsAccordion.isOpen = true
             scrollTimer.start()
         }
+
+        function profileSettingsSnapshot() {
+            var values = []
+            for (var key in settings) {
+                var value = settings[key]
+                if (typeof value === "boolean" || typeof value === "number" || typeof value === "string")
+                    values.push(key + "=" + String(value))
+            }
+            values.sort()
+            return values.join("\n")
+        }
+
+        function profileSaveReminderNeeded() {
+            return settings.profile_name.length > 0 &&
+                   settings.profile_name !== "default" &&
+                   initialProfileSettingsSnapshot.length > 0 &&
+                   initialProfileSettingsSnapshot !== profileSettingsSnapshot()
+        }
+
+        Component.onCompleted: initialProfileSettingsSnapshot = profileSettingsSnapshot()
 
         // Strip the RSSI proximity suffix (e.g. " (75%)") before saving device names
         function stripRssi(deviceName) {


### PR DESCRIPTION
## Summary
- show a toast when the license server ACK is received
- show a missing-ACK toast at most once every 5 minutes while keeping the existing license retry behavior
- when leaving `settings.qml`, remind the user to save the active profile only if a non-default profile is loaded and at least one setting actually changed

## Implementation notes
- the missing-ACK throttle uses `std::chrono::steady_clock` and is reset after a successful ACK
- `settings.qml` snapshots its persistent setting values when opened and compares them on exit, so the profile reminder does not depend on `settings_restart_to_apply`
- entering and leaving Settings without changes does not show the profile reminder
- the existing settings-load confirmation popup remains unchanged

## Validation
- final diff only changes `src/homeform.cpp`, `src/main.qml`, and `src/settings.qml`
- verified the existing 30-second license retry path is unchanged