### PR TITLE
android: USB permission PendingIntent must be mutable

### DIFF
--- a/src/android/src/HidBridge.java
+++ b/src/android/src/HidBridge.java
@@ -86,7 +86,13 @@ public class HidBridge {
 		}
 		
 		// Create and intent and request a permission.
-                int flags = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M ? PendingIntent.FLAG_IMMUTABLE : 0;
+                // UsbManager answers by filling EXTRA_DEVICE and
+                // EXTRA_PERMISSION_GRANTED into this PendingIntent, so it has to be
+                // mutable. An immutable one drops every fill-in extra, so mUsbReceiver
+                // below sees a null device and a false grant even when the user
+                // tapped Allow.
+                final int FLAG_MUTABLE = 0x02000000; // PendingIntent.FLAG_MUTABLE, API 31
+                int flags = Build.VERSION.SDK_INT >= 31 ? FLAG_MUTABLE : 0;
                 PendingIntent mPermissionIntent = PendingIntent.getBroadcast(_context, 0, new Intent(ACTION_USB_PERMISSION), flags);
 		IntentFilter filter = new IntentFilter(ACTION_USB_PERMISSION);
 				ContextCompat.registerReceiver(

--- a/src/android/src/Usbserial.java
+++ b/src/android/src/Usbserial.java
@@ -108,7 +108,12 @@ public class Usbserial {
                     granted[0] = intent.getBooleanExtra(UsbManager.EXTRA_PERMISSION_GRANTED, false);
                 }
             };
-            int flags = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M ? PendingIntent.FLAG_IMMUTABLE : 0;
+            // UsbManager answers by filling EXTRA_PERMISSION_GRANTED into this
+            // PendingIntent, so it has to be mutable. An immutable one drops every
+            // fill-in extra, and the broadcast then reads back as a denial even when
+            // the user tapped Allow.
+            final int FLAG_MUTABLE = 0x02000000; // PendingIntent.FLAG_MUTABLE, API 31
+            int flags = Build.VERSION.SDK_INT >= 31 ? FLAG_MUTABLE : 0;
             PendingIntent permissionIntent = PendingIntent.getBroadcast(context, 0, new Intent("org.cagnulen.qdomyoszwift.USB_PERMISSION"), flags);
             IntentFilter filter = new IntentFilter("org.cagnulen.qdomyoszwift.USB_PERMISSION");
             ContextCompat.registerReceiver(
@@ -126,6 +131,11 @@ public class Usbserial {
                 catch (InterruptedException e) {
                     // Do something here
                 }
+            }
+            if (granted[0] == null || !granted[0]) {
+                // The broadcast can be missed or arrive stripped of its extras;
+                // the manager itself is the authoritative answer.
+                granted[0] = manager.hasPermission(driver.getDevice());
             }
             QLog.d("QZ","USB permission "+granted[0]);
         }


### PR DESCRIPTION
### Symptom

The USB permission dialog appears, the user taps **Allow**, and the app behaves as if they had tapped Deny. In `HidBridge` the log line is `permission denied for the device null`. In `Usbserial` the wait loop concludes `false` and the caller starts over — which on a device that needs USB to produce any metrics at all is a large part of the delay before the first reading appears.

### Cause

`UsbManager.requestPermission()` answers by **filling** `EXTRA_DEVICE` and `EXTRA_PERMISSION_GRANTED` into the `PendingIntent` the caller supplied. `FLAG_IMMUTABLE` forbids exactly that: fill-in extras are dropped, so the broadcast arrives with a null device and `getBooleanExtra(EXTRA_PERMISSION_GRANTED, false)` returns `false` no matter what the user chose.

Both USB permission call sites used `FLAG_IMMUTABLE`, under a `SDK_INT >= M` guard, so this applies from API 23 up:

- `src/android/src/Usbserial.java`
- `src/android/src/HidBridge.java`

This is the one Android API where immutable is the wrong default, and it fails silently rather than throwing.

### Fix

Use `FLAG_MUTABLE` on these two intents. The constant is API 31, so its value (`0x02000000`) is inlined to keep compiling against older SDKs; below 31 the flag is left at 0, which is mutable by default. Notification `PendingIntent`s elsewhere in the app (`ForegroundService`) are deliberately untouched — immutable is correct there.

Also added a fallback in `Usbserial`: if the broadcast reports a denial or never arrives, consult `UsbManager.hasPermission(device)`, which is the authoritative answer and immune to the extras problem.

### Verification

Measured on a NordicTrack S22i console (Android 9, API 28) reaching its control board over USB-HID. Before the change, every grant read back as a denial and armed the retry delay; after it, the grant is seen on the first tap. I have not tested this on API 31+ hardware myself — the reasoning there is from the documented `FLAG_MUTABLE` requirement, not from a run.
