### PR TITLE
docs: clarify Zwift Click v2 pairing workflow

### DIFF
--- a/docs/faq/zwift.md
+++ b/docs/faq/zwift.md
@@ -4,10 +4,10 @@
 
 When using the Zwift Click v2 handshake workaround on iOS, do not leave the official Zwift app as soon as the controllers first appear connected.
 
-1. Open the official Zwift app and pair the trainer and Zwift Click v2 controllers.
+1. Open the **full official Zwift app** (not Zwift Companion) and pair the trainer and Zwift Click v2 controllers.
 2. Keep Zwift open for longer before closing it. Allow **at least about 3 minutes** rather than only a few seconds.
 3. Then continue with the normal QZ connection procedure.
 
-In a confirmed support case, waiting about three minutes in Zwift before continuing prevented the Click v2 controllers from freezing or disconnecting after roughly 60 seconds in QZ.
+In confirmed support cases, waiting about three minutes in Zwift before continuing prevented the Click v2 controllers from freezing or disconnecting after roughly 60 seconds in QZ. In a separate confirmed case, performing the pairing/unlock step in the full Zwift app worked after using Zwift Companion had not resolved the issue.
 
 An active Zwift subscription is not required for this handshake procedure; a Zwift account that can reach the pairing flow is sufficient.


### PR DESCRIPTION
## Summary

- clarify that the Zwift Click v2 handshake/unlock step must be performed in the full official Zwift app, not Zwift Companion
- keep the existing guidance to remain in Zwift for about 3 minutes before continuing with QZ
- document the distinction only because the support thread explicitly confirmed that switching from Companion to the full Zwift app resolved the issue

## Source

Confirmed QZ support case resolved on 2026-08-30. Existing `docs/faq/` and legacy FAQ guidance were checked first to avoid duplication.

## Images

No screenshots are required for this clarification.