### PR TITLE
fix: avoid double custom gear offset in FTMS bikes

### DIFF
--- a/src/devices/ftmsbike/ftmsbike.cpp
+++ b/src/devices/ftmsbike/ftmsbike.cpp
@@ -501,7 +501,7 @@ void ftmsbike::update() {
             double gearMultiplier = 5;
             if(REEBOK)
                 gearMultiplier = 1;
-            resistance_t rR = requestResistance + (gearsModifier() * gearMultiplier);
+            resistance_t rR = requestResistance + (settings.value(QZSettings::gears_custom_table_enabled, QZSettings::default_gears_custom_table_enabled).toBool() ? 0 : gearsModifier() * gearMultiplier);
 
             if (rR != currentResistance().value() || lastGearValue != gears()) {
                 bool ergModeNotSupported = (requestPower > 0 && !ergModeSupported);


### PR DESCRIPTION
Reference: support request from steinbrecher.c@gmx.de about MERACH S36C custom gear offsets in ROUVY

## Summary

- Fixes double application of the Custom Gear Table offset in the FTMS resistance path.
- Keeps the patch limited to `src/devices/ftmsbike/ftmsbike.cpp`.
- Preserves the legacy `gearMultiplier` behavior when the Custom Gear Table is disabled.

## Evidence

This follows the latest support mail from `steinbrecher.c@gmx.de` about a MERACH S36C using the Custom Gear Table with ROUVY, plus the attached logs:

- `debug-Sa__Aug__29_15_15_56_2026.log`
- `debug-Sa__Aug__29_15_22_50_2026.log`

In the first log, gear changes are detected correctly (`setGears` 10 through 21 and back), but the FTMS path repeatedly logs `changeResistance ... 4` and then writes values such as `04 28`, `04 64`, `04 a0`, and `04 dc`. This is consistent with applying the custom gear offset once in `bike::changeResistance()` and a second time in `ftmsbike::update()` using the legacy multiplier of 5.

## Fix

When `gears_custom_table_enabled` is true, `ftmsbike::update()` no longer adds `gearsModifier()` a second time. The value calculated by `bike::changeResistance()` is passed through unchanged. With the table disabled, the existing legacy calculation remains unchanged.

## Expected behavior

For a base resistance of 8 and offsets -2, 0, and +2, the FTMS request becomes 6, 8, and 10 respectively, rather than applying the offset twice.

## Validation

- `git diff --check` passes.
- Commit contains only the one-line change in `src/devices/ftmsbike/ftmsbike.cpp`.
- No source files in the existing dirty checkout were modified.
- No build was run in the isolated worktree; CI should provide the project build validation.
