### PR TITLE
nordictrackifitadb: accumulate crank revolutions over real elapsed time

### DIFF
--- a/src/devices/nordictrackifitadbbike/nordictrackifitadbbike.cpp
+++ b/src/devices/nordictrackifitadbbike/nordictrackifitadbbike.cpp
@@ -423,8 +423,21 @@ void nordictrackifitadbbike::processPendingDatagrams() {
                      ((double)lastRefreshCharacteristicChanged.msecsTo(now)));
 
         if (Cadence.value() > 0) {
-            CrankRevs++;
-            LastCrankEventTime += (uint16_t)(1024.0 / (((double)(Cadence.value())) / 60.0));
+            // Accumulate crank revolutions and the crank event clock over the real
+            // elapsed time, the same way KCal and Distance do above. Incrementing
+            // once per update inflated both fields by the update rate, which made
+            // the 16-bit event timestamp wrap far sooner than the 64s the spec
+            // implies and frequently run backwards, so a consumer deriving cadence
+            // from the deltas saw 0 rpm most of the time with brief flashes of the
+            // true value.
+            double deltaMs = (double)lastRefreshCharacteristicChanged.msecsTo(now);
+            if (deltaMs > 0) {
+                CrankRevs += (((double)Cadence.value()) / 60.0) * (deltaMs / 1000.0);
+                double ticks = deltaMs * 1.024 + crankEventTimeRemainder;
+                uint32_t wholeTicks = (uint32_t)ticks;
+                crankEventTimeRemainder = ticks - (double)wholeTicks;
+                LastCrankEventTime += (uint16_t)wholeTicks; // 1/1024 s, wraps at 64s
+            }
         }
 
         lastRefreshCharacteristicChanged = now;

--- a/src/devices/nordictrackifitadbbike/nordictrackifitadbbike.h
+++ b/src/devices/nordictrackifitadbbike/nordictrackifitadbbike.h
@@ -85,6 +85,7 @@ class nordictrackifitadbbike : public bike {
     QDateTime lastResistanceChanged = QDateTime::currentDateTime();
     uint8_t firstStateChanged = 0;
     uint16_t m_watts = 0;
+    double crankEventTimeRemainder = 0.0; // sub-tick carry for LastCrankEventTime
 
     bool initDone = false;
     bool initRequest = false;


### PR DESCRIPTION
### Symptom

A consumer reading cadence from Cycling Power (`0x2A63`) or CSC (`0x2A5B`) sees **0 rpm most of the time, with brief flashes of the correct value**, while instantaneous power from the same device looks perfectly healthy right next to it.

That combination is what makes this confusing to diagnose: watts are obviously fine, so the transport and the device are assumed fine, and the cadence problem gets blamed on the consuming app.

### Cause

```cpp
if (Cadence.value() > 0) {
    CrankRevs++;
    LastCrankEventTime += (uint16_t)(1024.0 / (((double)(Cadence.value())) / 60.0));
}
```

Both fields advance once per `processPendingDatagrams()` call, not per unit of time. They are therefore scaled by the update rate rather than by the clock.

Cadence in these characteristics is not a number — the consumer derives rpm from Δ(cumulative revolutions) ÷ Δ(1/1024 s event timestamp). Inflating both by the same factor keeps the derived *ratio* roughly correct, which is precisely why this survived: naive rpm math lands on the true value. Two consequences do not cancel:

1. **The 16-bit event time wraps far too early.** By spec it wraps every 64 s; inflated, it wrapped every ~3 s. Every wrap is a discontinuity the consumer has to guess at.
2. **Timestamps frequently run backwards**, because the per-call increment is derived from instantaneous cadence rather than elapsed time — a cadence change makes the next increment smaller than the last.

Only a consumer that first asks "has the crank advanced since the last notification?" trips over this; it then reports 0. That is why the same stream can look fine to one app and broken in another.

FTMS Indoor Bike Data (`0x2AD2`) carries instantaneous cadence as a plain field and was never affected.

### Fix

Accumulate both fields over the measured elapsed interval, exactly as `KCal` and `Distance` already do a few lines above using the same `lastRefreshCharacteristicChanged.msecsTo(now)`. The sub-tick remainder is carried in a new member so the event clock does not drift, and `LastCrankEventTime` is left to wrap naturally at 64 s as the spec intends.

`CrankRevs` is already a `double` (`bike.h:115`), so fractional accumulation needs no type change.

### Evidence

Measured on a NordicTrack S22i over the `tdf_10_ip` path (~21.7 updates/s), decoding the crank fields the way a consumer does, over 153 s of pedalling:

| | measured | expected |
|---|---|---|
| crank revs accumulated | 3,238 (implies 1,270 rpm) | ~149 |
| event clock advance | 3,326 s | 153 s |
| inflation, both fields | 21.74× | 1× |
| uint16 event-time wrap | every 3.0 s | every 64 s |
| samples with timestamp going backwards | 51 of 153 (33%) | 0 |
| ratio-derived cadence | 58.4 rpm | correct |

To be clear about what I have and have not checked on hardware: the pre-fix numbers above are a direct measurement. Post-fix, I have only an indirect check — the accumulated revolution count came back in the expected range (tens, not thousands) for the pedalling done — and I have not yet captured a side-by-side comparison of the crank-derived cadence against the `0x2AD2` field from the same session. The change is small enough to read, but that confirmation is still owed and I did not want to imply otherwise.
