### PR TITLE
docs: add Peloton login browser workaround

### DIFF
--- a/docs/faq/README.md
+++ b/docs/faq/README.md
@@ -5,6 +5,7 @@ This directory contains practical QZ frequently asked questions, organized by ca
 ## Categories
 
 - [Bike and trainer troubleshooting](bike-troubleshooting.md)
+- [Integrations and authentication](integrations.md)
 - [Zwift and virtual gearing](zwift.md)
 
 More category files can be added when a confirmed support case does not fit an existing category.

--- a/docs/faq/integrations.md
+++ b/docs/faq/integrations.md
@@ -1,0 +1,15 @@
+# Integrations and authentication
+
+## Peloton login from QZ stays on a spinning screen on an Echelon console. What should I try?
+
+On some Echelon consoles, the built-in **Lightning** browser may no longer complete the Peloton authentication flow correctly. QZ can appear to remain on the spinning login screen even though the problem is actually the browser on the console.
+
+If this happens:
+
+1. Sideload a modern browser such as **Google Chrome** onto the Echelon console.
+2. Set Chrome as the default browser.
+3. Retry the Peloton login from QZ.
+
+In a confirmed support case, replacing the built-in Lightning browser with Chrome immediately allowed the Peloton authentication flow to complete normally.
+
+If changing the browser does not help, try opening the Peloton website directly in the console browser. If it also fails there, the issue is likely outside QZ itself.


### PR DESCRIPTION
## Summary

- add an `Integrations and authentication` FAQ category
- document a confirmed Echelon console workaround for Peloton authentication getting stuck on the spinning screen
- explain that the built-in Lightning browser can be the cause and that sideloading Chrome and setting it as the default browser resolved the issue
- include a quick isolation check using the Peloton website directly in the console browser

## Source

Confirmed QZ support case resolved on 2026-08-31. The guidance was checked against `docs/faq/` and `docs/qz_faq_public.md` and no duplicate entry was found.

## Images

No screenshots are required for this entry.