### PR TITLE
fix(pitpat): parse S01PRO legacy telemetry

### DIFF
--- a/src/devices/pitpatbike/pitpatbike.cpp
+++ b/src/devices/pitpatbike/pitpatbike.cpp
@@ -14,6 +14,20 @@
 
 using namespace std::chrono_literals;
 
+namespace {
+uint16_t pitpatReadBE16(const QByteArray &packet, int offset) {
+    return (static_cast<uint16_t>(static_cast<uint8_t>(packet.at(offset))) << 8) |
+           static_cast<uint16_t>(static_cast<uint8_t>(packet.at(offset + 1)));
+}
+
+uint8_t pitpatXorCrc(const QByteArray &packet) {
+    uint8_t crc = 0;
+    for (int i = 1; i < packet.size() - 2; ++i)
+        crc ^= static_cast<uint8_t>(packet.at(i));
+    return crc;
+}
+} // namespace
+
 #ifdef Q_OS_IOS
 extern quint8 QZ_EnableDiscoveryCharsAndDescripttors;
 #endif
@@ -192,6 +206,71 @@ void pitpatbike::characteristicChanged(const QLowEnergyCharacteristic &character
 
     lastPacket = newValue;
 
+    // PitPat's current three-in-one protocol uses the legacy 0x6a framing.
+    // The startup frame is 34 bytes and advertises the actual bike layout.
+    if (newValue.size() >= 4 && static_cast<uint8_t>(newValue.at(0)) == 0x6a &&
+        static_cast<uint8_t>(newValue.at(3)) == 0x2c) {
+        legacyProtocol = true;
+        if (newValue.size() < 34) {
+            qDebug() << QStringLiteral("PitPat startup frame is too short") << newValue.size();
+            return;
+        }
+
+        qDebug() << QStringLiteral("PitPat startup: min resistance ") +
+                        QString::number(pitpatReadBE16(newValue, 9)) + QStringLiteral(", max resistance ") +
+                        QString::number(pitpatReadBE16(newValue, 11)) + QStringLiteral(", serial ") +
+                        QString::fromLatin1(newValue.constData() + 13, 16) + QStringLiteral(", version ") +
+                        QString::number(static_cast<uint8_t>(newValue.at(29))) + QStringLiteral(", model ") +
+                        QString::number(static_cast<uint8_t>(newValue.at(31))) +
+                        QStringLiteral(", crc ") +
+                        (pitpatXorCrc(newValue) == static_cast<uint8_t>(newValue.at(newValue.size() - 2))
+                             ? QStringLiteral("ok")
+                             : QStringLiteral("invalid"));
+        return;
+    }
+
+    if (legacyProtocol) {
+        // Legacy telemetry fields are documented by the APK's parser.
+        // Ignore commands/ACKs, but keep their raw log above.
+        if (newValue.size() < 28 || static_cast<uint8_t>(newValue.at(0)) != 0x6a ||
+            static_cast<uint8_t>(newValue.at(3)) != 0x02)
+            return;
+
+        if (pitpatXorCrc(newValue) != static_cast<uint8_t>(newValue.at(newValue.size() - 2)))
+            qDebug() << QStringLiteral("PitPat telemetry CRC mismatch") << newValue.toHex(' ');
+
+        QSettings settings;
+        const uint8_t cadence = static_cast<uint8_t>(newValue.at(25));
+        const uint16_t rawSpeed = pitpatReadBE16(newValue, 23);
+
+        Resistance = static_cast<uint8_t>(newValue.at(5));
+        m_pelotonResistance = m_pelotonResistance.value();
+        if (settings.value(QZSettings::cadence_sensor_name, QZSettings::default_cadence_sensor_name)
+                .toString()
+                .startsWith(QStringLiteral("Disabled"))) {
+            Cadence = cadence;
+        }
+
+        // Model 2 reports velocity in mm/s and distance in metres.
+        Speed = (static_cast<double>(rawSpeed) * 3.6) / 1000.0;
+        Distance = static_cast<double>(pitpatReadBE16(newValue, 10)) / 1000.0;
+        KCal = static_cast<double>(pitpatReadBE16(newValue, 12)) / 10.0;
+        Heart = static_cast<uint8_t>(newValue.at(18));
+        CrankRevs = pitpatReadBE16(newValue, 16);
+        LastCrankEventTime += cadence > 0 ? static_cast<uint16_t>(1024.0 / (static_cast<double>(cadence) / 60.0)) : 0;
+
+        // The APK has no watt field here: bytes 23/24 are velocity.
+        m_watt = 0;
+        lastRefreshCharacteristicChanged = QDateTime::currentDateTime();
+
+        qDebug() << QStringLiteral("PitPat legacy metrics: resistance ") + QString::number(Resistance.value()) +
+                        QStringLiteral(", speed ") + QString::number(Speed.value()) + QStringLiteral(", distance ") +
+                        QString::number(Distance.value()) + QStringLiteral(", cadence ") + QString::number(Cadence.value()) +
+                        QStringLiteral(", calories ") + QString::number(KCal.value()) + QStringLiteral(", heart ") +
+                        QString::number(Heart.value()) + QStringLiteral(", crank revs ") + QString::number(CrankRevs);
+        return;
+    }
+
     if (newValue.length() != 30) {
         return;
     }
@@ -282,7 +361,7 @@ QTime pitpatbike::GetElapsedFromPacket(const QByteArray &packet) {
 }
 
 double pitpatbike::GetDistanceFromPacket(const QByteArray &packet) {
-    uint16_t convertedData = (packet.at(7) << 8) | packet.at(8);
+    uint16_t convertedData = pitpatReadBE16(packet, 7);
     double data = ((double)convertedData) / 100.0f;
     return data;
 }

--- a/src/devices/pitpatbike/pitpatbike.cpp
+++ b/src/devices/pitpatbike/pitpatbike.cpp
@@ -26,6 +26,74 @@ uint8_t pitpatXorCrc(const QByteArray &packet) {
         crc ^= static_cast<uint8_t>(packet.at(i));
     return crc;
 }
+
+uint16_t pitpatEstimatedWatts(double cadence, double resistance) {
+    if (cadence <= 0.0)
+        return 0;
+
+    // The S01PRO does not expose power in its legacy telemetry. Until a
+    // device-specific curve is calibrated, reuse the default Echelon Connect
+    // Sport 1-32 resistance table. Both bikes expose the same 32 resistance
+    // levels, making this a useful provisional estimate for virtual cycling apps.
+    static const double wattTable[33][11] = {
+        {0.0, 1.0, 2.2, 4.8, 9.5, 13.6, 16.7, 22.6, 26.3, 29.2, 47.0},
+        {0.0, 1.0, 2.2, 4.8, 9.5, 13.6, 16.7, 22.6, 26.3, 29.2, 47.0},
+        {0.0, 1.3, 3.0, 5.4, 10.4, 14.5, 18.5, 24.6, 27.6, 33.5, 49.5},
+        {0.0, 1.5, 3.7, 6.7, 11.7, 15.9, 19.6, 26.1, 30.8, 35.2, 51.2},
+        {0.0, 1.6, 4.7, 7.5, 13.7, 17.6, 22.6, 29.0, 36.9, 42.6, 57.2},
+        {0.0, 1.8, 5.2, 8.0, 14.8, 19.1, 23.5, 32.5, 37.5, 50.8, 61.8},
+        {0.0, 1.9, 5.7, 8.7, 15.6, 20.2, 25.5, 33.5, 39.6, 52.1, 65.3},
+        {0.0, 2.0, 6.2, 9.5, 16.8, 21.8, 28.1, 37.0, 42.8, 57.8, 68.4},
+        {0.0, 2.1, 6.8, 10.8, 18.2, 23.6, 29.5, 40.0, 47.6, 60.5, 72.1},
+        {0.0, 2.2, 7.3, 11.5, 19.3, 26.3, 33.5, 45.3, 51.8, 66.7, 76.8},
+        {0.0, 2.4, 7.9, 12.7, 20.8, 29.8, 37.6, 52.2, 56.2, 73.5, 83.6},
+        {0.0, 2.6, 8.5, 13.5, 23.5, 33.6, 41.9, 55.1, 59.0, 78.6, 89.7},
+        {0.0, 2.7, 9.1, 14.2, 25.6, 35.4, 45.3, 57.3, 62.8, 81.3, 95.0},
+        {0.0, 2.9, 9.6, 16.8, 29.1, 37.5, 49.6, 62.5, 69.0, 84.7, 99.3},
+        {0.0, 3.0, 10.0, 22.3, 31.2, 40.3, 51.8, 65.0, 70.0, 92.6, 108.2},
+        {0.0, 3.2, 10.4, 24.0, 36.6, 42.5, 56.3, 74.0, 85.0, 98.2, 123.5},
+        {0.0, 3.5, 10.9, 25.1, 38.5, 47.6, 65.4, 83.0, 93.0, 114.8, 136.8},
+        {0.0, 3.7, 11.5, 26.0, 41.0, 53.2, 71.6, 90.0, 100.0, 121.7, 149.2},
+        {0.0, 4.0, 12.1, 27.5, 43.6, 56.0, 82.3, 101.0, 113.6, 143.0, 162.8},
+        {0.0, 4.2, 12.7, 29.7, 46.7, 64.2, 87.9, 109.2, 128.9, 154.0, 172.3},
+        {0.0, 4.5, 13.7, 32.0, 50.0, 71.8, 95.6, 113.8, 135.6, 165.0, 185.0},
+        {0.0, 4.7, 14.9, 34.5, 54.2, 77.0, 100.7, 127.0, 147.6, 180.0, 200.0},
+        {0.0, 5.0, 15.8, 36.5, 58.3, 83.4, 110.1, 136.0, 168.1, 196.0, 213.5},
+        {0.0, 5.6, 17.0, 39.5, 64.3, 88.8, 123.4, 154.0, 182.0, 210.0, 235.0},
+        {0.0, 6.1, 18.2, 44.0, 70.7, 99.9, 133.3, 166.0, 198.0, 230.0, 253.5},
+        {0.0, 6.8, 19.4, 49.0, 79.0, 108.8, 147.2, 185.0, 217.0, 255.2, 278.0},
+        {0.0, 7.6, 22.0, 54.8, 88.0, 127.0, 167.0, 212.0, 244.0, 287.0, 305.0},
+        {0.0, 8.7, 26.0, 62.0, 100.0, 145.0, 190.0, 242.0, 281.0, 315.1, 350.0},
+        {0.0, 9.2, 30.0, 71.0, 114.4, 161.6, 215.1, 275.1, 317.0, 358.5, 390.0},
+        {0.0, 9.8, 36.0, 82.5, 134.5, 195.3, 252.5, 313.7, 360.0, 420.3, 460.0},
+        {0.0, 10.5, 43.0, 95.0, 157.1, 228.4, 300.1, 374.1, 403.8, 487.8, 540.0},
+        {0.0, 12.5, 48.0, 99.3, 162.2, 232.9, 310.4, 400.3, 435.5, 530.5, 589.0},
+        {0.0, 13.0, 53.0, 102.0, 170.3, 242.0, 320.0, 427.9, 475.2, 570.0, 625.0}};
+
+    int level = static_cast<int>(resistance + 0.5);
+    if (level < 1)
+        level = 1;
+    else if (level > 32)
+        level = 32;
+
+    const double *wattsOfLevel = wattTable[level];
+    int wattStep = static_cast<int>(cadence / 10.0);
+    double watts = 0.0;
+    if (wattStep >= 10) {
+        watts = (cadence / 100.0) * wattsOfLevel[10];
+    } else {
+        const double wattBase = wattsOfLevel[wattStep];
+        watts = (((wattsOfLevel[wattStep + 1] - wattBase) / 10.0) *
+                 static_cast<int>(cadence) % 10) +
+                wattBase;
+    }
+
+    if (watts <= 0.0)
+        return 0;
+    if (watts >= 65535.0)
+        return 65535;
+    return static_cast<uint16_t>(watts + 0.5);
+}
 } // namespace
 
 #ifdef Q_OS_IOS
@@ -284,15 +352,21 @@ void pitpatbike::characteristicChanged(const QLowEnergyCharacteristic &character
         CrankRevs = pitpatReadBE16(newValue, 16);
         LastCrankEventTime += cadence > 0 ? static_cast<uint16_t>(1024.0 / (static_cast<double>(cadence) / 60.0)) : 0;
 
-        // The APK has no watt field here: bytes 23/24 are velocity.
-        m_watt = 0;
+        // The S01PRO does not report watts. Use the Echelon Connect Sport 1-32
+        // table as a provisional estimate until a PitPat-specific curve is calibrated.
+        if (settings.value(QZSettings::power_sensor_name, QZSettings::default_power_sensor_name)
+                .toString()
+                .startsWith(QStringLiteral("Disabled"))) {
+            m_watt = pitpatEstimatedWatts(Cadence.value(), Resistance.value());
+        }
         lastRefreshCharacteristicChanged = QDateTime::currentDateTime();
 
         qDebug() << QStringLiteral("PitPat legacy metrics: resistance ") + QString::number(Resistance.value()) +
                         QStringLiteral(", speed ") + QString::number(Speed.value()) + QStringLiteral(", distance ") +
                         QString::number(Distance.value()) + QStringLiteral(", cadence ") + QString::number(Cadence.value()) +
-                        QStringLiteral(", calories ") + QString::number(KCal.value()) + QStringLiteral(", heart ") +
-                        QString::number(Heart.value()) + QStringLiteral(", crank revs ") + QString::number(CrankRevs);
+                        QStringLiteral(", watts ") + QString::number(watts()) + QStringLiteral(", calories ") +
+                        QString::number(KCal.value()) + QStringLiteral(", heart ") + QString::number(Heart.value()) +
+                        QStringLiteral(", crank revs ") + QString::number(CrankRevs);
         return;
     }
 

--- a/src/devices/pitpatbike/pitpatbike.cpp
+++ b/src/devices/pitpatbike/pitpatbike.cpp
@@ -84,7 +84,7 @@ uint16_t pitpatEstimatedWatts(double cadence, double resistance) {
     } else {
         const double wattBase = wattsOfLevel[wattStep];
         watts = (((wattsOfLevel[wattStep + 1] - wattBase) / 10.0) *
-                 static_cast<int>(cadence) % 10) +
+                 (static_cast<int>(cadence) % 10)) +
                 wattBase;
     }
 
@@ -236,7 +236,7 @@ void pitpatbike::update() {
 }
 
 void pitpatbike::serviceDiscovered(const QBluetoothUuid &gatt) {
-    qDebug() << QStringLiteral("serviceDiscovered ") + gatt.toString();
+    qDebug() << QStringLiteral("serviceDiscovered ") + gatt.toString());
 }
 
 resistance_t pitpatbike::pelotonToBikeResistance(int pelotonResistance) {

--- a/src/devices/pitpatbike/pitpatbike.cpp
+++ b/src/devices/pitpatbike/pitpatbike.cpp
@@ -251,8 +251,8 @@ void pitpatbike::characteristicChanged(const QLowEnergyCharacteristic &character
             Cadence = cadence;
         }
 
-        // Model 2 reports velocity in mm/s and distance in metres.
-        Speed = (static_cast<double>(rawSpeed) * 3.6) / 1000.0;
+        // Model 2 reports velocity in mm/s; QZ speed is expressed in km/h.
+        Speed = static_cast<double>(rawSpeed) / 1000.0;
         Distance = static_cast<double>(pitpatReadBE16(newValue, 10)) / 1000.0;
         KCal = static_cast<double>(pitpatReadBE16(newValue, 12)) / 10.0;
         Heart = static_cast<uint8_t>(newValue.at(18));

--- a/src/devices/pitpatbike/pitpatbike.cpp
+++ b/src/devices/pitpatbike/pitpatbike.cpp
@@ -226,15 +226,40 @@ void pitpatbike::characteristicChanged(const QLowEnergyCharacteristic &character
                         (pitpatXorCrc(newValue) == static_cast<uint8_t>(newValue.at(newValue.size() - 2))
                              ? QStringLiteral("ok")
                              : QStringLiteral("invalid"));
+
+        // The official PitPat app answers the 0x2c startup frame before it starts
+        // polling or sending resistance commands. Until this handshake is ACKed,
+        // the S01PRO remains in its startup/scan state.
+        if (!initDone) {
+            uint8_t legacyHandshake[] = {0x6a, 0x05, 0x50, 0x1b, 0x01, 0x4f, 0x43};
+            writeCharacteristic(legacyHandshake, sizeof(legacyHandshake), QStringLiteral("legacy handshake"), false,
+                                false);
+        }
+        return;
+    }
+
+    // ACK observed in the official app immediately after the legacy handshake.
+    if (legacyProtocol && newValue == QByteArray::fromHex("6a06b01b0100ac43")) {
+        qDebug() << QStringLiteral("PitPat legacy handshake acknowledged");
+        initDone = true;
+        sec1Update = 0;
         return;
     }
 
     if (legacyProtocol) {
-        // Legacy telemetry fields are documented by the APK's parser.
-        // Ignore commands/ACKs, but keep their raw log above.
+        // Legacy telemetry fields are documented by the APK's parser and were
+        // confirmed against a live HCI snoop from the official PitPat app.
         if (newValue.size() < 28 || static_cast<uint8_t>(newValue.at(0)) != 0x6a ||
             static_cast<uint8_t>(newValue.at(3)) != 0x02)
             return;
+
+        // If the ACK notification was lost but telemetry has already started,
+        // the bike necessarily accepted the handshake, so it is safe to proceed.
+        if (!initDone) {
+            qDebug() << QStringLiteral("PitPat legacy telemetry received; handshake accepted");
+            initDone = true;
+            sec1Update = 0;
+        }
 
         if (pitpatXorCrc(newValue) != static_cast<uint8_t>(newValue.at(newValue.size() - 2)))
             qDebug() << QStringLiteral("PitPat telemetry CRC mismatch") << newValue.toHex(' ');
@@ -367,7 +392,20 @@ double pitpatbike::GetDistanceFromPacket(const QByteArray &packet) {
 }
 
 void pitpatbike::btinit() {
-    initDone = true;
+    // Give the S01PRO a short window to advertise its 0x2c startup frame before
+    // enabling the normal poll/control loop. Existing PitPat devices that do not
+    // use this startup handshake continue on the old path after the timeout.
+    if (legacyProtocol && initDone)
+        return;
+
+    initDone = false;
+    sec1Update = 0;
+    QTimer::singleShot(1500ms, this, [this]() {
+        if (!legacyProtocol && m_control && m_control->state() != QLowEnergyController::UnconnectedState) {
+            qDebug() << QStringLiteral("PitPat legacy startup frame not seen; enabling existing protocol path");
+            initDone = true;
+        }
+    });
 }
 
 void pitpatbike::stateChanged(QLowEnergyService::ServiceState state) {
@@ -548,6 +586,8 @@ void pitpatbike::controllerStateChanged(QLowEnergyController::ControllerState st
         lastResistanceBeforeDisconnection = Resistance.value();
         qDebug() << QStringLiteral("trying to connect back again...");
         initDone = false;
+        legacyProtocol = false;
+        sec1Update = 0;
         m_control->connectToDevice();
     }
 }

--- a/src/devices/pitpatbike/pitpatbike.cpp
+++ b/src/devices/pitpatbike/pitpatbike.cpp
@@ -236,7 +236,7 @@ void pitpatbike::update() {
 }
 
 void pitpatbike::serviceDiscovered(const QBluetoothUuid &gatt) {
-    qDebug() << QStringLiteral("serviceDiscovered ") + gatt.toString());
+    qDebug() << QStringLiteral("serviceDiscovered ") + gatt.toString();
 }
 
 resistance_t pitpatbike::pelotonToBikeResistance(int pelotonResistance) {

--- a/src/devices/pitpatbike/pitpatbike.h
+++ b/src/devices/pitpatbike/pitpatbike.h
@@ -72,6 +72,7 @@ class pitpatbike : public bike {
 
     bool initDone = false;
     bool initRequest = false;
+    bool legacyProtocol = false;
 
     bool noWriteResistance = false;
     bool noHeartService = false;


### PR DESCRIPTION
## Reference

Reference material used for this PR:

- QZ debug log `debug-Mon_Aug_31_18_39_51_2026.log`;
- PitPat Android app 4.21.01 (`com.linzi.sport`), inspected to recover the legacy/three-in-one parser and control commands;
- live Android Bluetooth HCI snoop captured on 2026-09-03 while the official PitPat app was connected to the same `PitPat-S01PRO` bike;
- follow-up live QZ tests confirming speed, cadence and resistance control;
- user calibration measurements collected on 2026-09-14 at several resistance levels.

## Summary

- Adds support for the current `PitPat-S01PRO` legacy/three-in-one telemetry frame.
- Adds the startup handshake used by the official PitPat app before polling or sending resistance commands.
- Keeps the existing 30-byte PitPat parser unchanged for already-supported devices.
- Confirms the resistance command and telemetry mapping against a live HCI capture.
- Adds a provisional S01PRO-specific watt estimate based on cadence and resistance.

## Device / GATT

- Device: `PitPat-S01PRO` (`7C:FE:62:9D:BA:98`).
- Service: `0000FBB0-0000-1000-8000-00805F9B34FB`.
- Write characteristic: `FBB1`.
- Notification characteristic: `FBB2`.

## Startup frame

The bike repeatedly advertises this 34-byte startup frame while it is still in its startup/scan state:

```text
6a 20 b0 2c 1a 00 01 02 03 00 01 00 20
74 38 43 39 31 39 66 4b 6d 64 68 71 7a 36 37 36
20 00 02 eb 43
```

The frame has a valid XOR CRC (`eb`). Fields recovered from the PitPat APK parser are:

- minimum resistance: bytes `9..10`, big-endian;
- maximum resistance: bytes `11..12`, big-endian;
- serial: bytes `13..28`;
- firmware version: byte `29`;
- unit: byte `30`;
- model: byte `31`.

For this bike the startup frame reports `min=1`, `max=32`, model `2`.

## Required startup handshake

Before the official PitPat app starts normal polling or sends resistance commands, it answers the `0x2c` startup frame with:

```text
app -> bike
6a 05 50 1b 01 4f 43
```

The bike acknowledges it with:

```text
bike -> app
6a 06 b0 1b 01 00 ac 43
```

Only after this exchange does the bike leave its startup/scan state and begin normal telemetry:

```text
6a 1c b0 02 ...
```

The implementation now waits for this startup path, sends the handshake, accepts the ACK or first valid telemetry frame as confirmation, resets detection on reconnect, and falls back to the existing PitPat behavior when the legacy frame is not seen.

## Telemetry mapping confirmed by HCI snoop

The live capture contains 555 changing telemetry frames from the official PitPat app session. The mapping is:

- resistance: byte `5`;
- elapsed/activity time: bytes `8..9`;
- distance: bytes `10..11`, divided by `1000` for km;
- calories: bytes `12..13`, divided by `10`;
- crank revolutions: bytes `16..17`;
- heart rate: byte `18`;
- velocity: bytes `23..24`, divided by `1000` for km/h;
- cadence: byte `25`;
- run ID / connection status: bytes `26` / `27`.

Bytes `23..24` are not watts. No native watt field has been identified in the S01PRO legacy frame.

## Provisional power estimate

Direct connection to MyWhoosh showed a cadence-only value of approximately `cadence * 4`, unchanged by resistance. The user confirmed this behavior at resistance levels 1, 2, 20, 28 and 32. Because that value is not physically meaningful, QZ intentionally does not reproduce it directly.

For live testing we agreed to make power depend on both cadence and resistance, with a linear resistance scale across all 32 levels:

```text
resistanceScale = 0.10 + 0.90 * ((resistance - 1) / 31)
watts = cadence * 4 * resistanceScale
```

Examples at 100 RPM:

- resistance 1: about 40 W;
- resistance 32: about 400 W;
- intermediate resistance levels are linearly interpolated.

This keeps the maximum-resistance result aligned with the observed MyWhoosh value while avoiding the unrealistic case where resistance 1 and resistance 32 produce the same watts.

The estimate is used only on the legacy S01PRO path and only when no external power sensor is configured. An external power sensor still takes precedence.

## Resistance control confirmed by HCI snoop

The existing QZ command matches the official PitPat app:

```text
6a 06 51 82 01 <level> <crc> 43
```

`<level>` is clamped to `1..32`. The HCI capture contains 56 resistance changes and all received an ACK, with subsequent telemetry confirming the requested level.

## Compatibility

- The legacy path is selected only when the `0x6a ... 0x2c` startup frame is observed.
- Existing devices that do not emit this frame continue through the existing parser after the short detection window.
- Existing PitPat detection (`PITPAT-S`) and GATT UUIDs are unchanged.
- The provisional power estimate is restricted to the legacy path.
- External power sensors still override the estimated value.

## Validation

Confirmed so far:

- startup handshake request/ACK;
- telemetry starts after the handshake;
- resistance command confirmed against the official app;
- resistance byte mapping confirmed;
- speed, distance and cadence mapping confirmed;
- bytes `23..24` confirmed as velocity rather than watts;
- live QZ test reports working speed, cadence and resistance;
- user confirmed that direct MyWhoosh power is cadence-only and does not react to resistance.

## Remaining live-device validation

A new QZ build should now be tested on the S01PRO to confirm that:

1. MyWhoosh receives non-zero power and the rider moves;
2. watts increase with both cadence and resistance;
3. around 100 RPM the estimate is roughly 40 W at resistance 1 and 400 W at resistance 32;
4. auto resistance still works correctly;
5. no `ServiceError` appears during sustained use;
6. the curve feels plausible enough for use, or can be refined from further measurements or a real power meter.