### PR TITLE
Route TOORX iConsole ellipticals to AppGate elliptical

### DIFF
--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -1219,7 +1219,8 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 }
                 this->signalBluetoothDeviceConnected(trxappgateusbRower);
             } else if (((b.name().toUpper().startsWith(QStringLiteral("FAL-SPORTS")) && !toorx_bike) ||
-                       (b.name().toUpper().startsWith(QStringLiteral("I-CONSOLE+")) && iconsole_elliptical)) &&
+                       ((b.name().toUpper().startsWith(QStringLiteral("I-CONSOLE+")) ||
+                         b.name().toUpper().startsWith(QStringLiteral("TOORX"))) && iconsole_elliptical)) &&
                        !trxappgateusbElliptical && ftms_bike.contains(QZSettings::default_ftms_bike) && ftms_elliptical.contains(QZSettings::default_ftms_elliptical) && filter) {
                 this->setLastBluetoothDevice(b);
                 this->stopDiscovery();

--- a/src/devices/trxappgateusbelliptical/trxappgateusbelliptical.cpp
+++ b/src/devices/trxappgateusbelliptical/trxappgateusbelliptical.cpp
@@ -162,7 +162,12 @@ void trxappgateusbelliptical::serviceDiscovered(const QBluetoothUuid &gatt) {
 
 double trxappgateusbelliptical::GetSpeedFromPacket(const QByteArray &packet) {
 
-    if (elliptical_type == TYPE::JTX_FITNESS) {
+    if (bluetoothDevice.name().compare(QStringLiteral("TOORX0095"), Qt::CaseInsensitive) == 0) {
+        QSettings settings;
+        double cadence_speed_ratio = settings.value(QZSettings::cadence_sensor_speed_ratio,
+                                                    QZSettings::default_cadence_sensor_speed_ratio).toDouble();
+        return toorx0095SpeedFromCadence(toorx0095CadenceFromPacket(packet), cadence_speed_ratio);
+    } else if (elliptical_type == TYPE::JTX_FITNESS) {
         // JTX Fitness doesn't send speed via bluetooth, calculate from cadence using settings ratio
         QSettings settings;
         double cadence_speed_ratio = settings.value(QZSettings::cadence_sensor_speed_ratio, QZSettings::default_cadence_sensor_speed_ratio).toDouble();
@@ -178,13 +183,23 @@ double trxappgateusbelliptical::GetSpeedFromPacket(const QByteArray &packet) {
 double trxappgateusbelliptical::GetCadenceFromPacket(const QByteArray &packet) {
 
     uint16_t convertedData;
-    if (elliptical_type == TYPE::JTX_FITNESS) {
+    if (bluetoothDevice.name().compare(QStringLiteral("TOORX0095"), Qt::CaseInsensitive) == 0) {
+        return toorx0095CadenceFromPacket(packet);
+    } else if (elliptical_type == TYPE::JTX_FITNESS) {
         // JTX Fitness uses only byte 5 for cadence
         convertedData = packet.at(5);
     } else {
         convertedData = ((uint16_t)packet.at(9)) + ((uint16_t)packet.at(8) * 100);
     }
     return convertedData;
+}
+
+double trxappgateusbelliptical::toorx0095CadenceFromPacket(const QByteArray &packet) {
+    return static_cast<uint8_t>(packet.at(5));
+}
+
+double trxappgateusbelliptical::toorx0095SpeedFromCadence(double cadence, double ratio) {
+    return cadence * ratio;
 }
 
 double trxappgateusbelliptical::GetWattFromPacket(const QByteArray &packet) {

--- a/src/devices/trxappgateusbelliptical/trxappgateusbelliptical.cpp
+++ b/src/devices/trxappgateusbelliptical/trxappgateusbelliptical.cpp
@@ -314,6 +314,8 @@ void trxappgateusbelliptical::btinit() {
         writeCharacteristic((uint8_t *)initData2, sizeof(initData2), QStringLiteral("init"), false, true);
         writeCharacteristic((uint8_t *)initData3, sizeof(initData3), QStringLiteral("init"), false, true);
         writeCharacteristic((uint8_t *)initData2, sizeof(initData2), QStringLiteral("init"), false, true);
+        writeCharacteristic((uint8_t *)initData3, sizeof(initData3), QStringLiteral("init"), false, true);
+        writeCharacteristic((uint8_t *)initData2, sizeof(initData2), QStringLiteral("init"), false, true);
         writeCharacteristic((uint8_t *)initData4, sizeof(initData4), QStringLiteral("init"), false, true);
         writeCharacteristic((uint8_t *)initData5, sizeof(initData5), QStringLiteral("init"), false, true);
         writeCharacteristic((uint8_t *)initData6, sizeof(initData6), QStringLiteral("init"), false, true);

--- a/src/devices/trxappgateusbelliptical/trxappgateusbelliptical.cpp
+++ b/src/devices/trxappgateusbelliptical/trxappgateusbelliptical.cpp
@@ -75,6 +75,10 @@ void trxappgateusbelliptical::forceResistance(resistance_t requestResistance) {
     }
 }
 
+bool trxappgateusbelliptical::toorxResistanceInRange(resistance_t resistance) {
+    return resistance >= 1 && resistance <= 32;
+}
+
 void trxappgateusbelliptical::update() {
     if (m_control->state() == QLowEnergyController::UnconnectedState) {
         emit disconnected();
@@ -117,8 +121,9 @@ void trxappgateusbelliptical::update() {
             if (requestResistance != -1) {
                 if (requestResistance < 1)
                     requestResistance = 1;
-                if (requestResistance != currentResistance().value() && requestResistance >= 1 &&
-                    requestResistance <= 15) {
+                if (requestResistance != currentResistance().value() &&
+                    ((elliptical_type == TYPE::TOORX && toorxResistanceInRange(requestResistance)) ||
+                     (elliptical_type != TYPE::TOORX && requestResistance >= 1 && requestResistance <= 15))) {
                     emit debug(QStringLiteral("writing resistance ") + QString::number(requestResistance));
                     forceResistance(requestResistance);
                 }

--- a/src/devices/trxappgateusbelliptical/trxappgateusbelliptical.cpp
+++ b/src/devices/trxappgateusbelliptical/trxappgateusbelliptical.cpp
@@ -479,7 +479,8 @@ void trxappgateusbelliptical::error(QLowEnergyController::Error err) {
 
 void trxappgateusbelliptical::deviceDiscovered(const QBluetoothDeviceInfo &device) {
     emit debug(QStringLiteral("Found new device: ") + device.name() + " (" + device.address().toString() + ')');
-    if (device.name().toUpper().startsWith(QStringLiteral("I-CONSOLE+"))) {
+    if (device.name().toUpper().startsWith(QStringLiteral("I-CONSOLE+")) ||
+        device.name().toUpper().startsWith(QStringLiteral("TOORX"))) {
         elliptical_type = DCT2000I;
         qDebug() << "DCT2000I workaround activacted!";
     }

--- a/src/devices/trxappgateusbelliptical/trxappgateusbelliptical.cpp
+++ b/src/devices/trxappgateusbelliptical/trxappgateusbelliptical.cpp
@@ -56,7 +56,13 @@ void trxappgateusbelliptical::writeCharacteristic(uint8_t *data, uint8_t data_le
 }
 
 void trxappgateusbelliptical::forceResistance(resistance_t requestResistance) {
-    if (elliptical_type == TYPE::DCT2000I || elliptical_type == TYPE::JTX_FITNESS || elliptical_type == TYPE::TAURUS_FX99) {
+    if (elliptical_type == TYPE::TOORX) {
+        uint8_t resistance[] = {0xf0, 0xa6, 0x23, 0x01, 0x00, 0x00};
+        resistance[4] = requestResistance + 1;
+        for (uint8_t i = 0; i < sizeof(resistance) - 1; i++)
+            resistance[5] += resistance[i];
+        writeCharacteristic(resistance, sizeof(resistance), QStringLiteral("writingResistance"));
+    } else if (elliptical_type == TYPE::DCT2000I || elliptical_type == TYPE::JTX_FITNESS || elliptical_type == TYPE::TAURUS_FX99) {
         uint8_t noOpData1[] = {0xf0, 0xa6, 0x01, 0x01, 0x03, 0x9b};
         noOpData1[4] = requestResistance + 1;
         noOpData1[5] = noOpData1[4] + 0x98;
@@ -118,7 +124,13 @@ void trxappgateusbelliptical::update() {
                 }
                 requestResistance = -1;
             } else {
-                if (elliptical_type == TYPE::DCT2000I || elliptical_type == TYPE::JTX_FITNESS || elliptical_type == TYPE::TAURUS_FX99) {
+                if (elliptical_type == TYPE::TOORX) {
+                    if (lastToorxPollTime.isNull() || lastToorxPollTime.msecsTo(QDateTime::currentDateTime()) >= 500) {
+                        uint8_t noOpData1[] = {0xf0, 0xa2, 0x23, 0x01, 0xb6};
+                        writeCharacteristic(noOpData1, sizeof(noOpData1), QStringLiteral("noOp"));
+                        lastToorxPollTime = QDateTime::currentDateTime();
+                    }
+                } else if (elliptical_type == TYPE::DCT2000I || elliptical_type == TYPE::JTX_FITNESS || elliptical_type == TYPE::TAURUS_FX99) {
                     uint8_t noOpData1[] = {0xf0, 0xa2, 0x01, 0x01, 0x94};
                     writeCharacteristic(noOpData1, sizeof(noOpData1), QStringLiteral("noOp"));
                 } else {
@@ -162,11 +174,8 @@ void trxappgateusbelliptical::serviceDiscovered(const QBluetoothUuid &gatt) {
 
 double trxappgateusbelliptical::GetSpeedFromPacket(const QByteArray &packet) {
 
-    if (bluetoothDevice.name().compare(QStringLiteral("TOORX0095"), Qt::CaseInsensitive) == 0) {
-        QSettings settings;
-        double cadence_speed_ratio = settings.value(QZSettings::cadence_sensor_speed_ratio,
-                                                    QZSettings::default_cadence_sensor_speed_ratio).toDouble();
-        return toorx0095SpeedFromCadence(toorx0095CadenceFromPacket(packet), cadence_speed_ratio);
+    if (elliptical_type == TYPE::TOORX) {
+        return toorxSpeedFromPacket(packet);
     } else if (elliptical_type == TYPE::JTX_FITNESS) {
         // JTX Fitness doesn't send speed via bluetooth, calculate from cadence using settings ratio
         QSettings settings;
@@ -183,8 +192,8 @@ double trxappgateusbelliptical::GetSpeedFromPacket(const QByteArray &packet) {
 double trxappgateusbelliptical::GetCadenceFromPacket(const QByteArray &packet) {
 
     uint16_t convertedData;
-    if (bluetoothDevice.name().compare(QStringLiteral("TOORX0095"), Qt::CaseInsensitive) == 0) {
-        return toorx0095CadenceFromPacket(packet);
+    if (elliptical_type == TYPE::TOORX) {
+        return toorxCadenceFromPacket(packet);
     } else if (elliptical_type == TYPE::JTX_FITNESS) {
         // JTX Fitness uses only byte 5 for cadence
         convertedData = packet.at(5);
@@ -194,12 +203,15 @@ double trxappgateusbelliptical::GetCadenceFromPacket(const QByteArray &packet) {
     return convertedData;
 }
 
-double trxappgateusbelliptical::toorx0095CadenceFromPacket(const QByteArray &packet) {
-    return static_cast<uint8_t>(packet.at(5));
+double trxappgateusbelliptical::toorxCadenceFromPacket(const QByteArray &packet) {
+    return (static_cast<uint8_t>(packet.at(9)) - 1) +
+           ((static_cast<uint8_t>(packet.at(8)) - 1) * 100);
 }
 
-double trxappgateusbelliptical::toorx0095SpeedFromCadence(double cadence, double ratio) {
-    return cadence * ratio;
+double trxappgateusbelliptical::toorxSpeedFromPacket(const QByteArray &packet) {
+    const uint16_t convertedData = (static_cast<uint8_t>(packet.at(7)) - 1) +
+                                   ((static_cast<uint8_t>(packet.at(6)) - 1) * 100);
+    return static_cast<double>(convertedData) / 10.0;
 }
 
 double trxappgateusbelliptical::GetWattFromPacket(const QByteArray &packet) {
@@ -283,7 +295,29 @@ void trxappgateusbelliptical::characteristicChanged(const QLowEnergyCharacterist
 
 void trxappgateusbelliptical::btinit() {
 
-    if (elliptical_type == TYPE::DCT2000I || elliptical_type == TYPE::JTX_FITNESS || elliptical_type == TYPE::TAURUS_FX99) {
+    if (elliptical_type == TYPE::TOORX) {
+        const uint8_t initData1[] = {0xf0, 0xa0, 0x01, 0x00, 0x91};
+        const uint8_t initData2[] = {0xf0, 0xa0, 0x23, 0x01, 0xb4};
+        const uint8_t initData3[] = {0xf0, 0xa1, 0x23, 0x01, 0xb5};
+        const uint8_t initData4[] = {0xf0, 0xa3, 0x23, 0x01, 0x01, 0xb8};
+        const uint8_t initData5[] = {0xf0, 0xa4, 0x23, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0xc2};
+        const uint8_t initData6[] = {0xf0, 0xa5, 0x23, 0x01, 0x02, 0xbb};
+
+        writeCharacteristic((uint8_t *)initData1, sizeof(initData1), QStringLiteral("init"), false, true);
+        writeCharacteristic((uint8_t *)initData2, sizeof(initData2), QStringLiteral("init"), false, true);
+        writeCharacteristic((uint8_t *)initData3, sizeof(initData3), QStringLiteral("init"), false, true);
+        writeCharacteristic((uint8_t *)initData3, sizeof(initData3), QStringLiteral("init"), false, true);
+        writeCharacteristic((uint8_t *)initData2, sizeof(initData2), QStringLiteral("init"), false, true);
+        writeCharacteristic((uint8_t *)initData3, sizeof(initData3), QStringLiteral("init"), false, true);
+        writeCharacteristic((uint8_t *)initData2, sizeof(initData2), QStringLiteral("init"), false, true);
+        writeCharacteristic((uint8_t *)initData3, sizeof(initData3), QStringLiteral("init"), false, true);
+        writeCharacteristic((uint8_t *)initData2, sizeof(initData2), QStringLiteral("init"), false, true);
+        writeCharacteristic((uint8_t *)initData3, sizeof(initData3), QStringLiteral("init"), false, true);
+        writeCharacteristic((uint8_t *)initData2, sizeof(initData2), QStringLiteral("init"), false, true);
+        writeCharacteristic((uint8_t *)initData4, sizeof(initData4), QStringLiteral("init"), false, true);
+        writeCharacteristic((uint8_t *)initData5, sizeof(initData5), QStringLiteral("init"), false, true);
+        writeCharacteristic((uint8_t *)initData6, sizeof(initData6), QStringLiteral("init"), false, true);
+    } else if (elliptical_type == TYPE::DCT2000I || elliptical_type == TYPE::JTX_FITNESS || elliptical_type == TYPE::TAURUS_FX99) {
         uint8_t initData1[] = {0xf0, 0xa0, 0x01, 0x00, 0x91};
         uint8_t initData2[] = {0xf0, 0xa0, 0x01, 0x01, 0x92};
         uint8_t initData3[] = {0xf0, 0xa1, 0x01, 0x01, 0x93};
@@ -344,7 +378,7 @@ void trxappgateusbelliptical::stateChanged(QLowEnergyService::ServiceState state
         QString uuidNotify1 = QStringLiteral("0000fff1-0000-1000-8000-00805f9b34fb");
         QString uuidNotify2 = QStringLiteral("49535343-4c8a-39b3-2f49-511cff073b7e");
 
-        if (elliptical_type == TYPE::DCT2000I || elliptical_type == TYPE::JTX_FITNESS) {
+        if (elliptical_type == TYPE::DCT2000I || elliptical_type == TYPE::JTX_FITNESS || elliptical_type == TYPE::TOORX) {
             uuidWrite = QStringLiteral("49535343-8841-43f4-a8d4-ecbe34729bb3");
             uuidNotify1 = QStringLiteral("49535343-1E4D-4BD9-BA61-23C647249616");
             uuidNotify2 = QStringLiteral("49535343-4c8a-39b3-2f49-511cff073b7e");
@@ -428,7 +462,7 @@ void trxappgateusbelliptical::serviceScanDone(void) {
     QString uuid2 = QStringLiteral("49535343-FE7D-4AE5-8FA9-9FAFD205E455");
     QString uuid3 = QStringLiteral("0000fff0-0000-1000-8000-00805f9b34fb");
 
-    if (elliptical_type == TYPE::DCT2000I) {
+    if (elliptical_type == TYPE::DCT2000I || elliptical_type == TYPE::TOORX) {
         uuid = uuid2;
     }
 
@@ -494,10 +528,12 @@ void trxappgateusbelliptical::error(QLowEnergyController::Error err) {
 
 void trxappgateusbelliptical::deviceDiscovered(const QBluetoothDeviceInfo &device) {
     emit debug(QStringLiteral("Found new device: ") + device.name() + " (" + device.address().toString() + ')');
-    if (device.name().toUpper().startsWith(QStringLiteral("I-CONSOLE+")) ||
-        device.name().toUpper().startsWith(QStringLiteral("TOORX"))) {
+    if (device.name().toUpper().startsWith(QStringLiteral("I-CONSOLE+"))) {
         elliptical_type = DCT2000I;
         qDebug() << "DCT2000I workaround activacted!";
+    } else if (device.name().toUpper().startsWith(QStringLiteral("TOORX"))) {
+        elliptical_type = TOORX;
+        qDebug() << "TOORX protocol profile activated!";
     }
 
     {

--- a/src/devices/trxappgateusbelliptical/trxappgateusbelliptical.h
+++ b/src/devices/trxappgateusbelliptical/trxappgateusbelliptical.h
@@ -39,8 +39,8 @@ class trxappgateusbelliptical : public elliptical {
                    double bikeResistanceGain = 1.0);
     bool connected() override;
     bool inclinationAvailableByHardware() override;
-    static double toorx0095CadenceFromPacket(const QByteArray &packet);
-    static double toorx0095SpeedFromCadence(double cadence, double ratio);
+    static double toorxCadenceFromPacket(const QByteArray &packet);
+    static double toorxSpeedFromPacket(const QByteArray &packet);
 
   private:
     void writeCharacteristic(uint8_t *data, uint8_t data_len, const QString &info, bool disable_log = false,
@@ -63,6 +63,7 @@ class trxappgateusbelliptical : public elliptical {
     QByteArray lastPacket;
     QDateTime lastValidPacketTime = QDateTime::currentDateTime();
     QDateTime lastRefreshCharacteristicChanged = QDateTime::currentDateTime();
+    QDateTime lastToorxPollTime;
     uint8_t firstStateChanged = 0;
     int8_t bikeResistanceOffset = 4;
     double bikeResistanceGain = 1.0;
@@ -86,6 +87,7 @@ class trxappgateusbelliptical : public elliptical {
         DCT2000I = 1,
         JTX_FITNESS = 2,
         TAURUS_FX99 = 3,
+        TOORX = 4,
     } TYPE;
     TYPE elliptical_type = ELLIPTICAL_GENERIC;
 

--- a/src/devices/trxappgateusbelliptical/trxappgateusbelliptical.h
+++ b/src/devices/trxappgateusbelliptical/trxappgateusbelliptical.h
@@ -39,6 +39,7 @@ class trxappgateusbelliptical : public elliptical {
                    double bikeResistanceGain = 1.0);
     bool connected() override;
     bool inclinationAvailableByHardware() override;
+    static bool toorxResistanceInRange(resistance_t resistance);
     static double toorxCadenceFromPacket(const QByteArray &packet);
     static double toorxSpeedFromPacket(const QByteArray &packet);
 

--- a/src/devices/trxappgateusbelliptical/trxappgateusbelliptical.h
+++ b/src/devices/trxappgateusbelliptical/trxappgateusbelliptical.h
@@ -39,6 +39,8 @@ class trxappgateusbelliptical : public elliptical {
                    double bikeResistanceGain = 1.0);
     bool connected() override;
     bool inclinationAvailableByHardware() override;
+    static double toorx0095CadenceFromPacket(const QByteArray &packet);
+    static double toorx0095SpeedFromCadence(double cadence, double ratio);
 
   private:
     void writeCharacteristic(uint8_t *data, uint8_t data_len, const QString &info, bool disable_log = false,

--- a/tst/Devices/TestTrxAppGateUsBellipticalParser.cpp
+++ b/tst/Devices/TestTrxAppGateUsBellipticalParser.cpp
@@ -1,0 +1,1 @@
+#include "TestTrxAppGateUsBellipticalParser.h"

--- a/tst/Devices/TestTrxAppGateUsBellipticalParser.h
+++ b/tst/Devices/TestTrxAppGateUsBellipticalParser.h
@@ -5,6 +5,13 @@
 
 #include "devices/trxappgateusbelliptical/trxappgateusbelliptical.h"
 
+TEST(TrxAppGateUsBellipticalParserTest, ToorxSupportsResistanceLevelsThrough32) {
+    EXPECT_FALSE(trxappgateusbelliptical::toorxResistanceInRange(0));
+    EXPECT_TRUE(trxappgateusbelliptical::toorxResistanceInRange(1));
+    EXPECT_TRUE(trxappgateusbelliptical::toorxResistanceInRange(32));
+    EXPECT_FALSE(trxappgateusbelliptical::toorxResistanceInRange(33));
+}
+
 TEST(TrxAppGateUsBellipticalParserTest, ToorxUsesCadenceFieldFromPacket) {
     const QByteArray packet = QByteArray::fromHex("f0b223010121011401130101010101010145020261");
 

--- a/tst/Devices/TestTrxAppGateUsBellipticalParser.h
+++ b/tst/Devices/TestTrxAppGateUsBellipticalParser.h
@@ -5,12 +5,14 @@
 
 #include "devices/trxappgateusbelliptical/trxappgateusbelliptical.h"
 
-TEST(TrxAppGateUsBellipticalParserTest, Toorx0095UsesByteFiveAsCadence) {
-    const QByteArray packet = QByteArray::fromHex("f0b22301073a010101010101010101010101020217");
+TEST(TrxAppGateUsBellipticalParserTest, ToorxUsesCadenceFieldFromPacket) {
+    const QByteArray packet = QByteArray::fromHex("f0b223010121011401130101010101010145020261");
 
-    EXPECT_DOUBLE_EQ(trxappgateusbelliptical::toorx0095CadenceFromPacket(packet), 58.0);
+    EXPECT_DOUBLE_EQ(trxappgateusbelliptical::toorxCadenceFromPacket(packet), 18.0);
 }
 
-TEST(TrxAppGateUsBellipticalParserTest, Toorx0095SpeedIsCalculatedFromCadenceAndRatio) {
-    EXPECT_NEAR(trxappgateusbelliptical::toorx0095SpeedFromCadence(58.0, 0.33), 19.14, 0.000001);
+TEST(TrxAppGateUsBellipticalParserTest, ToorxUsesSpeedFieldFromPacket) {
+    const QByteArray packet = QByteArray::fromHex("f0b223010121011401130101010101010145020261");
+
+    EXPECT_DOUBLE_EQ(trxappgateusbelliptical::toorxSpeedFromPacket(packet), 1.9);
 }

--- a/tst/Devices/TestTrxAppGateUsBellipticalParser.h
+++ b/tst/Devices/TestTrxAppGateUsBellipticalParser.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <gtest/gtest.h>
+#include <QByteArray>
+
+#include "devices/trxappgateusbelliptical/trxappgateusbelliptical.h"
+
+TEST(TrxAppGateUsBellipticalParserTest, Toorx0095UsesByteFiveAsCadence) {
+    const QByteArray packet = QByteArray::fromHex("f0b22301073a010101010101010101010101020217");
+
+    EXPECT_DOUBLE_EQ(trxappgateusbelliptical::toorx0095CadenceFromPacket(packet), 58.0);
+}
+
+TEST(TrxAppGateUsBellipticalParserTest, Toorx0095SpeedIsCalculatedFromCadenceAndRatio) {
+    EXPECT_NEAR(trxappgateusbelliptical::toorx0095SpeedFromCadence(58.0, 0.33), 19.14, 0.000001);
+}

--- a/tst/Devices/devicetestdataindex.cpp
+++ b/tst/Devices/devicetestdataindex.cpp
@@ -1411,6 +1411,7 @@ void DeviceTestDataIndex::Initialize() {
     RegisterNewDeviceTestData(DeviceIndex::TrxAppGateUSBEllipticalIConsole)
         ->expectDevice<trxappgateusbelliptical>()
         ->acceptDeviceName("I-CONSOLE+", DeviceNameComparison::StartsWithIgnoreCase)
+        ->acceptDeviceName("TOORX", DeviceNameComparison::StartsWithIgnoreCase)
         ->excluding(toorxAppGateUSBBikeExclusions)
         ->configureSettingsWith([trxAppGateUSBEllipticalSettingsApplicator](const DeviceDiscoveryInfo &info, bool enable, std::vector<DeviceDiscoveryInfo> &configurations) -> void
                                 {

--- a/tst/qdomyos-zwift-tests.pro
+++ b/tst/qdomyos-zwift-tests.pro
@@ -31,6 +31,7 @@ SOURCES += \
         Devices/TestSchwinn411510EParser.cpp \
         Devices/TestZwiftRideController.cpp \
         Devices/TestApexBikeParser.cpp \
+        Devices/TestTrxAppGateUsBellipticalParser.cpp \
         Devices/TestKeepBikeParser.cpp \
         Devices/TestRenphoBikeKnobGears.cpp \
         Devices/TestNordictrackEllipticalS700Parser.cpp \
@@ -65,6 +66,7 @@ HEADERS += \
     Devices/devicetestdataindex.h \
     Devices/TestSchwinn411510EParser.h \
     Devices/TestApexBikeParser.h \
+    Devices/TestTrxAppGateUsBellipticalParser.h \
     Devices/TestKeepBikeParser.h \
     Devices/TestRenphoBikeKnobGears.h \
     Devices/TestNordictrackEllipticalS700Parser.h \


### PR DESCRIPTION
## Summary

Fix TOORX ellipticals that use the iConsole/AppGate protocol when **iConsole Elliptical** is enabled.

- route `TOORX*` devices to `trxappgateusbelliptical` when `iconsole_elliptical` is enabled
- classify those TOORX devices as `DCT2000I`, like `I-CONSOLE+`, so the driver selects the Microchip transparent UART service/characteristics and uses the DCT/iConsole 21-byte metric layout instead of falling back to the JTX parser
- extend the existing iConsole elliptical discovery test to cover the `TOORX` prefix

Related discussion: https://github.com/cagnulein/qdomyos-zwift/discussions/5011#discussioncomment-18230040

## Routing check

The new elliptical condition is before the later TOORX treadmill/bike/FTMS branches in the `else if` chain. The existing AppGate treadmill and AppGate bike branches are also explicitly guarded by `!iconsole_elliptical`, so with this setting enabled the TOORX device is not claimed by those handlers.

## Log check

The supplied log discovers `TOORX0095` with service `49535343-FE7D-4AE5-8FA9-9FAFD205E455`. The current code incorrectly instantiates `trxappgateusbtreadmill`, which then looks for `0000fff0` and stops with `invalid service`.

`trxappgateusbelliptical` already supports that `49535343-FE7D-4AE5-8FA9-9FAFD205E455` service for the DCT/iConsole protocol, so this fixes the service selection path.

The supplied log was captured with `iconsole_elliptical=false` and the treadmill driver stops before notifications are enabled, so it does not contain the incoming 21-byte metric packets. Therefore the actual TOORX payload values (speed/cadence/watts/resistance) cannot be validated byte-for-byte from this log alone; a log from this PR with iConsole Elliptical enabled will confirm the payload parsing.