### PR TITLE
docs: add Echelon MyWhoosh zero-power workaround

### DIFF
--- a/docs/faq/bike-troubleshooting.md
+++ b/docs/faq/bike-troubleshooting.md
@@ -14,3 +14,16 @@ This can restore the normal bike data stream when the Garmin ANT bike option int
 ### Why can incline still show zero?
 
 Bike resistance and incline are different values. A Yesoul bike may report resistance without reporting a real incline value. QZ's incline tile can instead be populated by an external source such as Zwift or a GPX route. A resistance-to-incline conversion requires a specific mapping and should not be assumed from the resistance percentage alone.
+
+## MyWhoosh connects to QZ for my Echelon bike, but power stays at 0 W. What should I check?
+
+If the Echelon bike itself is already working normally in QZ and MyWhoosh can see/connect to the QZ device but the workout data remains at zero, check whether **Virtual Echelon** is still enabled from a previous setup or unlock attempt.
+
+1. Open **QZ Settings > Experimental settings**.
+2. Disable **Virtual Echelon**.
+3. Fully close and restart QZ.
+4. Reconnect the Echelon bike, then pair QZ again in MyWhoosh.
+
+**Virtual Echelon** is intended for the Echelon initialization/unlock workflow. It is not normally needed once the bike can connect and operate directly through QZ. In a confirmed support case, disabling this setting and restarting QZ immediately restored data transmission to MyWhoosh.
+
+If the bike itself is locked and QZ explicitly asks you to enable Virtual Echelon for initialization, follow the on-screen unlock instructions first; this troubleshooting step applies when the bike is already operating normally in QZ but the downstream training app receives no metrics.


### PR DESCRIPTION
## Summary

- add a confirmed troubleshooting FAQ for Echelon bikes where MyWhoosh connects to QZ but receives 0 W / no workout metrics
- document disabling `Virtual Echelon` under Experimental settings and fully restarting QZ when the bike already works normally in QZ
- clarify that `Virtual Echelon` is still appropriate when QZ explicitly requires it for the Echelon initialization/unlock flow

## Source

Confirmed QZ support case resolved on 2026-09-01: disabling `Virtual Echelon` and restarting QZ restored MyWhoosh data transmission. The guidance was checked against the current QZ code and existing `docs/faq/` / `docs/qz_faq_public.md`, with no duplicate entry found.

## Exclusions

Other September 1 threads were not documented when they remained unresolved, involved private/non-public procedures, or substantially overlapped existing compatibility guidance.

## Images

No screenshots are required for this entry.