### PR TITLE
dircon: never advertise a serial-number of 0

### DIFF
--- a/src/devices/dircon/dirconmanager.cpp
+++ b/src/devices/dircon/dirconmanager.cpp
@@ -9,6 +9,14 @@ using namespace std::chrono_literals;
 #define DM_MACHINE_TYPE_BIKE 1
 #define DM_MACHINE_TYPE_TREADMILL 2
 
+// Base for the advertised DirCon serial-number. Machine indexes start at 0,
+// and a serial-number of 0 is rejected by some DirCon consumers: MyWhoosh
+// parses this field as an unsigned integer and treats 0 as "sensor invalid",
+// so the trainer pairs and streams normally while every reading is reported
+// back as -1 ("no power source connected"). Offsetting the index keeps the
+// serial unique per machine and never zero.
+#define DM_SERIAL_BASE 1
+
 #define DM_SERV_OP(OP, P1, P2, P3, ZWIFT_ENABLED)                                                                     \
     OP(FITNESS_MACHINE_CYCLE, 0x1826, WAHOO_KICKR, P1, P2, P3)                                                         \
     OP(FITNESS_MACHINE_TREADMILL, 0x1826, WAHOO_TREADMILL, P1, P2, P3)                                                 \
@@ -142,7 +150,7 @@ enum {
                 P2,                                                                                                    \
                 QString(QStringLiteral(NAME))                                                                          \
                     .replace(QStringLiteral("$uuid_hex$"), dircon_id),                                                 \
-                server_base_port + DM_MACHINE_##DESC, rouvy_compatibility ? dircon_id : QString(QStringLiteral("%1")).arg(DM_MACHINE_##DESC), mac,       \
+                server_base_port + DM_MACHINE_##DESC, rouvy_compatibility ? dircon_id : QString(QStringLiteral("%1")).arg(DM_SERIAL_BASE + DM_MACHINE_##DESC), mac,       \
                 this);                                                                                                 \
             QString servdesc;                                                                                          \
             foreach (DirconProcessorService *s, P2) { servdesc += *s + QStringLiteral(","); }                          \


### PR DESCRIPTION
### Symptom

MyWhoosh discovers the DirCon trainer, resolves it, connects, and streams data — and then reports **"no power source connected"** for the entire ride, with every metric shown as absent. It looks like a data problem, but the stream is fine.

### Cause

The advertised `serial-number` TXT record is the machine index, so the trainer (`WAHOO_KICKR`, index 0) publishes `serial-number=0`.

MyWhoosh parses that field into an unsigned integer and validates the sensor with `identifier != 0`. A serial of 0 fails that test, so every getter on the sensor returns `-1` while the socket keeps happily streaming. Nothing logs an error on either side — that combination is what makes it expensive to find.

Setting any non-zero serial makes the identical build work immediately. Verified by publishing the same records with `serial-number=100866` and watching power, cadence and resistance appear with no other change.

### Fix

Offset the machine index by a constant so the serial is never zero and stays unique per machine. `server_base_port + DM_MACHINE_##DESC` keeps using the raw index, so listening ports are unchanged.

Rouvy compatibility mode already had this covered — it substitutes `1234` when `dircon_id` is 0 — so this only affects the default path.

### Compatibility note

The trainer's advertised serial changes from `0` to `1`. An app that remembers a DirCon sensor by serial will see it as a new sensor once and may ask to re-pair. Happy to gate this behind a setting instead if you'd prefer to avoid that for existing users.
