### PR TITLE
docs: add categorized FAQ structure from support cases

### DIFF
--- a/docs/faq/README.md
+++ b/docs/faq/README.md
@@ -1,0 +1,21 @@
+# QZ FAQ
+
+This directory contains practical QZ frequently asked questions, organized by category and based on confirmed support solutions.
+
+## Categories
+
+- [Bike and trainer troubleshooting](bike-troubleshooting.md)
+- [Zwift and virtual gearing](zwift.md)
+
+More category files can be added when a confirmed support case does not fit an existing category.
+
+## Contribution rules
+
+Before adding a FAQ entry:
+
+1. Confirm that the support case was actually resolved or that the user explicitly confirmed the workaround worked.
+2. Search this directory and the existing [`docs/qz_faq_public.md`](../qz_faq_public.md) first. Do not add duplicate information.
+3. Prefer reusable settings, setup steps, workarounds, and usage guidance over one-off debugging details.
+4. Write the FAQ in English, regardless of the language used in the support conversation.
+5. Do not include names, email addresses, logs, or other personal information from the original support case.
+6. Add screenshots or other images only when they materially help explain the solution.

--- a/docs/faq/bike-troubleshooting.md
+++ b/docs/faq/bike-troubleshooting.md
@@ -1,0 +1,16 @@
+# Bike and trainer troubleshooting
+
+## QZ detects my Yesoul bike, but the bike metrics stay at zero. What should I try?
+
+If QZ recognizes the bike but cadence, power, speed, or other bike data are not updating while other sources such as heart rate still work:
+
+1. Open **QZ Settings > Garmin options**.
+2. Disable **ANT Bike Garmin**.
+3. Fully close and restart QZ.
+4. Reconnect the bike and start pedaling.
+
+This can restore the normal bike data stream when the Garmin ANT bike option interferes with the connection.
+
+### Why can incline still show zero?
+
+Bike resistance and incline are different values. A Yesoul bike may report resistance without reporting a real incline value. QZ's incline tile can instead be populated by an external source such as Zwift or a GPX route. A resistance-to-incline conversion requires a specific mapping and should not be assumed from the resistance percentage alone.

--- a/docs/faq/bike-troubleshooting.md
+++ b/docs/faq/bike-troubleshooting.md
@@ -1,6 +1,6 @@
 # Bike and trainer troubleshooting
 
-## QZ detects my Yesoul bike, but the bike metrics stay at zero. What should I try?
+## QZ detects my bike, but the bike metrics stay at zero. What should I try?
 
 If QZ recognizes the bike but cadence, power, speed, or other bike data are not updating while other sources such as heart rate still work:
 

--- a/docs/faq/zwift.md
+++ b/docs/faq/zwift.md
@@ -1,0 +1,13 @@
+# Zwift and virtual gearing
+
+## Zwift Click v2 disconnects or freezes about one minute after QZ connects on iOS. What should I try?
+
+When using the Zwift Click v2 handshake workaround on iOS, do not leave the official Zwift app as soon as the controllers first appear connected.
+
+1. Open the official Zwift app and pair the trainer and Zwift Click v2 controllers.
+2. Keep Zwift open for longer before closing it. Allow **at least about 3 minutes** rather than only a few seconds.
+3. Then continue with the normal QZ connection procedure.
+
+In a confirmed support case, waiting about three minutes in Zwift before continuing prevented the Click v2 controllers from freezing or disconnecting after roughly 60 seconds in QZ.
+
+An active Zwift subscription is not required for this handshake procedure; a Zwift account that can reach the pairing flow is sufficient.


### PR DESCRIPTION
## Summary

- add `docs/faq/README.md` as the category index and contribution rules
- add a Yesoul troubleshooting FAQ for bike metrics staying at zero when `ANT Bike Garmin` is enabled
- add a Zwift Click v2 on iOS FAQ for the ~60 second disconnect/freeze workaround by keeping Zwift open for about 3 minutes
- document that entries must be confirmed solutions, written in English, anonymized, and checked against both the categorized FAQ and the existing `docs/qz_faq_public.md`

## Source

Confirmed support cases resolved on 2026-08-29. Unresolved or speculative threads were intentionally excluded.

## Images

No screenshots are required for these two entries.