### PR TITLE
Skip wizard when Computrainer serial port is configured

### DIFF
--- a/src/homeform.h
+++ b/src/homeform.h
@@ -58,7 +58,7 @@ class DataObject : public QObject {
     Q_PROPERTY(int gridId READ gridId NOTIFY gridIdChanged WRITE setGridId)
     Q_PROPERTY(QString value READ value WRITE setValue NOTIFY valueChanged)
     Q_PROPERTY(QString secondLine READ secondLine WRITE setSecondLine NOTIFY secondLineChanged)
-    Q_PROPERTY(int valueFontSize READ valueFontSize WRITE setValueFontSize NOTIFY valueFontSizeChanged)
+    Q_PROPERTY(int valueFontSize READ valueFontSize WRITE setValueFontSize NOTIFY valueChanged)
     Q_PROPERTY(QString valueFontColor READ valueFontColor WRITE setValueFontColor NOTIFY valueFontColorChanged)
     Q_PROPERTY(int labelFontSize READ labelFontSize WRITE setLabelFontSize NOTIFY labelFontSizeChanged)
     Q_PROPERTY(bool writable READ writable NOTIFY writableChanged)
@@ -401,6 +401,8 @@ class homeform : public QObject {
         QString proformtreadmillip = settings.value(QZSettings::proformtreadmillip, QZSettings::default_proformtreadmillip).toString();
         QString freebeatSerialPort =
             settings.value(QZSettings::freebeat_serialport, QZSettings::default_freebeat_serialport).toString();
+        QString computrainerSerialPort =
+            settings.value(QZSettings::computrainer_serialport, QZSettings::default_computrainer_serialport).toString();
 
         QString nordictrack_2950_ip =
             settings.value(QZSettings::nordictrack_2950_ip, QZSettings::default_nordictrack_2950_ip).toString();
@@ -421,7 +423,7 @@ class homeform : public QObject {
                 nordictrack_2950_ip.isEmpty() && tdf_10_ip.isEmpty() && !fake_bike && !fakedevice_elliptical &&
                 !fakedevice_rower && !waterrower_usb && !fakedevice_treadmill && !antbike && !android_antbike && proform_elliptical_ip.isEmpty() &&
                 proformtdf4ip.isEmpty() && proformtdf1ip.isEmpty() && proformtreadmillip.isEmpty() &&
-                freebeatSerialPort.isEmpty();
+                freebeatSerialPort.isEmpty() && computrainerSerialPort.isEmpty();
     }
 
 
@@ -1103,7 +1105,7 @@ public:
     void intervalsicu_download_todays_workout();
     void intervalsicu_download_workout_completed(QNetworkReply *reply);
     QString intervalsicuAuthUrl;
-    bool intervalsicuAuthWebVisible;
+    bool intervalsicuWebVisible;
 
     static quint64 cryptoKeySettingsProfiles();
 

--- a/src/homeform.h
+++ b/src/homeform.h
@@ -58,7 +58,7 @@ class DataObject : public QObject {
     Q_PROPERTY(int gridId READ gridId NOTIFY gridIdChanged WRITE setGridId)
     Q_PROPERTY(QString value READ value WRITE setValue NOTIFY valueChanged)
     Q_PROPERTY(QString secondLine READ secondLine WRITE setSecondLine NOTIFY secondLineChanged)
-    Q_PROPERTY(int valueFontSize READ valueFontSize WRITE setValueFontSize NOTIFY valueChanged)
+    Q_PROPERTY(int valueFontSize READ valueFontSize WRITE setValueFontSize NOTIFY valueFontSizeChanged)
     Q_PROPERTY(QString valueFontColor READ valueFontColor WRITE setValueFontColor NOTIFY valueFontColorChanged)
     Q_PROPERTY(int labelFontSize READ labelFontSize WRITE setLabelFontSize NOTIFY labelFontSizeChanged)
     Q_PROPERTY(bool writable READ writable NOTIFY writableChanged)
@@ -1105,7 +1105,7 @@ public:
     void intervalsicu_download_todays_workout();
     void intervalsicu_download_workout_completed(QNetworkReply *reply);
     QString intervalsicuAuthUrl;
-    bool intervalsicuWebVisible;
+    bool intervalsicuAuthWebVisible;
 
     static quint64 cryptoKeySettingsProfiles();
 


### PR DESCRIPTION
## Summary
- read the configured Computrainer serial port in `homeform::firstRun()`
- treat a configured Computrainer port as an existing device setup
- skip the first-run wizard when that serial port is already set

## Why
Computrainer is configured through `computrainer_serialport`, but this setting was not included in the conditions used to determine whether QZ should show `Wizard.qml` on startup.