### PR TITLE
docs: add Garmin ANT+ and Connect FAQ

### DIFF
--- a/docs/faq/README.md
+++ b/docs/faq/README.md
@@ -1,6 +1,6 @@
 # QZ FAQ
 
-This directory contains practical QZ frequently asked questions, organized by category and based on confirmed support solutions.
+This directory contains practical QZ frequently asked questions, organized by category and based on confirmed support solutions or verified reusable capability/setup guidance.
 
 ## Categories
 
@@ -8,15 +8,15 @@ This directory contains practical QZ frequently asked questions, organized by ca
 - [Integrations and authentication](integrations.md)
 - [Zwift and virtual gearing](zwift.md)
 
-More category files can be added when a confirmed support case does not fit an existing category.
+More category files can be added when a reusable support case or capability question does not fit an existing category.
 
 ## Contribution rules
 
 Before adding a FAQ entry:
 
-1. Confirm that the support case was actually resolved or that the user explicitly confirmed the workaround worked.
+1. For troubleshooting/workaround entries, confirm that the support case was actually resolved or that the user explicitly confirmed the workaround worked. For general capability/setup questions, verify the answer against the current QZ code or existing documentation even if no success confirmation is required.
 2. Search this directory and the existing [`docs/qz_faq_public.md`](../qz_faq_public.md) first. Do not add duplicate information.
-3. Prefer reusable settings, setup steps, workarounds, and usage guidance over one-off debugging details.
+3. Prefer reusable settings, setup steps, workarounds, capabilities, and usage guidance over one-off debugging details.
 4. Write the FAQ in English, regardless of the language used in the support conversation.
 5. Do not include names, email addresses, logs, or other personal information from the original support case.
 6. Add screenshots or other images only when they materially help explain the solution.

--- a/docs/faq/integrations.md
+++ b/docs/faq/integrations.md
@@ -16,7 +16,7 @@ The Android device running QZ must be able to **transmit ANT+**. If the phone or
 
 If you do not need the Garmin watch to receive the treadmill data live, QZ can record the workout itself and upload the generated **FIT activity** to Garmin Connect.
 
-In this setup the watch does not need to be paired to QZ as an ANT+ sensor. Configure the Garmin Connect integration in QZ and use QZ to record the session; the completed activity can then be pushed to Garmin Connect.
+In this setup the watch does not need to be paired to QZ as an ANT+ sensor. Configure the Garmin Connect integration in QZ and use QZ to record the session; the completed activity will be pushed automatically to Garmin Connect and it will count as training effect and Vo2Max.
 
 Choose **ANT+ SDM/footpod** when you want the watch itself to see and record the treadmill speed/distance during the workout. Choose **Garmin Connect FIT upload** when your main goal is simply to have the finished activity and its metrics in Garmin Connect.
 

--- a/docs/faq/integrations.md
+++ b/docs/faq/integrations.md
@@ -1,5 +1,25 @@
 # Integrations and authentication
 
+## Can I use QZ to get treadmill data into Garmin without Zwift or another training app?
+
+Yes. There are two different approaches depending on whether you want the Garmin watch to receive the treadmill metrics live or you only want the completed activity in Garmin Connect.
+
+### Option 1: send speed and distance live to a Garmin watch over ANT+
+
+On Android, QZ can connect to a supported treadmill over Bluetooth/FTMS and retransmit treadmill speed and distance using the **ANT+ SDM/footpod profile**.
+
+Your Garmin watch can then pair with QZ as a footpod or speed/distance sensor and record the treadmill activity directly. Zwift, Kinomap, and similar training apps are not required for this setup.
+
+The Android device running QZ must be able to **transmit ANT+**. If the phone or tablet does not have usable native ANT+ support, a compatible USB ANT+ dongle with the appropriate USB/OTG adapter can be used. Make sure the dongle supports transmission, not only reception.
+
+### Option 2: upload the completed QZ workout to Garmin Connect
+
+If you do not need the Garmin watch to receive the treadmill data live, QZ can record the workout itself and upload the generated **FIT activity** to Garmin Connect.
+
+In this setup the watch does not need to be paired to QZ as an ANT+ sensor. Configure the Garmin Connect integration in QZ and use QZ to record the session; the completed activity can then be pushed to Garmin Connect.
+
+Choose **ANT+ SDM/footpod** when you want the watch itself to see and record the treadmill speed/distance during the workout. Choose **Garmin Connect FIT upload** when your main goal is simply to have the finished activity and its metrics in Garmin Connect.
+
 ## Peloton login from QZ stays on a spinning screen on an Echelon console. What should I try?
 
 On some Echelon consoles, the built-in **Lightning** browser may no longer complete the Peloton authentication flow correctly. QZ can appear to remain on the spinning login screen even though the problem is actually the browser on the console.


### PR DESCRIPTION
## Summary

- add a Garmin integration FAQ explaining the two QZ workflows for treadmill users
- document live speed/distance retransmission to a Garmin watch over ANT+ SDM/footpod
- document the alternative of recording in QZ and uploading the completed FIT activity to Garmin Connect
- clarify that Android ANT+ hardware/dongles must support transmission for the live-watch workflow
- relax the FAQ contribution rule so verified capability/setup questions can be documented without requiring a customer success reply

## Source

Reusable support question from 2026-08-31. Unlike a troubleshooting workaround, this is a capability/setup FAQ, so the answer was verified against the current QZ implementation before documenting it.

## Duplication check

The legacy `docs/qz_faq_public.md` contains general Garmin integration guidance, but it does not explain the distinction between live ANT+ SDM/footpod broadcasting to the watch and post-workout FIT upload to Garmin Connect.

## Images

No screenshots are required for this entry.