### PR TITLE
Update settings catalog metadata

### DIFF
--- a/.github/workflows/settings-catalog.yml
+++ b/.github/workflows/settings-catalog.yml
@@ -1,0 +1,27 @@
+name: Settings catalog validation
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  validate-settings-catalog:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch pull request base
+        if: github.event_name == 'pull_request'
+        run: git fetch origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
+
+      - name: Validate settings catalog
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            python3 tools/check_settings_catalog.py "origin/${{ github.base_ref }}"
+          else
+            python3 tools/check_settings_catalog.py "HEAD^"
+          fi

--- a/src/settings-catalog.json
+++ b/src/settings-catalog.json
@@ -2,7 +2,7 @@
   "$schema": "https://qdomyos-zwift.local/settings-catalog.schema.json",
   "schemaVersion": 1,
   "format": "qdomyos-zwift-settings-catalog",
-  "settingCount": 971,
+  "settingCount": 1001,
   "pages": [
     {
       "key": "page_custom_gear_table",
@@ -12,16 +12,6 @@
       "type": "page",
       "control": "page",
       "target": "customgears.qml",
-      "visible": true
-    },
-    {
-      "key": "page_custom_inclination_resistance_table",
-      "name": "Custom Inclination to Resistance Table",
-      "description": "Configure how virtual-app inclination maps to bike resistance.",
-      "parent": "Bike Options",
-      "type": "page",
-      "control": "page",
-      "target": "custominclinationresistance.qml",
       "visible": true
     },
     {
@@ -56,7 +46,7 @@
     },
     {
       "key": "page_tts_text_to_speech_settings",
-      "name": "TTS (Text to Speech) Settings \ud83d\udd0a",
+      "name": "TTS (Text to Speech) Settings 🔊",
       "description": null,
       "parent": "General",
       "type": "page",
@@ -66,12 +56,22 @@
     },
     {
       "key": "page_keyboard_shortcuts",
-      "name": "Keyboard Shortcuts \u2328\ufe0f",
+      "name": "Keyboard Shortcuts ⌨️",
       "description": null,
       "parent": "Tiles",
       "type": "page",
       "control": "page",
       "target": "settings-shortcuts.qml",
+      "visible": true
+    },
+    {
+      "key": "page_custom_inclination_resistance_table",
+      "name": "Custom Inclination to Resistance Table",
+      "description": "Configure how virtual-app inclination maps to bike resistance.",
+      "parent": "Bike Options",
+      "type": "page",
+      "control": "page",
+      "target": "custominclinationresistance.qml",
       "visible": true
     }
   ],
@@ -176,7 +176,8 @@
           "label": "NordicTrack VR21",
           "sets": "nordictrack_vr21"
         }
-      ]
+      ],
+      "restartRequired": true
     },
     {
       "key": "nordictrack_treadmill_model",
@@ -442,7 +443,8 @@
           "label": "Nordictrack Incline Trainer X7i NTL15010.0",
           "sets": "nordictrack_incline_trainer_x7i_ntl15010_0"
         }
-      ]
+      ],
+      "restartRequired": true
     }
   ],
   "settings": [
@@ -457,7 +459,8 @@
       "visible": true,
       "defaultValue": 100.0,
       "defaultExpression": "100.0",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "bike_heartrate_service",
@@ -470,12 +473,13 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "bike_resistance_offset",
       "name": "Zwift Resistance Offset",
-      "description": "This setting sets your \u201cflat road\u201d in Zwift. All communicated resistance changes will be based on this setting. The value entered is personal preference and will be dependent on your level of fitness. The suggested value for Echelon bikes is between 18 and 20. Default is 4.",
+      "description": "This setting sets your “flat road” in Zwift. All communicated resistance changes will be based on this setting. The value entered is personal preference and will be dependent on your level of fitness. The suggested value for Echelon bikes is between 18 and 20. Default is 4.",
       "parent": "Bike Options",
       "type": "integer",
       "qmlType": "int",
@@ -483,12 +487,13 @@
       "visible": true,
       "defaultValue": 4,
       "defaultExpression": "4",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "bike_resistance_gain_f",
       "name": "Zwift Resistance Gain",
-      "description": "(for bikes and treadmills when using \u201ctreadmill as a bike\u201d setting). This setting scales the resistance from your bike or the speed from your treadmill before sending it to Zwift. Default is 1.",
+      "description": "(for bikes and treadmills when using “treadmill as a bike” setting). This setting scales the resistance from your bike or the speed from your treadmill before sending it to Zwift. Default is 1.",
       "parent": "Bike Options",
       "type": "number",
       "qmlType": "real",
@@ -496,7 +501,8 @@
       "visible": true,
       "defaultValue": 1.0,
       "defaultExpression": "1.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "zwift_erg",
@@ -509,12 +515,13 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "zwift_erg_filter",
       "name": "Zwift ERG Watt Up Filter",
-      "description": "In ERG Mode or during a Power Zone workout on Peloton, the app sends a \u201ctarget output\u201d request. If the output requested doesn\u2019t match your current output (calculated using cadence and resistance level), your target resistance will change to help you get closer to the target output. If the filter is set to higher values, you will get less adjustment of the target resistance and you will have to increase your cadence to match the target output. The Up and Down Watt Filter settings are the upper and lower margin before the adjustment of resistance is communicated. Example: if the up and down filters are set to 10 and the target output is 100 watts, a change of your resistance will only be communicated if your bike produces less than 90 watts or more than 110 watts. Default is 10.",
+      "description": "In ERG Mode or during a Power Zone workout on Peloton, the app sends a “target output” request. If the output requested doesn’t match your current output (calculated using cadence and resistance level), your target resistance will change to help you get closer to the target output. If the filter is set to higher values, you will get less adjustment of the target resistance and you will have to increase your cadence to match the target output. The Up and Down Watt Filter settings are the upper and lower margin before the adjustment of resistance is communicated. Example: if the up and down filters are set to 10 and the target output is 100 watts, a change of your resistance will only be communicated if your bike produces less than 90 watts or more than 110 watts. Default is 10.",
       "parent": "Bike Options",
       "type": "number",
       "qmlType": "real",
@@ -522,7 +529,8 @@
       "visible": true,
       "defaultValue": 10.0,
       "defaultExpression": "10.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "zwift_erg_filter_down",
@@ -535,12 +543,13 @@
       "visible": true,
       "defaultValue": 10.0,
       "defaultExpression": "10.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "zwift_negative_inclination_x2",
       "name": "Double Negative Inclination",
-      "description": "Turn this on if you have a bike with inclination capabilities to fix Zwift\u2019s bug that sends half-negative downhill inclination",
+      "description": "Turn this on if you have a bike with inclination capabilities to fix Zwift’s bug that sends half-negative downhill inclination",
       "parent": "Advanced Settings",
       "type": "boolean",
       "qmlType": "bool",
@@ -548,7 +557,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "zwift_inclination_offset",
@@ -561,7 +571,8 @@
       "visible": true,
       "defaultValue": 0.0,
       "defaultExpression": "0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "zwift_inclination_gain",
@@ -574,7 +585,8 @@
       "visible": true,
       "defaultValue": 1.0,
       "defaultExpression": "1.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "echelon_resistance_offset",
@@ -587,7 +599,8 @@
       "visible": true,
       "defaultValue": 0.0,
       "defaultExpression": "0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "echelon_resistance_gain",
@@ -600,7 +613,8 @@
       "visible": true,
       "defaultValue": 1.0,
       "defaultExpression": "1.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "speed_power_based",
@@ -613,7 +627,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "bike_resistance_start",
@@ -626,7 +641,8 @@
       "visible": true,
       "defaultValue": 1,
       "defaultExpression": "1",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "age",
@@ -639,7 +655,8 @@
       "visible": true,
       "defaultValue": 35,
       "defaultExpression": "35.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "weight",
@@ -652,7 +669,8 @@
       "visible": true,
       "defaultValue": 75.0,
       "defaultExpression": "75.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "ftp",
@@ -665,7 +683,8 @@
       "visible": true,
       "defaultValue": 200.0,
       "defaultExpression": "200.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "user_email",
@@ -678,7 +697,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "user_nickname",
@@ -691,7 +711,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "miles_unit",
@@ -700,11 +721,12 @@
       "parent": "General Options",
       "type": "boolean",
       "qmlType": "bool",
-      "control": "text",
+      "control": "switch",
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "pause_on_start",
@@ -717,12 +739,13 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "treadmill_force_speed",
       "name": "Treadmill Speed Forcing",
-      "description": "Turn this on to have QZ control the speed of your treadmill during, for example, Peloton classes based on the coach\u2019s speed callouts. Your speed will be in the low, upper or average range based on your Peloton Options > Difficulty setting. Default is off.",
+      "description": "Turn this on to have QZ control the speed of your treadmill during, for example, Peloton classes based on the coach’s speed callouts. Your speed will be in the low, upper or average range based on your Peloton Options > Difficulty setting. Default is off.",
       "parent": "Treadmill Options",
       "type": "boolean",
       "qmlType": "bool",
@@ -730,7 +753,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "pause_on_start_treadmill",
@@ -743,12 +767,13 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "continuous_moving",
       "name": "Continuous Moving",
-      "description": "Turn this on for: - Peloton Bootcamp classes or other workouts that are on and off the bike or treadmill. QZ will continue to track your workout even when you step away from your equipment. - Capturing non-equipment-based workouts, such as yoga or strength training. NOTE: All such workouts are labeled as \u201cRides\u201d in Strava, but you can edit the label in Strava.",
+      "description": "Turn this on for: - Peloton Bootcamp classes or other workouts that are on and off the bike or treadmill. QZ will continue to track your workout even when you step away from your equipment. - Capturing non-equipment-based workouts, such as yoga or strength training. NOTE: All such workouts are labeled as “Rides” in Strava, but you can edit the label in Strava.",
       "parent": "General Options",
       "type": "boolean",
       "qmlType": "bool",
@@ -756,7 +781,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "bike_cadence_sensor",
@@ -769,7 +795,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "run_cadence_sensor",
@@ -782,7 +809,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "bike_power_sensor",
@@ -795,7 +823,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "heart_rate_belt_name",
@@ -811,7 +840,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.bluetoothDevices"
-      }
+      },
+      "restartRequired": true
     },
     {
       "key": "heart_ignore_builtin",
@@ -824,7 +854,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "kcal_ignore_builtin",
@@ -837,7 +868,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "ant_cadence",
@@ -850,7 +882,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "ant_heart",
@@ -863,7 +896,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "top_bar_enabled",
@@ -876,7 +910,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "peloton_username",
@@ -889,7 +924,8 @@
       "visible": false,
       "defaultValue": "username",
       "defaultExpression": "\"username\"",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "peloton_password",
@@ -902,7 +938,8 @@
       "visible": false,
       "defaultValue": "password",
       "defaultExpression": "\"password\"",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "peloton_difficulty",
@@ -922,7 +959,8 @@
           "upper",
           "average"
         ]
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "peloton_cadence_metric",
@@ -935,7 +973,8 @@
       "visible": false,
       "defaultValue": "Cadence",
       "defaultExpression": "\"Cadence\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "peloton_heartrate_metric",
@@ -951,7 +990,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.metrics"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "peloton_date",
@@ -971,7 +1011,8 @@
           "After Title",
           "Disabled"
         ]
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "peloton_description_link",
@@ -984,12 +1025,13 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "pzp_username",
       "name": "PZP Username",
-      "description": "As of 4/1/2022, this feature is broken due to a Power Zone Pack (PZP) website change. Leave (or change back to) the default of \u201cusername\u201d (without quotation marks, all lowercase and all one word) until further notice.",
+      "description": "As of 4/1/2022, this feature is broken due to a Power Zone Pack (PZP) website change. Leave (or change back to) the default of “username” (without quotation marks, all lowercase and all one word) until further notice.",
       "parent": "Peloton Options",
       "type": "string",
       "qmlType": "string",
@@ -997,7 +1039,8 @@
       "visible": true,
       "defaultValue": "username",
       "defaultExpression": "\"username\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "pzp_password",
@@ -1010,7 +1053,8 @@
       "visible": true,
       "defaultValue": "username",
       "defaultExpression": "\"username\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_speed_enabled",
@@ -1023,7 +1067,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_speed_order",
@@ -1039,7 +1084,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_inclination_enabled",
@@ -1052,7 +1098,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_inclination_order",
@@ -1068,7 +1115,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_cadence_enabled",
@@ -1081,7 +1129,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_cadence_order",
@@ -1097,7 +1146,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_elevation_enabled",
@@ -1110,7 +1160,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_elevation_order",
@@ -1126,7 +1177,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_calories_enabled",
@@ -1139,7 +1191,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_calories_order",
@@ -1155,7 +1208,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_odometer_enabled",
@@ -1168,7 +1222,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_odometer_order",
@@ -1184,7 +1239,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_pace_enabled",
@@ -1197,7 +1253,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_pace_order",
@@ -1213,7 +1270,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_resistance_enabled",
@@ -1226,12 +1284,13 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_resistance_order",
       "name": "order index",
-      "description": "Displays your bike\u2019s resistance. The +/- buttons can be used to change resistance, if your bike is compatible.",
+      "description": "Displays your bike’s resistance. The +/- buttons can be used to change resistance, if your bike is compatible.",
       "parent": "tile_resistance_enabled",
       "type": "integer",
       "qmlType": "int",
@@ -1242,7 +1301,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_watt_enabled",
@@ -1255,7 +1315,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_watt_order",
@@ -1271,7 +1332,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_weight_loss_enabled",
@@ -1284,7 +1346,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_weight_loss_order",
@@ -1300,7 +1363,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_avgwatt_enabled",
@@ -1313,7 +1377,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_avgwatt_order",
@@ -1329,7 +1394,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_ftp_enabled",
@@ -1342,7 +1408,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_ftp_order",
@@ -1358,7 +1425,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_heart_enabled",
@@ -1371,7 +1439,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_heart_order",
@@ -1387,7 +1456,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_fan_enabled",
@@ -1400,7 +1470,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_fan_order",
@@ -1416,7 +1487,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_jouls_enabled",
@@ -1429,7 +1501,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_jouls_order",
@@ -1445,7 +1518,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_elapsed_enabled",
@@ -1458,7 +1532,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_elapsed_order",
@@ -1474,7 +1549,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_lapelapsed_enabled",
@@ -1487,7 +1563,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_lapelapsed_order",
@@ -1503,7 +1580,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_moving_time_enabled",
@@ -1516,7 +1594,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_moving_time_order",
@@ -1532,7 +1611,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_peloton_offset_enabled",
@@ -1545,12 +1625,13 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_peloton_offset_order",
       "name": "order index",
-      "description": "Allows you to sync resistance and cadence target changes with the Peloton coach\u2019s callouts. If the targets are changing in QZ after the coach\u2019s callouts, use the \u2018+\u2019 button to add seconds (essentially speeding QZ up). Use the \u2018-\u2019 button to slow QZ down. Use this tile in conjunction with the Remaining Time/Row tile (see below).",
+      "description": "Allows you to sync resistance and cadence target changes with the Peloton coach’s callouts. If the targets are changing in QZ after the coach’s callouts, use the ‘+’ button to add seconds (essentially speeding QZ up). Use the ‘-’ button to slow QZ down. Use this tile in conjunction with the Remaining Time/Row tile (see below).",
       "parent": "tile_peloton_offset_enabled",
       "type": "integer",
       "qmlType": "int",
@@ -1561,7 +1642,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_peloton_difficulty_enabled",
@@ -1574,7 +1656,8 @@
       "visible": false,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_peloton_difficulty_order",
@@ -1587,7 +1670,8 @@
       "visible": false,
       "defaultValue": 32,
       "defaultExpression": "32",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_peloton_resistance_enabled",
@@ -1600,7 +1684,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_peloton_resistance_order",
@@ -1616,7 +1701,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_datetime_enabled",
@@ -1629,7 +1715,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_datetime_order",
@@ -1645,7 +1732,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_target_resistance_enabled",
@@ -1658,12 +1746,13 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_target_resistance_order",
       "name": "order index",
-      "description": "Displays target resistance in your bike\u2019s resistance scale. For example, during a Peloton class or Zwift session, you want the resistance displayed in this tile to match the Resistance Tile. During a Peloton class (bike only), +/- shifts the class's resistance target up or down for the rest of the ride.",
+      "description": "Displays target resistance in your bike’s resistance scale. For example, during a Peloton class or Zwift session, you want the resistance displayed in this tile to match the Resistance Tile. During a Peloton class (bike only), +/- shifts the class's resistance target up or down for the rest of the ride.",
       "parent": "tile_target_resistance_enabled",
       "type": "integer",
       "qmlType": "int",
@@ -1674,7 +1763,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_target_peloton_resistance_enabled",
@@ -1687,7 +1777,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_target_peloton_resistance_order",
@@ -1703,7 +1794,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_target_cadence_enabled",
@@ -1716,7 +1808,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_target_cadence_order",
@@ -1732,7 +1825,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_target_power_enabled",
@@ -1745,7 +1839,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_target_power_order",
@@ -1761,7 +1856,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_target_zone_enabled",
@@ -1774,7 +1870,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_target_zone_order",
@@ -1790,7 +1887,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_target_speed_enabled",
@@ -1803,7 +1901,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_target_speed_order",
@@ -1819,7 +1918,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_target_incline_enabled",
@@ -1832,7 +1932,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_target_incline_order",
@@ -1848,7 +1949,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_strokes_count_enabled",
@@ -1861,7 +1963,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_strokes_count_order",
@@ -1877,7 +1980,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_strokes_length_enabled",
@@ -1890,7 +1994,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_strokes_length_order",
@@ -1906,7 +2011,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_watt_kg_enabled",
@@ -1919,12 +2025,13 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_watt_kg_order",
       "name": "order index",
-      "description": "Calculates your output (watts) divided by your weight. This is the primary metric used by Zwift and similar apps to calculate your virtual speed. NOTE: This is a much better metric to use than Output/Watts when comparing your effort to other users. This is why Peloton\u2019s leaderboard, which uses only Output, is flawed.",
+      "description": "Calculates your output (watts) divided by your weight. This is the primary metric used by Zwift and similar apps to calculate your virtual speed. NOTE: This is a much better metric to use than Output/Watts when comparing your effort to other users. This is why Peloton’s leaderboard, which uses only Output, is flawed.",
       "parent": "tile_watt_kg_enabled",
       "type": "integer",
       "qmlType": "int",
@@ -1935,7 +2042,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_gears_enabled",
@@ -1948,7 +2056,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_gears_order",
@@ -1964,7 +2073,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_remainingtimetrainprogramrow_enabled",
@@ -1977,7 +2087,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_remainingtimetrainprogramrow_order",
@@ -1993,7 +2104,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_nextrowstrainprogram_enabled",
@@ -2006,12 +2118,13 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_nextrowstrainprogram_order",
       "name": "order index",
-      "description": "Displays the next Peloton interval with duration and FTP Zone (in Power Zone classes) or Peloton Resistance (non\u2013Power Zone classes).",
+      "description": "Displays the next Peloton interval with duration and FTP Zone (in Power Zone classes) or Peloton Resistance (non–Power Zone classes).",
       "parent": "tile_nextrowstrainprogram_enabled",
       "type": "integer",
       "qmlType": "int",
@@ -2022,7 +2135,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_mets_enabled",
@@ -2035,7 +2149,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_mets_order",
@@ -2051,7 +2166,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_targetmets_enabled",
@@ -2064,7 +2180,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_targetmets_order",
@@ -2080,7 +2197,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_steering_angle_enabled",
@@ -2093,7 +2211,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_steering_angle_order",
@@ -2109,7 +2228,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_pid_hr_enabled",
@@ -2122,12 +2242,13 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_pid_hr_order",
       "name": "order index",
-      "description": "Use this tile to display the target heart rate zone in which you\u2019ve chosen to work out in Settings > Training Program Options.",
+      "description": "Use this tile to display the target heart rate zone in which you’ve chosen to work out in Settings > Training Program Options.",
       "parent": "tile_pid_hr_enabled",
       "type": "integer",
       "qmlType": "int",
@@ -2138,7 +2259,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "heart_rate_zone1",
@@ -2151,7 +2273,8 @@
       "visible": true,
       "defaultValue": 70.0,
       "defaultExpression": "70.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "heart_rate_zone2",
@@ -2164,7 +2287,8 @@
       "visible": true,
       "defaultValue": 80.0,
       "defaultExpression": "80.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "heart_rate_zone3",
@@ -2177,7 +2301,8 @@
       "visible": true,
       "defaultValue": 90.0,
       "defaultExpression": "90.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "heart_rate_zone4",
@@ -2190,7 +2315,8 @@
       "visible": true,
       "defaultValue": 100.0,
       "defaultExpression": "100.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "heart_max_override_enable",
@@ -2203,7 +2329,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "heart_max_override_value",
@@ -2216,7 +2343,8 @@
       "visible": true,
       "defaultValue": 195.0,
       "defaultExpression": "195.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "heart_rate_resting",
@@ -2229,7 +2357,8 @@
       "visible": true,
       "defaultValue": 60,
       "defaultExpression": "60",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "peloton_gain",
@@ -2242,12 +2371,13 @@
       "visible": true,
       "defaultValue": 1.0,
       "defaultExpression": "1.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "peloton_offset",
       "name": "Conversion Offset",
-      "description": "Increases the resistance that QZ displays in the Peloton Resistance tile. If QZ\u2019s calculated conversion from your bike\u2019s resistance scale to Peloton\u2019s seems too low, the number you enter here will be added to the calculated resistance without increasing your effort or actual resistance. (Example: If QZ displays Peloton resistance of 30 and you enter 5, QZ will display 35.)",
+      "description": "Increases the resistance that QZ displays in the Peloton Resistance tile. If QZ’s calculated conversion from your bike’s resistance scale to Peloton’s seems too low, the number you enter here will be added to the calculated resistance without increasing your effort or actual resistance. (Example: If QZ displays Peloton resistance of 30 and you enter 5, QZ will display 35.)",
       "parent": "Peloton Options",
       "type": "number",
       "qmlType": "real",
@@ -2255,12 +2385,13 @@
       "visible": true,
       "defaultValue": 0.0,
       "defaultExpression": "0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "treadmill_pid_heart_zone",
       "name": "PID on Heart Zone",
-      "description": "QZ controls your treadmill or bike to keep you within a chosen Heart Rate Zone. Turn on, set a target heart rate (HR) zone in which to train and click OK. For example, enter 2 to train in HR zone 2 and the treadmill will auto adjust the speed (or resistance on a bike) to maintain your heart rate in zone 2. QZ gradually increases or decreases your speed (or bike resistance) in small increments every 40 seconds to reach and maintain your target HR zone. During a workout, you can display and use the \u2018+\u2019 and \u2018-\u2019 button on the PID HR Zone tile to change the target HR zone.",
+      "description": "QZ controls your treadmill or bike to keep you within a chosen Heart Rate Zone. Turn on, set a target heart rate (HR) zone in which to train and click OK. For example, enter 2 to train in HR zone 2 and the treadmill will auto adjust the speed (or resistance on a bike) to maintain your heart rate in zone 2. QZ gradually increases or decreases your speed (or bike resistance) in small increments every 40 seconds to reach and maintain your target HR zone. During a workout, you can display and use the ‘+’ and ‘-’ button on the PID HR Zone tile to change the target HR zone.",
       "parent": "Training Program Options",
       "type": "string",
       "qmlType": "string",
@@ -2278,12 +2409,13 @@
           "4",
           "5"
         ]
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "pacef_1mile",
       "name": "1 mile pace (total time)",
-      "description": "Enter your 1 mile time goal, click OK. This setting will be used when you\u2019re following a training program with the speed control. These settings should also match the Zwift app settings. More info: https://github.com/cagnulein/qdomyos-zwift/issues/609.",
+      "description": "Enter your 1 mile time goal, click OK. This setting will be used when you’re following a training program with the speed control. These settings should also match the Zwift app settings. More info: https://github.com/cagnulein/qdomyos-zwift/issues/609.",
       "parent": "Training Program Options",
       "type": "number",
       "qmlType": "real",
@@ -2291,7 +2423,8 @@
       "visible": true,
       "defaultValue": 250.0,
       "defaultExpression": "250",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "pacef_5km",
@@ -2304,7 +2437,8 @@
       "visible": true,
       "defaultValue": 300.0,
       "defaultExpression": "300",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "pacef_10km",
@@ -2317,7 +2451,8 @@
       "visible": true,
       "defaultValue": 320.0,
       "defaultExpression": "320",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "pacef_halfmarathon",
@@ -2330,7 +2465,8 @@
       "visible": true,
       "defaultValue": 340.0,
       "defaultExpression": "340",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "pacef_marathon",
@@ -2343,7 +2479,8 @@
       "visible": true,
       "defaultValue": 360.0,
       "defaultExpression": "360",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "pace_default",
@@ -2365,7 +2502,8 @@
           "Half Marathon",
           "Marathon"
         ]
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "domyos_treadmill_buttons",
@@ -2378,7 +2516,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "domyos_treadmill_distance_display",
@@ -2391,7 +2530,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "domyos_treadmill_display_invert",
@@ -2404,7 +2544,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "domyos_bike_cadence_filter",
@@ -2417,7 +2558,8 @@
       "visible": true,
       "defaultValue": 0.0,
       "defaultExpression": "0.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "domyos_bike_display_calories",
@@ -2430,7 +2572,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "domyos_elliptical_speed_ratio",
@@ -2443,7 +2586,8 @@
       "visible": true,
       "defaultValue": 1.0,
       "defaultExpression": "1.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "eslinker_cadenza",
@@ -2456,7 +2600,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "echelon_watttable",
@@ -2475,7 +2620,8 @@
           "Echelon",
           "mgarcea"
         ]
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "proform_wheel_ratio",
@@ -2488,7 +2634,8 @@
       "visible": true,
       "defaultValue": 0.33,
       "defaultExpression": "0.33",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "proform_tour_de_france_clc",
@@ -2502,7 +2649,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_bike_model"
+      "virtualParent": "nordictrack_bike_model",
+      "restartRequired": true
     },
     {
       "key": "proform_tdf_jonseed_watt",
@@ -2515,7 +2663,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "proform_studio",
@@ -2529,7 +2678,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_bike_model"
+      "virtualParent": "nordictrack_bike_model",
+      "restartRequired": true
     },
     {
       "key": "proform_tdf_10",
@@ -2543,7 +2693,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_bike_model"
+      "virtualParent": "nordictrack_bike_model",
+      "restartRequired": true
     },
     {
       "key": "horizon_gr7_cadence_multiplier",
@@ -2556,7 +2707,8 @@
       "visible": true,
       "defaultValue": 1.0,
       "defaultExpression": "1.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "fitshow_user_id",
@@ -2569,7 +2721,8 @@
       "visible": true,
       "defaultValue": 5034,
       "defaultExpression": "0x13AA",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "inspire_peloton_formula",
@@ -2582,7 +2735,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "inspire_peloton_formula2",
@@ -2595,7 +2749,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "hammer_racer_s",
@@ -2608,7 +2763,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "pafers_treadmill",
@@ -2621,7 +2777,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "yesoul_peloton_formula",
@@ -2634,7 +2791,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "nordictrack_10_treadmill",
@@ -2648,7 +2806,8 @@
       "defaultValue": true,
       "defaultExpression": "true",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "nordictrack_t65s_treadmill",
@@ -2662,7 +2821,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "toorx_3_0",
@@ -2675,7 +2835,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "toorx_65s_evo",
@@ -2688,7 +2849,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "jtx_fitness_sprint_treadmill",
@@ -2701,7 +2863,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "dkn_endurun_treadmill",
@@ -2714,7 +2877,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "trx_route_key",
@@ -2727,7 +2891,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "bh_spada_2",
@@ -2740,7 +2905,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "toorx_bike",
@@ -2753,7 +2919,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "toorx_ftms",
@@ -2766,7 +2933,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "jll_IC400_bike",
@@ -2779,7 +2947,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "fytter_ri08_bike",
@@ -2792,7 +2961,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "asviva_bike",
@@ -2805,7 +2975,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "hertz_xr_770",
@@ -2818,7 +2989,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "m3i_bike_id",
@@ -2831,7 +3003,8 @@
       "visible": true,
       "defaultValue": 256,
       "defaultExpression": "256",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "m3i_bike_speed_buffsize",
@@ -2844,7 +3017,8 @@
       "visible": true,
       "defaultValue": 90,
       "defaultExpression": "90",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "m3i_bike_qt_search",
@@ -2857,7 +3031,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "m3i_bike_kcal",
@@ -2870,7 +3045,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "snode_bike",
@@ -2883,7 +3059,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "fitplus_bike",
@@ -2896,7 +3073,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "virtufit_etappe",
@@ -2909,7 +3087,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "flywheel_filter",
@@ -2922,7 +3101,8 @@
       "visible": true,
       "defaultValue": 2,
       "defaultExpression": "2",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "flywheel_life_fitness_ic8",
@@ -2935,7 +3115,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "sole_treadmill_inclination",
@@ -2948,7 +3129,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "sole_treadmill_miles",
@@ -2961,7 +3143,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "sole_treadmill_f65",
@@ -2974,7 +3157,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "sole_treadmill_f63",
@@ -2987,7 +3171,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "sole_treadmill_tt8",
@@ -3000,7 +3185,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "schwinn_bike_resistance",
@@ -3013,7 +3199,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "schwinn_bike_resistance_v2",
@@ -3026,7 +3213,8 @@
       "visible": true,
       "defaultValue": null,
       "defaultExpression": "value",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "technogym_myrun_treadmill_experimental",
@@ -3039,7 +3227,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "trainprogram_random",
@@ -3052,7 +3241,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "trainprogram_total",
@@ -3065,7 +3255,8 @@
       "visible": true,
       "defaultValue": 60,
       "defaultExpression": "60",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "trainprogram_period_seconds",
@@ -3078,7 +3269,8 @@
       "visible": true,
       "defaultValue": 60.0,
       "defaultExpression": "60",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "trainprogram_speed_min",
@@ -3091,7 +3283,8 @@
       "visible": true,
       "defaultValue": 8.0,
       "defaultExpression": "8",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "trainprogram_speed_max",
@@ -3104,7 +3297,8 @@
       "visible": true,
       "defaultValue": 16.0,
       "defaultExpression": "16",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "trainprogram_incline_min",
@@ -3117,7 +3311,8 @@
       "visible": true,
       "defaultValue": 0.0,
       "defaultExpression": "0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "trainprogram_incline_max",
@@ -3130,7 +3325,8 @@
       "visible": true,
       "defaultValue": 15.0,
       "defaultExpression": "15",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "trainprogram_resistance_min",
@@ -3143,7 +3339,8 @@
       "visible": true,
       "defaultValue": 1.0,
       "defaultExpression": "1",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "trainprogram_resistance_max",
@@ -3156,7 +3353,8 @@
       "visible": true,
       "defaultValue": 32.0,
       "defaultExpression": "32",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "watt_offset",
@@ -3169,7 +3367,8 @@
       "visible": true,
       "defaultValue": 0.0,
       "defaultExpression": "0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "watt_gain",
@@ -3182,7 +3381,8 @@
       "visible": true,
       "defaultValue": 1.0,
       "defaultExpression": "1",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "power_avg_5s",
@@ -3191,7 +3391,7 @@
       "parent": "Advanced Settings",
       "type": "boolean",
       "qmlType": "bool",
-      "control": "select",
+      "control": "switch",
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
@@ -3202,7 +3402,8 @@
           "3 seconds",
           "5 seconds"
         ]
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "instant_power_on_pause",
@@ -3215,7 +3416,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "speed_offset",
@@ -3228,7 +3430,8 @@
       "visible": true,
       "defaultValue": 0.0,
       "defaultExpression": "0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "speed_gain",
@@ -3241,12 +3444,13 @@
       "visible": true,
       "defaultValue": 1.0,
       "defaultExpression": "1",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "filter_device",
       "name": "Manual Device",
-      "description": "Allows you to force QZ to connect to your equipment (see \u201cBluetooth Troubleshooting\u201d below). Default is \u201cDisabled.\u201d",
+      "description": "Allows you to force QZ to connect to your equipment (see “Bluetooth Troubleshooting” below). Default is “Disabled.”",
       "parent": "Advanced Settings",
       "type": "string",
       "qmlType": "string",
@@ -3257,12 +3461,13 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.bluetoothDevices"
-      }
+      },
+      "restartRequired": true
     },
     {
       "key": "strava_suffix",
       "name": "Suffix activity",
-      "description": "Default is \u201cQZ.\u201d Please leave this set to default so that other Strava users will see the QZ; a tiny bit of advertising that helps promote the app and support its development. If you choose to remove it, please consider contributing to the developer\u2019s Patreon or Buy Me a Coffee accounts or just subscribe to the Swag bag in the left side bar to allow me to continue developing and supporting the app.",
+      "description": "Default is “QZ.” Please leave this set to default so that other Strava users will see the QZ; a tiny bit of advertising that helps promote the app and support its development. If you choose to remove it, please consider contributing to the developer’s Patreon or Buy Me a Coffee accounts or just subscribe to the Swag bag in the left side bar to allow me to continue developing and supporting the app.",
       "parent": "Advanced Settings",
       "type": "string",
       "qmlType": "string",
@@ -3270,7 +3475,8 @@
       "visible": true,
       "defaultValue": "#QZ",
       "defaultExpression": "\"#QZ\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "cadence_sensor_name",
@@ -3286,7 +3492,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.bluetoothDevices"
-      }
+      },
+      "restartRequired": true
     },
     {
       "key": "cadence_sensor_as_bike",
@@ -3299,7 +3506,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "cadence_sensor_speed_ratio",
@@ -3312,7 +3520,8 @@
       "visible": true,
       "defaultValue": 0.33,
       "defaultExpression": "0.33",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "power_hr_pwr1",
@@ -3325,7 +3534,8 @@
       "visible": true,
       "defaultValue": 200.0,
       "defaultExpression": "200",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "power_hr_hr1",
@@ -3338,7 +3548,8 @@
       "visible": true,
       "defaultValue": 150.0,
       "defaultExpression": "150",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "power_hr_pwr2",
@@ -3351,7 +3562,8 @@
       "visible": true,
       "defaultValue": 230.0,
       "defaultExpression": "230",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "power_hr_hr2",
@@ -3364,7 +3576,8 @@
       "visible": true,
       "defaultValue": 170.0,
       "defaultExpression": "170",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "power_sensor_name",
@@ -3380,12 +3593,13 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.bluetoothDevices"
-      }
+      },
+      "restartRequired": true
     },
     {
       "key": "power_sensor_as_bike",
       "name": "Power Sensor as a Bike",
-      "description": "If your bike doesn\u2019t have Bluetooth, this setting allows you to use a power meter pedal sensor so your bike will work with QZ. Default is off.",
+      "description": "If your bike doesn’t have Bluetooth, this setting allows you to use a power meter pedal sensor so your bike will work with QZ. Default is off.",
       "parent": "Power Sensor Options",
       "type": "boolean",
       "qmlType": "bool",
@@ -3393,12 +3607,13 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "power_sensor_as_treadmill",
       "name": "Power Sensor as a Treadmill",
-      "description": "If your treadmill doesn\u2019t have Bluetooth, this setting allows you to use a Stryde sensor (or similar) so your treadmill will work with QZ. Default is off.",
+      "description": "If your treadmill doesn’t have Bluetooth, this setting allows you to use a Stryde sensor (or similar) so your treadmill will work with QZ. Default is off.",
       "parent": "Power Sensor Options",
       "type": "boolean",
       "qmlType": "bool",
@@ -3406,7 +3621,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "powr_sensor_running_cadence_double",
@@ -3419,7 +3635,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "elite_rizer_name",
@@ -3435,7 +3652,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.bluetoothDevices"
-      }
+      },
+      "restartRequired": true
     },
     {
       "key": "elite_sterzo_smart_name",
@@ -3451,7 +3669,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.bluetoothDevices"
-      }
+      },
+      "restartRequired": true
     },
     {
       "key": "ftms_accessory_name",
@@ -3467,7 +3686,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.bluetoothDevices"
-      }
+      },
+      "restartRequired": true
     },
     {
       "key": "ss2k_shift_step",
@@ -3480,26 +3700,28 @@
       "visible": true,
       "defaultValue": 900.0,
       "defaultExpression": "900",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "fitmetria_fanfit_enable",
       "name": "Enable",
       "description": null,
-      "parent": "Fitmetria Fitfan\u2122 Options",
+      "parent": "Fitmetria Fitfan™ Options",
       "type": "boolean",
       "qmlType": "bool",
       "control": "switch",
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "fitmetria_fanfit_mode",
       "name": "Mode",
       "description": null,
-      "parent": "Fitmetria Fitfan\u2122 Options",
+      "parent": "Fitmetria Fitfan™ Options",
       "type": "string",
       "qmlType": "string",
       "control": "select",
@@ -3513,33 +3735,36 @@
           "Power",
           "Manual"
         ]
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "fitmetria_fanfit_min",
       "name": "Min. value (0-100)",
       "description": null,
-      "parent": "Fitmetria Fitfan\u2122 Options",
+      "parent": "Fitmetria Fitfan™ Options",
       "type": "number",
       "qmlType": "real",
       "control": "text",
       "visible": true,
       "defaultValue": 0.0,
       "defaultExpression": "0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "fitmetria_fanfit_max",
       "name": "Max value (0-100)",
       "description": null,
-      "parent": "Fitmetria Fitfan\u2122 Options",
+      "parent": "Fitmetria Fitfan™ Options",
       "type": "number",
       "qmlType": "real",
       "control": "text",
       "visible": true,
       "defaultValue": 100.0,
       "defaultExpression": "100",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "virtualbike_forceresistance",
@@ -3552,7 +3777,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "bluetooth_relaxed",
@@ -3565,12 +3791,13 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "bluetooth_30m_hangs",
       "name": "Bluetooth hangs after 30 m",
-      "description": "Same as \u201cRelaxed Bluetooth for mad devices\u201d. Leave off unless the Support staff asks you to turn it on. Default is off.",
+      "description": "Same as “Relaxed Bluetooth for mad devices”. Leave off unless the Support staff asks you to turn it on. Default is off.",
       "parent": "Experimental Features",
       "type": "boolean",
       "qmlType": "bool",
@@ -3578,7 +3805,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "battery_service",
@@ -3591,7 +3819,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "virtual_device_enabled",
@@ -3604,7 +3833,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "virtual_device_bluetooth",
@@ -3617,7 +3847,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "ios_peloton_workaround",
@@ -3630,7 +3861,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "android_wakelock",
@@ -3643,7 +3875,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "log_debug",
@@ -3656,7 +3889,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "virtual_device_onlyheart",
@@ -3669,7 +3903,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "virtual_device_echelon",
@@ -3682,7 +3917,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "virtual_device_ifit",
@@ -3695,7 +3931,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "virtual_device_rower",
@@ -3708,7 +3945,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "virtual_device_force_bike",
@@ -3721,7 +3959,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "volume_change_gears",
@@ -3734,12 +3973,13 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "applewatch_fakedevice",
       "name": "Fake Device",
-      "description": "Simulates QZ being connected to a bike. When this is turned on QZ will calculate KCal based on your heart rate. Examples of when to use this setting: \u25cb To capture Peloton class data for classes without connected equipment (e.g., a strength or yoga workout).. \u25cb To arrange tiles on the QZ dashboard without connecting to your equipment. \u25cb To use the QZ Apple Watch app without connecting to your equipment.",
+      "description": "Simulates QZ being connected to a bike. When this is turned on QZ will calculate KCal based on your heart rate. Examples of when to use this setting: ○ To capture Peloton class data for classes without connected equipment (e.g., a strength or yoga workout).. ○ To arrange tiles on the QZ dashboard without connecting to your equipment. ○ To use the QZ Apple Watch app without connecting to your equipment.",
       "parent": "Experimental Features",
       "type": "boolean",
       "qmlType": "bool",
@@ -3747,7 +3987,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "zwift_erg_resistance_down",
@@ -3760,7 +4001,8 @@
       "visible": true,
       "defaultValue": 0.0,
       "defaultExpression": "0.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "zwift_erg_resistance_up",
@@ -3773,7 +4015,8 @@
       "visible": true,
       "defaultValue": 999.0,
       "defaultExpression": "999.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "horizon_paragon_x",
@@ -3786,7 +4029,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "treadmill_step_speed",
@@ -3799,7 +4043,8 @@
       "visible": true,
       "defaultValue": 0.5,
       "defaultExpression": "0.5",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "treadmill_step_incline",
@@ -3812,7 +4057,8 @@
       "visible": true,
       "defaultValue": 0.5,
       "defaultExpression": "0.5",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "fitshow_anyrun",
@@ -3825,7 +4071,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "nordictrack_s30_treadmill",
@@ -3839,7 +4086,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "nordictrack_fs5i_treadmill",
@@ -3852,7 +4100,8 @@
       "visible": false,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "renpho_peloton_conversion_v2",
@@ -3865,7 +4114,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "ss2k_resistance_sample_1",
@@ -3878,7 +4128,8 @@
       "visible": true,
       "defaultValue": 20.0,
       "defaultExpression": "20",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "ss2k_shift_step_sample_1",
@@ -3891,7 +4142,8 @@
       "visible": true,
       "defaultValue": 0.0,
       "defaultExpression": "0",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "ss2k_resistance_sample_2",
@@ -3904,7 +4156,8 @@
       "visible": true,
       "defaultValue": 30.0,
       "defaultExpression": "30",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "ss2k_shift_step_sample_2",
@@ -3917,7 +4170,8 @@
       "visible": true,
       "defaultValue": 0.0,
       "defaultExpression": "0",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "ss2k_resistance_sample_3",
@@ -3930,7 +4184,8 @@
       "visible": true,
       "defaultValue": 40.0,
       "defaultExpression": "40",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "ss2k_shift_step_sample_3",
@@ -3943,7 +4198,8 @@
       "visible": true,
       "defaultValue": 0.0,
       "defaultExpression": "0",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "ss2k_resistance_sample_4",
@@ -3956,7 +4212,8 @@
       "visible": true,
       "defaultValue": 50.0,
       "defaultExpression": "50",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "ss2k_shift_step_sample_4",
@@ -3969,7 +4226,8 @@
       "visible": true,
       "defaultValue": 0.0,
       "defaultExpression": "0",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "fitshow_truetimer",
@@ -3982,7 +4240,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "elite_rizer_gain",
@@ -3995,7 +4254,8 @@
       "visible": true,
       "defaultValue": 1.0,
       "defaultExpression": "1.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_ext_incline_enabled",
@@ -4008,7 +4268,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_ext_incline_order",
@@ -4024,7 +4285,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "reebok_fr30_treadmill",
@@ -4037,7 +4299,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "horizon_treadmill_7_8",
@@ -4050,7 +4313,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "profile_name",
@@ -4063,7 +4327,8 @@
       "visible": false,
       "defaultValue": "default",
       "defaultExpression": "\"default\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_cadence_color_enabled",
@@ -4076,7 +4341,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_watt_color_enabled",
@@ -4089,7 +4355,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_pace_color_enabled",
@@ -4102,7 +4369,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_peloton_remaining_enabled",
@@ -4115,7 +4383,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_peloton_remaining_order",
@@ -4131,7 +4400,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_peloton_resistance_color_enabled",
@@ -4144,7 +4414,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "dircon_yes",
@@ -4157,7 +4428,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "dircon_server_base_port",
@@ -4170,7 +4442,8 @@
       "visible": true,
       "defaultValue": 36866,
       "defaultExpression": "36866",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "ios_cache_heart_device",
@@ -4183,7 +4456,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "app_opening",
@@ -4196,7 +4470,8 @@
       "visible": false,
       "defaultValue": 0,
       "defaultExpression": "0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "proformtdf4ip",
@@ -4209,7 +4484,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "fitfiu_mc_v460",
@@ -4222,7 +4498,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "bike_weight",
@@ -4235,7 +4512,8 @@
       "visible": true,
       "defaultValue": 0.0,
       "defaultExpression": "0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "kingsmith_encrypt_v2",
@@ -4248,7 +4526,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "proform_treadmill_9_0",
@@ -4262,7 +4541,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "proform_treadmill_1800i",
@@ -4276,7 +4556,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "cadence_offset",
@@ -4289,7 +4570,8 @@
       "visible": true,
       "defaultValue": 0.0,
       "defaultExpression": "0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "cadence_gain",
@@ -4302,7 +4584,8 @@
       "visible": true,
       "defaultValue": 1.0,
       "defaultExpression": "1",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "sp_ht_9600ie",
@@ -4315,7 +4598,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "tts_enabled",
@@ -4328,7 +4612,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tts_summary_sec",
@@ -4341,7 +4626,8 @@
       "visible": true,
       "defaultValue": 120,
       "defaultExpression": "120",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tts_act_speed",
@@ -4354,7 +4640,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tts_avg_speed",
@@ -4367,7 +4654,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tts_max_speed",
@@ -4380,7 +4668,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tts_act_inclination",
@@ -4393,7 +4682,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tts_act_cadence",
@@ -4406,7 +4696,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tts_avg_cadence",
@@ -4419,7 +4710,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tts_max_cadence",
@@ -4432,7 +4724,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tts_act_elevation",
@@ -4445,7 +4738,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tts_act_calories",
@@ -4458,7 +4752,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tts_act_odometer",
@@ -4471,7 +4766,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tts_act_pace",
@@ -4484,7 +4780,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tts_avg_pace",
@@ -4497,7 +4794,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tts_max_pace",
@@ -4510,7 +4808,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tts_act_resistance",
@@ -4523,7 +4822,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tts_avg_resistance",
@@ -4536,7 +4836,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tts_max_resistance",
@@ -4549,7 +4850,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tts_act_watt",
@@ -4562,7 +4864,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tts_avg_watt",
@@ -4575,7 +4878,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tts_max_watt",
@@ -4588,7 +4892,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tts_act_ftp",
@@ -4615,7 +4920,8 @@
           "defaultExpression": "true",
           "defaultValue": true
         }
-      ]
+      ],
+      "restartRequired": false
     },
     {
       "key": "tts_avg_ftp",
@@ -4628,7 +4934,8 @@
       "visible": false,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tts_max_ftp",
@@ -4641,7 +4948,8 @@
       "visible": false,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tts_act_heart",
@@ -4654,7 +4962,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tts_avg_heart",
@@ -4667,7 +4976,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tts_max_heart",
@@ -4680,7 +4990,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tts_act_jouls",
@@ -4693,7 +5004,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tts_act_elapsed",
@@ -4706,7 +5018,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tts_act_peloton_resistance",
@@ -4719,7 +5032,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tts_avg_peloton_resistance",
@@ -4732,7 +5046,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tts_max_peloton_resistance",
@@ -4745,7 +5060,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tts_act_target_peloton_resistance",
@@ -4758,7 +5074,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tts_act_target_cadence",
@@ -4771,7 +5088,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tts_act_target_power",
@@ -4784,7 +5102,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tts_act_target_zone",
@@ -4797,7 +5116,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tts_act_target_speed",
@@ -4810,7 +5130,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tts_act_target_incline",
@@ -4823,7 +5144,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tts_act_watt_kg",
@@ -4836,7 +5158,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tts_avg_watt_kg",
@@ -4849,7 +5172,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tts_max_watt_kg",
@@ -4862,7 +5186,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "fakedevice_elliptical",
@@ -4875,7 +5200,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "nordictrack_2950_ip",
@@ -4888,7 +5214,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "tile_instantaneous_stride_length_enabled",
@@ -4901,7 +5228,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_instantaneous_stride_length_order",
@@ -4917,7 +5245,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_ground_contact_enabled",
@@ -4930,7 +5259,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_ground_contact_order",
@@ -4946,7 +5276,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_vertical_oscillation_enabled",
@@ -4959,7 +5290,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_vertical_oscillation_order",
@@ -4975,7 +5307,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "sex",
@@ -4994,13 +5327,14 @@
           "Male",
           "Female"
         ]
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "maps_type",
       "name": "Maps Type",
       "description": null,
-      "parent": "Maps \ud83d\uddfa\ufe0f",
+      "parent": "Maps 🗺️",
       "type": "string",
       "qmlType": "string",
       "control": "select",
@@ -5013,7 +5347,8 @@
           "2D",
           "3D"
         ]
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "ss2k_max_resistance",
@@ -5026,7 +5361,8 @@
       "visible": true,
       "defaultValue": 100.0,
       "defaultExpression": "100",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "ss2k_min_resistance",
@@ -5039,7 +5375,8 @@
       "visible": true,
       "defaultValue": 0.0,
       "defaultExpression": "0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "proform_treadmill_se",
@@ -5053,7 +5390,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "proformtreadmillip",
@@ -5066,7 +5404,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "kingsmith_encrypt_v3",
@@ -5079,7 +5418,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "tdf_10_ip",
@@ -5092,7 +5432,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "fakedevice_treadmill",
@@ -5105,7 +5446,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "video_playback_window_s",
@@ -5118,7 +5460,8 @@
       "visible": false,
       "defaultValue": 12,
       "defaultExpression": "12",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "horizon_treadmill_profile_user1",
@@ -5131,7 +5474,8 @@
       "visible": true,
       "defaultValue": "user1",
       "defaultExpression": "\"user1\"",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "horizon_treadmill_profile_user2",
@@ -5144,7 +5488,8 @@
       "visible": true,
       "defaultValue": "user2",
       "defaultExpression": "\"user2\"",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "horizon_treadmill_profile_user3",
@@ -5157,7 +5502,8 @@
       "visible": true,
       "defaultValue": "user3",
       "defaultExpression": "\"user3\"",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "horizon_treadmill_profile_user4",
@@ -5170,7 +5516,8 @@
       "visible": true,
       "defaultValue": "user4",
       "defaultExpression": "\"user4\"",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "horizon_treadmill_profile_user5",
@@ -5183,7 +5530,8 @@
       "visible": true,
       "defaultValue": "user5",
       "defaultExpression": "\"user5\"",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "nordictrack_gx_2_7",
@@ -5197,7 +5545,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_bike_model"
+      "virtualParent": "nordictrack_bike_model",
+      "restartRequired": true
     },
     {
       "key": "rolling_resistance",
@@ -5210,7 +5559,8 @@
       "visible": true,
       "defaultValue": 0.005,
       "defaultExpression": "0.005",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "eslinker_ypoo",
@@ -5223,7 +5573,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "wahoo_rgt_dircon",
@@ -5236,7 +5587,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "tts_description_enabled",
@@ -5249,7 +5601,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_resistance_1_enabled",
@@ -5262,7 +5615,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_resistance_1_order",
@@ -5278,7 +5632,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_preset_resistance_1_value",
@@ -5291,7 +5646,8 @@
       "visible": true,
       "defaultValue": 1.0,
       "defaultExpression": "1.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_resistance_1_label",
@@ -5304,7 +5660,8 @@
       "visible": true,
       "defaultValue": "Res. 1",
       "defaultExpression": "\"Res. 1\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_resistance_2_enabled",
@@ -5317,7 +5674,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_resistance_2_order",
@@ -5333,7 +5691,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_preset_resistance_2_value",
@@ -5346,7 +5705,8 @@
       "visible": true,
       "defaultValue": 10.0,
       "defaultExpression": "10.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_resistance_2_label",
@@ -5359,7 +5719,8 @@
       "visible": true,
       "defaultValue": "Res. 10",
       "defaultExpression": "\"Res. 10\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_resistance_3_enabled",
@@ -5372,7 +5733,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_resistance_3_order",
@@ -5388,7 +5750,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_preset_resistance_3_value",
@@ -5401,7 +5764,8 @@
       "visible": true,
       "defaultValue": 20.0,
       "defaultExpression": "20.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_resistance_3_label",
@@ -5414,7 +5778,8 @@
       "visible": true,
       "defaultValue": "Res. 20",
       "defaultExpression": "\"Res. 20\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_resistance_4_enabled",
@@ -5427,7 +5792,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_resistance_4_order",
@@ -5443,7 +5809,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_preset_resistance_4_value",
@@ -5456,7 +5823,8 @@
       "visible": true,
       "defaultValue": 25.0,
       "defaultExpression": "25.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_resistance_4_label",
@@ -5469,7 +5837,8 @@
       "visible": true,
       "defaultValue": "Res. 25",
       "defaultExpression": "\"Res. 25\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_resistance_5_enabled",
@@ -5482,7 +5851,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_resistance_5_order",
@@ -5498,7 +5868,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_preset_resistance_5_value",
@@ -5511,7 +5882,8 @@
       "visible": true,
       "defaultValue": 30.0,
       "defaultExpression": "30.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_resistance_5_label",
@@ -5524,7 +5896,8 @@
       "visible": true,
       "defaultValue": "Res. 30",
       "defaultExpression": "\"Res. 30\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_speed_1_enabled",
@@ -5537,7 +5910,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_speed_1_order",
@@ -5553,7 +5927,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_preset_speed_1_value",
@@ -5566,7 +5941,8 @@
       "visible": true,
       "defaultValue": 5.0,
       "defaultExpression": "5.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_speed_1_label",
@@ -5579,7 +5955,8 @@
       "visible": true,
       "defaultValue": "5 km/h",
       "defaultExpression": "\"5 km/h\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_speed_2_enabled",
@@ -5592,7 +5969,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_speed_2_order",
@@ -5608,7 +5986,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_preset_speed_2_value",
@@ -5621,7 +6000,8 @@
       "visible": true,
       "defaultValue": 7.0,
       "defaultExpression": "7.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_speed_2_label",
@@ -5634,7 +6014,8 @@
       "visible": true,
       "defaultValue": "7 km/h",
       "defaultExpression": "\"7 km/h\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_speed_3_enabled",
@@ -5647,7 +6028,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_speed_3_order",
@@ -5663,7 +6045,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_preset_speed_3_value",
@@ -5676,7 +6059,8 @@
       "visible": true,
       "defaultValue": 10.0,
       "defaultExpression": "10.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_speed_3_label",
@@ -5689,7 +6073,8 @@
       "visible": true,
       "defaultValue": "10 km/h",
       "defaultExpression": "\"10 km/h\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_speed_4_enabled",
@@ -5702,7 +6087,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_speed_4_order",
@@ -5718,7 +6104,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_preset_speed_4_value",
@@ -5731,7 +6118,8 @@
       "visible": true,
       "defaultValue": 11.0,
       "defaultExpression": "11.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_speed_4_label",
@@ -5744,7 +6132,8 @@
       "visible": true,
       "defaultValue": "11 km/h",
       "defaultExpression": "\"11 km/h\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_speed_5_enabled",
@@ -5757,7 +6146,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_speed_5_order",
@@ -5773,7 +6163,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_preset_speed_5_value",
@@ -5786,7 +6177,8 @@
       "visible": true,
       "defaultValue": 12.0,
       "defaultExpression": "12.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_speed_5_label",
@@ -5799,7 +6191,8 @@
       "visible": true,
       "defaultValue": "12 km/h",
       "defaultExpression": "\"12 km/h\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_inclination_1_enabled",
@@ -5812,7 +6205,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_inclination_1_order",
@@ -5828,7 +6222,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_preset_inclination_1_value",
@@ -5841,7 +6236,8 @@
       "visible": true,
       "defaultValue": 0.0,
       "defaultExpression": "0.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_inclination_1_label",
@@ -5854,7 +6250,8 @@
       "visible": true,
       "defaultValue": "0%",
       "defaultExpression": "\"0%\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_inclination_2_enabled",
@@ -5867,7 +6264,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_inclination_2_order",
@@ -5883,7 +6281,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_preset_inclination_2_value",
@@ -5896,7 +6295,8 @@
       "visible": true,
       "defaultValue": 1.0,
       "defaultExpression": "1.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_inclination_2_label",
@@ -5909,7 +6309,8 @@
       "visible": true,
       "defaultValue": "1%",
       "defaultExpression": "\"1%\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_inclination_3_enabled",
@@ -5922,7 +6323,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_inclination_3_order",
@@ -5938,7 +6340,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_preset_inclination_3_value",
@@ -5951,7 +6354,8 @@
       "visible": true,
       "defaultValue": 2.0,
       "defaultExpression": "2.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_inclination_3_label",
@@ -5964,7 +6368,8 @@
       "visible": true,
       "defaultValue": "2%",
       "defaultExpression": "\"2%\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_inclination_4_enabled",
@@ -5977,7 +6382,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_inclination_4_order",
@@ -5993,7 +6399,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_preset_inclination_4_value",
@@ -6006,7 +6413,8 @@
       "visible": true,
       "defaultValue": 3.0,
       "defaultExpression": "3.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_inclination_4_label",
@@ -6019,7 +6427,8 @@
       "visible": true,
       "defaultValue": "3%",
       "defaultExpression": "\"3%\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_inclination_5_enabled",
@@ -6032,7 +6441,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_inclination_5_order",
@@ -6048,7 +6458,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_preset_inclination_5_value",
@@ -6061,7 +6472,8 @@
       "visible": true,
       "defaultValue": 4.0,
       "defaultExpression": "4.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_inclination_5_label",
@@ -6074,7 +6486,8 @@
       "visible": true,
       "defaultValue": "4%",
       "defaultExpression": "\"4%\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_resistance_1_color",
@@ -6087,7 +6500,8 @@
       "visible": true,
       "defaultValue": "grey",
       "defaultExpression": "\"grey\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_resistance_2_color",
@@ -6100,7 +6514,8 @@
       "visible": true,
       "defaultValue": "grey",
       "defaultExpression": "\"grey\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_resistance_3_color",
@@ -6113,7 +6528,8 @@
       "visible": true,
       "defaultValue": "grey",
       "defaultExpression": "\"grey\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_resistance_4_color",
@@ -6126,7 +6542,8 @@
       "visible": true,
       "defaultValue": "grey",
       "defaultExpression": "\"grey\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_resistance_5_color",
@@ -6139,7 +6556,8 @@
       "visible": true,
       "defaultValue": "grey",
       "defaultExpression": "\"grey\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_speed_1_color",
@@ -6152,7 +6570,8 @@
       "visible": true,
       "defaultValue": "grey",
       "defaultExpression": "\"grey\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_speed_2_color",
@@ -6165,7 +6584,8 @@
       "visible": true,
       "defaultValue": "grey",
       "defaultExpression": "\"grey\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_speed_3_color",
@@ -6178,7 +6598,8 @@
       "visible": true,
       "defaultValue": "grey",
       "defaultExpression": "\"grey\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_speed_4_color",
@@ -6191,7 +6612,8 @@
       "visible": true,
       "defaultValue": "grey",
       "defaultExpression": "\"grey\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_speed_5_color",
@@ -6204,7 +6626,8 @@
       "visible": true,
       "defaultValue": "grey",
       "defaultExpression": "\"grey\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_inclination_1_color",
@@ -6217,7 +6640,8 @@
       "visible": true,
       "defaultValue": "grey",
       "defaultExpression": "\"grey\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_inclination_2_color",
@@ -6230,7 +6654,8 @@
       "visible": true,
       "defaultValue": "grey",
       "defaultExpression": "\"grey\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_inclination_3_color",
@@ -6243,7 +6668,8 @@
       "visible": true,
       "defaultValue": "grey",
       "defaultExpression": "\"grey\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_inclination_4_color",
@@ -6256,7 +6682,8 @@
       "visible": true,
       "defaultValue": "grey",
       "defaultExpression": "\"grey\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_inclination_5_color",
@@ -6269,7 +6696,8 @@
       "visible": true,
       "defaultValue": "grey",
       "defaultExpression": "\"grey\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_avg_watt_lap_enabled",
@@ -6282,7 +6710,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_avg_watt_lap_order",
@@ -6298,7 +6727,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "nordictrack_t70_treadmill",
@@ -6312,7 +6742,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "crrGain",
@@ -6325,7 +6756,8 @@
       "visible": true,
       "defaultValue": 0.0,
       "defaultExpression": "0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "cwGain",
@@ -6338,7 +6770,8 @@
       "visible": true,
       "defaultValue": 0.0,
       "defaultExpression": "0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "proform_treadmill_cadence_lt",
@@ -6352,7 +6785,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "trainprogram_stop_at_end",
@@ -6365,7 +6799,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "domyos_elliptical_inclination",
@@ -6378,20 +6813,22 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "gpx_loop",
       "name": "Loop Start-End-Start",
       "description": null,
-      "parent": "Maps \ud83d\uddfa\ufe0f",
+      "parent": "Maps 🗺️",
       "type": "boolean",
       "qmlType": "bool",
       "control": "switch",
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "android_notification",
@@ -6404,7 +6841,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "kingsmith_encrypt_v4",
@@ -6417,7 +6855,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "horizon_treadmill_disable_pause",
@@ -6430,7 +6869,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "domyos_bike_500_profile_v1",
@@ -6443,7 +6883,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "ss2k_peloton",
@@ -6456,7 +6897,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "computrainer_serialport",
@@ -6469,7 +6911,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "strava_virtual_activity",
@@ -6482,7 +6925,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "powr_sensor_running_cadence_half_on_strava",
@@ -6495,7 +6939,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "nordictrack_ifit_adb_remote",
@@ -6508,7 +6953,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "floating_height",
@@ -6521,7 +6967,8 @@
       "visible": true,
       "defaultValue": 210,
       "defaultExpression": "210",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "floating_width",
@@ -6534,7 +6981,8 @@
       "visible": true,
       "defaultValue": 370,
       "defaultExpression": "370",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "floating_transparency",
@@ -6547,7 +6995,8 @@
       "visible": true,
       "defaultValue": 80,
       "defaultExpression": "80",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "floating_startup",
@@ -6560,7 +7009,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "norditrack_s25i_treadmill",
@@ -6574,7 +7024,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "toorx_ftms_treadmill",
@@ -6587,7 +7038,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "nordictrack_t65s_83_treadmill",
@@ -6601,7 +7053,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "horizon_treadmill_suspend_stats_pause",
@@ -6614,7 +7067,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "sportstech_sx600",
@@ -6627,7 +7081,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "sole_elliptical_inclination",
@@ -6640,7 +7095,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "proform_hybrid_trainer_xt",
@@ -6653,7 +7109,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "gears_restore_value",
@@ -6666,7 +7123,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "gears_current_value",
@@ -6679,7 +7137,8 @@
       "visible": false,
       "defaultValue": 0,
       "defaultExpression": "0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_pace_last500m_enabled",
@@ -6692,7 +7151,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_pace_last500m_order",
@@ -6708,7 +7168,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "treadmill_difficulty_gain_or_offset",
@@ -6721,7 +7182,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "pafers_treadmill_bh_iboxster_plus",
@@ -6734,7 +7196,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "proform_cycle_trainer_400",
@@ -6748,7 +7211,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_bike_model"
+      "virtualParent": "nordictrack_bike_model",
+      "restartRequired": true
     },
     {
       "key": "fitshow_treadmill_miles",
@@ -6761,7 +7225,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "proform_hybrid_trainer_PFEL03815",
@@ -6774,7 +7239,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "schwinn_resistance_smooth",
@@ -6787,7 +7253,8 @@
       "visible": true,
       "defaultValue": 0,
       "defaultExpression": "0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "peloton_workout_ocr",
@@ -6800,7 +7267,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "treadmill_inclination_override_0",
@@ -6813,7 +7281,8 @@
       "visible": true,
       "defaultValue": 0.0,
       "defaultExpression": "0.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "treadmill_inclination_override_05",
@@ -6826,7 +7295,8 @@
       "visible": true,
       "defaultValue": 0.5,
       "defaultExpression": "0.5",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "treadmill_inclination_override_10",
@@ -6839,7 +7309,8 @@
       "visible": true,
       "defaultValue": 1.0,
       "defaultExpression": "1.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "treadmill_inclination_override_15",
@@ -6852,7 +7323,8 @@
       "visible": true,
       "defaultValue": 1.5,
       "defaultExpression": "1.5",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "treadmill_inclination_override_20",
@@ -6865,7 +7337,8 @@
       "visible": true,
       "defaultValue": 2.0,
       "defaultExpression": "2.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "treadmill_inclination_override_25",
@@ -6878,7 +7351,8 @@
       "visible": true,
       "defaultValue": 2.5,
       "defaultExpression": "2.5",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "treadmill_inclination_override_30",
@@ -6891,7 +7365,8 @@
       "visible": true,
       "defaultValue": 3.0,
       "defaultExpression": "3.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "treadmill_inclination_override_35",
@@ -6904,7 +7379,8 @@
       "visible": true,
       "defaultValue": 3.5,
       "defaultExpression": "3.5",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "treadmill_inclination_override_40",
@@ -6917,7 +7393,8 @@
       "visible": true,
       "defaultValue": 4.0,
       "defaultExpression": "4.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "treadmill_inclination_override_45",
@@ -6930,7 +7407,8 @@
       "visible": true,
       "defaultValue": 4.5,
       "defaultExpression": "4.5",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "treadmill_inclination_override_50",
@@ -6943,7 +7421,8 @@
       "visible": true,
       "defaultValue": 5.0,
       "defaultExpression": "5.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "treadmill_inclination_override_55",
@@ -6956,7 +7435,8 @@
       "visible": true,
       "defaultValue": 5.5,
       "defaultExpression": "5.5",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "treadmill_inclination_override_60",
@@ -6969,7 +7449,8 @@
       "visible": true,
       "defaultValue": 6.0,
       "defaultExpression": "6.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "treadmill_inclination_override_65",
@@ -6982,7 +7463,8 @@
       "visible": true,
       "defaultValue": 6.5,
       "defaultExpression": "6.5",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "treadmill_inclination_override_70",
@@ -6995,7 +7477,8 @@
       "visible": true,
       "defaultValue": 7.0,
       "defaultExpression": "7.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "treadmill_inclination_override_75",
@@ -7008,7 +7491,8 @@
       "visible": true,
       "defaultValue": 7.5,
       "defaultExpression": "7.5",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "treadmill_inclination_override_80",
@@ -7021,7 +7505,8 @@
       "visible": true,
       "defaultValue": 8.0,
       "defaultExpression": "8.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "treadmill_inclination_override_85",
@@ -7034,7 +7519,8 @@
       "visible": true,
       "defaultValue": 8.5,
       "defaultExpression": "8.5",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "treadmill_inclination_override_90",
@@ -7047,7 +7533,8 @@
       "visible": true,
       "defaultValue": 9.0,
       "defaultExpression": "9.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "treadmill_inclination_override_95",
@@ -7060,7 +7547,8 @@
       "visible": true,
       "defaultValue": 9.5,
       "defaultExpression": "9.5",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "treadmill_inclination_override_100",
@@ -7073,7 +7561,8 @@
       "visible": true,
       "defaultValue": 10.0,
       "defaultExpression": "10.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "treadmill_inclination_override_105",
@@ -7086,7 +7575,8 @@
       "visible": true,
       "defaultValue": 10.5,
       "defaultExpression": "10.5",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "treadmill_inclination_override_110",
@@ -7099,7 +7589,8 @@
       "visible": true,
       "defaultValue": 11.0,
       "defaultExpression": "11.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "treadmill_inclination_override_115",
@@ -7112,7 +7603,8 @@
       "visible": true,
       "defaultValue": 11.5,
       "defaultExpression": "11.5",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "treadmill_inclination_override_120",
@@ -7125,7 +7617,8 @@
       "visible": true,
       "defaultValue": 12.0,
       "defaultExpression": "12.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "treadmill_inclination_override_125",
@@ -7138,7 +7631,8 @@
       "visible": true,
       "defaultValue": 12.5,
       "defaultExpression": "12.5",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "treadmill_inclination_override_130",
@@ -7151,7 +7645,8 @@
       "visible": true,
       "defaultValue": 13.0,
       "defaultExpression": "13.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "treadmill_inclination_override_135",
@@ -7164,7 +7659,8 @@
       "visible": true,
       "defaultValue": 13.5,
       "defaultExpression": "13.5",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "treadmill_inclination_override_140",
@@ -7177,7 +7673,8 @@
       "visible": true,
       "defaultValue": 14.0,
       "defaultExpression": "14.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "treadmill_inclination_override_145",
@@ -7190,7 +7687,8 @@
       "visible": true,
       "defaultValue": 14.5,
       "defaultExpression": "14.5",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "treadmill_inclination_override_150",
@@ -7203,7 +7701,8 @@
       "visible": true,
       "defaultValue": 15.0,
       "defaultExpression": "15.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "sole_elliptical_e55",
@@ -7216,7 +7715,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "horizon_treadmill_force_ftms",
@@ -7229,7 +7729,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "treadmill_pid_heart_min",
@@ -7242,7 +7743,8 @@
       "visible": true,
       "defaultValue": 0,
       "defaultExpression": "0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "treadmill_pid_heart_max",
@@ -7255,7 +7757,8 @@
       "visible": true,
       "defaultValue": 0,
       "defaultExpression": "0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "nordictrack_elliptical_c7_5",
@@ -7268,7 +7771,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "renpho_bike_double_resistance",
@@ -7281,7 +7785,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "renpho_bike_knob_gears",
@@ -7294,7 +7799,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "nordictrack_incline_trainer_x7i",
@@ -7308,7 +7814,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "strava_auth_external_webbrowser",
@@ -7321,7 +7828,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "gears_from_bike",
@@ -7334,7 +7842,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "peloton_spinups_autoresistance",
@@ -7347,7 +7856,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "eslinker_costaway",
@@ -7360,7 +7870,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "treadmill_inclination_ovveride_gain",
@@ -7373,7 +7884,8 @@
       "visible": true,
       "defaultValue": 1.0,
       "defaultExpression": "1.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "treadmill_inclination_ovveride_offset",
@@ -7386,7 +7898,8 @@
       "visible": true,
       "defaultValue": 0.0,
       "defaultExpression": "0.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "bh_spada_2_watt",
@@ -7399,7 +7912,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "tacx_neo2_peloton",
@@ -7412,7 +7926,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "sole_treadmill_inclination_fast",
@@ -7425,7 +7940,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "zwift_ocr",
@@ -7438,7 +7954,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "gem_module_inclination",
@@ -7451,7 +7968,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "treadmill_simulate_inclination_with_speed",
@@ -7464,7 +7982,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "garmin_companion",
@@ -7477,7 +7996,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "peloton_companion_workout_ocr",
@@ -7490,7 +8010,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "iconcept_elliptical",
@@ -7503,7 +8024,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "theme_tile_icon_enabled",
@@ -7516,7 +8038,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "theme_tile_background_color",
@@ -7529,7 +8052,8 @@
       "visible": true,
       "defaultValue": "#303030",
       "defaultExpression": "\"#303030\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "theme_status_bar_background_color",
@@ -7542,7 +8066,8 @@
       "visible": true,
       "defaultValue": "#800080",
       "defaultExpression": "\"#800080\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "theme_background_color",
@@ -7555,7 +8080,8 @@
       "visible": true,
       "defaultValue": "#303030",
       "defaultExpression": "\"#303030\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "theme_tile_shadow_enabled",
@@ -7568,7 +8094,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "theme_tile_shadow_color",
@@ -7581,7 +8108,8 @@
       "visible": true,
       "defaultValue": "#9C27B0",
       "defaultExpression": "\"#9C27B0\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "gears_gain",
@@ -7594,7 +8122,8 @@
       "visible": true,
       "defaultValue": 1.0,
       "defaultExpression": "1.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "gears_current_value_f",
@@ -7607,7 +8136,8 @@
       "visible": true,
       "defaultValue": 0.0,
       "defaultExpression": "0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "proform_treadmill_8_0",
@@ -7621,7 +8151,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "zero_zt2500_treadmill",
@@ -7634,7 +8165,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "kingsmith_encrypt_v5",
@@ -7647,7 +8179,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "peloton_rower_level",
@@ -7674,7 +8207,8 @@
           "9",
           "10"
         ]
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_target_pace_enabled",
@@ -7687,7 +8221,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_target_pace_order",
@@ -7703,7 +8238,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tts_act_target_pace",
@@ -7716,7 +8252,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "csafe_rower",
@@ -7729,12 +8266,13 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "ftms_rower",
       "name": "FTMS Rower",
-      "description": "Allows you to force QZ to connect to your FTMS Rower. If you are in doubt, leave this Disabled and send an email to the QZ support. Default is \u201cDisabled.\u201d",
+      "description": "Allows you to force QZ to connect to your FTMS Rower. If you are in doubt, leave this Disabled and send an email to the QZ support. Default is “Disabled.”",
       "parent": "Rower Options",
       "type": "string",
       "qmlType": "string",
@@ -7745,7 +8283,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.bluetoothDevices"
-      }
+      },
+      "restartRequired": true
     },
     {
       "key": "theme_tile_secondline_textsize",
@@ -7758,7 +8297,8 @@
       "visible": true,
       "defaultValue": 12,
       "defaultExpression": "12",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "fakedevice_rower",
@@ -7771,7 +8311,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "proform_bike_sb",
@@ -7785,7 +8326,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_bike_model"
+      "virtualParent": "nordictrack_bike_model",
+      "restartRequired": true
     },
     {
       "key": "zwift_workout_ocr",
@@ -7798,7 +8340,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "zwift_ocr_climb_portal",
@@ -7811,7 +8354,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "poll_device_time",
@@ -7824,7 +8368,8 @@
       "visible": true,
       "defaultValue": 200,
       "defaultExpression": "200",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "proform_bike_PFEVEX71316_1",
@@ -7838,7 +8383,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_bike_model"
+      "virtualParent": "nordictrack_bike_model",
+      "restartRequired": true
     },
     {
       "key": "schwinn_bike_resistance_v3",
@@ -7851,12 +8397,13 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "watt_ignore_builtin",
       "name": "Disable wattage from machinery",
-      "description": "This prevents your fitness device from sending its wattage calculation to QZ and defaults to QZ\u2019s more accurate calculation.",
+      "description": "This prevents your fitness device from sending its wattage calculation to QZ and defaults to QZ’s more accurate calculation.",
       "parent": "Advanced Settings",
       "type": "boolean",
       "qmlType": "bool",
@@ -7864,7 +8411,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "proform_treadmill_z1300i",
@@ -7878,7 +8426,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "ftms_bike",
@@ -7894,7 +8443,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.bluetoothDevices"
-      }
+      },
+      "restartRequired": true
     },
     {
       "key": "ftms_treadmill",
@@ -7910,7 +8460,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.bluetoothDevices"
-      }
+      },
+      "restartRequired": true
     },
     {
       "key": "ant_speed_offset",
@@ -7923,7 +8474,8 @@
       "visible": true,
       "defaultValue": 0.0,
       "defaultExpression": "0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "ant_speed_gain",
@@ -7936,7 +8488,8 @@
       "visible": true,
       "defaultValue": 1.0,
       "defaultExpression": "1",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "proform_rower_sport_rl",
@@ -7949,7 +8502,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "strava_date_prefix",
@@ -7962,7 +8516,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "race_mode",
@@ -7975,7 +8530,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "proform_pro_1000_treadmill",
@@ -7989,7 +8545,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "saris_trainer",
@@ -8002,7 +8559,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "proform_studio_NTEX71021",
@@ -8016,7 +8574,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_bike_model"
+      "virtualParent": "nordictrack_bike_model",
+      "restartRequired": true
     },
     {
       "key": "nordictrack_x22i",
@@ -8030,7 +8589,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "iconsole_elliptical",
@@ -8043,7 +8603,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "autolap_distance",
@@ -8056,7 +8617,8 @@
       "visible": true,
       "defaultValue": 0.0,
       "defaultExpression": "0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "nordictrack_s20_treadmill",
@@ -8070,7 +8632,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "freemotion_coachbike_b22_7",
@@ -8084,7 +8647,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_bike_model"
+      "virtualParent": "nordictrack_bike_model",
+      "restartRequired": true
     },
     {
       "key": "proform_cycle_trainer_300_ci",
@@ -8098,7 +8662,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_bike_model"
+      "virtualParent": "nordictrack_bike_model",
+      "restartRequired": true
     },
     {
       "key": "kingsmith_encrypt_g1_walking_pad",
@@ -8111,7 +8676,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "proform_bike_225_csx",
@@ -8125,7 +8691,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_bike_model"
+      "virtualParent": "nordictrack_bike_model",
+      "restartRequired": true
     },
     {
       "key": "proform_treadmill_l6_0s",
@@ -8139,7 +8706,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "proformtdf1ip",
@@ -8152,7 +8720,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "zwift_username",
@@ -8165,7 +8734,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "zwift_password",
@@ -8178,7 +8748,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "garmin_bluetooth_compatibility",
@@ -8191,7 +8762,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "norditrack_s25_treadmill",
@@ -8205,7 +8777,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "proform_8_5_treadmill",
@@ -8219,7 +8792,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "treadmill_incline_min",
@@ -8232,7 +8806,8 @@
       "visible": true,
       "defaultValue": -100.0,
       "defaultExpression": "-100",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "treadmill_incline_max",
@@ -8245,7 +8820,8 @@
       "visible": true,
       "defaultValue": 100.0,
       "defaultExpression": "100",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "proform_2000_treadmill",
@@ -8259,7 +8835,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "android_documents_folder",
@@ -8272,7 +8849,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "zwift_api_autoinclination",
@@ -8285,7 +8863,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "domyos_treadmill_button_5kmh",
@@ -8298,7 +8877,8 @@
       "visible": true,
       "defaultValue": 5.0,
       "defaultExpression": "5.0",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "domyos_treadmill_button_10kmh",
@@ -8311,7 +8891,8 @@
       "visible": true,
       "defaultValue": 10.0,
       "defaultExpression": "10.0",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "domyos_treadmill_button_16kmh",
@@ -8324,7 +8905,8 @@
       "visible": true,
       "defaultValue": 16.0,
       "defaultExpression": "16.0",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "domyos_treadmill_button_22kmh",
@@ -8337,7 +8919,8 @@
       "visible": true,
       "defaultValue": 22.0,
       "defaultExpression": "22.0",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "proform_treadmill_sport_8_5",
@@ -8351,7 +8934,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "domyos_treadmill_t900a",
@@ -8364,7 +8948,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "enerfit_SPX_9500",
@@ -8377,7 +8962,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "proform_treadmill_505_cst",
@@ -8391,7 +8977,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "nordictrack_treadmill_t8_5s",
@@ -8405,7 +8992,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "proform_treadmill_705_cst",
@@ -8419,7 +9007,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "zwift_click",
@@ -8432,7 +9021,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "hop_sport_hs_090h_bike",
@@ -8445,7 +9035,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "zwift_play",
@@ -8458,7 +9049,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "nordictrack_treadmill_x14i",
@@ -8472,7 +9064,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "zwift_api_poll",
@@ -8485,7 +9078,8 @@
       "visible": true,
       "defaultValue": 5,
       "defaultExpression": "5",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "tile_step_count_enabled",
@@ -8498,7 +9092,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_step_count_order",
@@ -8514,7 +9109,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_erg_mode_enabled",
@@ -8527,7 +9123,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_erg_mode_order",
@@ -8543,7 +9140,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "toorx_srx_3500",
@@ -8556,7 +9154,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "inclination_delay_seconds",
@@ -8569,7 +9168,8 @@
       "visible": true,
       "defaultValue": 0.0,
       "defaultExpression": "0.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "ergDataPoints",
@@ -8578,11 +9178,12 @@
       "parent": "Advanced Settings",
       "type": "string",
       "qmlType": "string",
-      "control": "button",
-      "visible": true,
+      "control": "internal",
+      "visible": false,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "proform_tdf_10_0",
@@ -8596,7 +9197,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_bike_model"
+      "virtualParent": "nordictrack_bike_model",
+      "restartRequired": true
     },
     {
       "key": "proform_carbon_tl",
@@ -8610,7 +9212,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "proform_proshox2",
@@ -8624,7 +9227,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "nordictrack_GX4_5_bike",
@@ -8638,7 +9242,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_bike_model"
+      "virtualParent": "nordictrack_bike_model",
+      "restartRequired": true
     },
     {
       "key": "ftp_run",
@@ -8651,7 +9256,8 @@
       "visible": true,
       "defaultValue": 200.0,
       "defaultExpression": "200.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_rss_enabled",
@@ -8664,7 +9270,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_rss_order",
@@ -8680,7 +9287,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "treadmillDataPoints",
@@ -8689,11 +9297,12 @@
       "parent": "Advanced Settings",
       "type": "string",
       "qmlType": "string",
-      "control": "button",
-      "visible": true,
+      "control": "internal",
+      "visible": false,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "nordictrack_s20i_treadmill",
@@ -8707,7 +9316,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "stryd_speed_instead_treadmill",
@@ -8720,7 +9330,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "proform_595i_proshox2",
@@ -8734,7 +9345,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "proform_treadmill_8_7",
@@ -8748,7 +9360,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "proform_bike_325_csx",
@@ -8762,7 +9375,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_bike_model"
+      "virtualParent": "nordictrack_bike_model",
+      "restartRequired": true
     },
     {
       "key": "strava_upload_mode",
@@ -8782,7 +9396,8 @@
           "Request",
           "Disabled"
         ]
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "proform_treadmill_705_cst_V78_239",
@@ -8796,7 +9411,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "stryd_add_inclination_gain",
@@ -8809,7 +9425,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "toorx_bike_srx_500",
@@ -8822,7 +9439,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "atletica_lightspeed_treadmill",
@@ -8835,7 +9453,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "peloton_treadmill_level",
@@ -8862,7 +9481,8 @@
           "9",
           "10"
         ]
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "nordictrackadbbike_resistance",
@@ -8875,7 +9495,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "proform_treadmill_carbon_t7",
@@ -8889,7 +9510,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "nordictrack_treadmill_exp_5i",
@@ -8903,7 +9525,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "dircon_id",
@@ -8916,7 +9539,8 @@
       "visible": true,
       "defaultValue": 0,
       "defaultExpression": "0",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "proform_elliptical_ip",
@@ -8929,7 +9553,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "antbike",
@@ -8942,7 +9567,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "domyosbike_notfmts",
@@ -8955,7 +9581,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "gears_volume_debouncing",
@@ -8968,7 +9595,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_biggears_enabled",
@@ -8981,7 +9609,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_biggears_order",
@@ -8997,7 +9626,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "domyostreadmill_notfmts",
@@ -9010,7 +9640,8 @@
       "visible": false,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "zwiftplay_swap",
@@ -9023,7 +9654,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "gears_zwift_ratio",
@@ -9036,7 +9668,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "domyos_bike_500_profile_v2",
@@ -9049,7 +9682,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "gears_offset",
@@ -9062,7 +9696,8 @@
       "visible": true,
       "defaultValue": 0.0,
       "defaultExpression": "0.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "proform_carbon_tl_PFTL59720",
@@ -9076,7 +9711,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "proform_treadmill_sport_70",
@@ -9090,7 +9726,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "peloton_date_format",
@@ -9109,7 +9746,8 @@
           "MM/dd/yy",
           "yy/MM/dd"
         ]
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "force_resistance_instead_inclination",
@@ -9122,7 +9760,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "proform_treadmill_575i",
@@ -9136,7 +9775,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "zwift_play_emulator",
@@ -9149,7 +9789,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "gear_configuration",
@@ -9162,7 +9803,8 @@
       "visible": false,
       "defaultValue": "1|38|44|true\n2|38|38|true\n3|38|32|true\n4|38|28|true\n5|38|24|true\n6|38|21|true\n7|38|19|true\n8|38|17|true\n9|38|15|true\n10|38|13|true\n11|38|11|true\n12|38|10|true",
       "defaultExpression": "\"1|38|44|true\\n2|38|38|true\\n3|38|32|true\\n4|38|28|true\\n5|38|24|true\\n6|38|21|true\\n7|38|19|true\\n8|38|17|true\\n9|38|15|true\\n10|38|13|true\\n11|38|11|true\\n12|38|10|true\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "gear_crankset_size",
@@ -9175,7 +9817,8 @@
       "visible": false,
       "defaultValue": 42,
       "defaultExpression": "42",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "gear_cog_size",
@@ -9188,7 +9831,8 @@
       "visible": false,
       "defaultValue": 14,
       "defaultExpression": "14",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "gear_wheel_size",
@@ -9201,7 +9845,8 @@
       "visible": false,
       "defaultValue": "700 x 18C",
       "defaultExpression": "\"700 x 18C\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "gear_circumference",
@@ -9214,7 +9859,8 @@
       "visible": false,
       "defaultValue": 2070.0,
       "defaultExpression": "2070",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "restore_specific_gear",
@@ -9227,7 +9873,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "skipLocationServicesDialog",
@@ -9240,7 +9887,8 @@
       "visible": false,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "trainprogram_pid_pushy",
@@ -9253,7 +9901,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "trainprogram_pid_hr_recovery_zone_limit",
@@ -9262,11 +9911,12 @@
       "parent": "Training Program Options",
       "type": "number",
       "qmlType": "real",
-      "control": "textfield",
+      "control": "text",
       "visible": true,
       "defaultValue": 60.0,
       "defaultExpression": "60.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "nordictrack_elliptical_s700",
@@ -9279,7 +9929,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "trainprogram_pid_hr_pushy_zone_limit",
@@ -9288,11 +9939,12 @@
       "parent": "Training Program Options",
       "type": "number",
       "qmlType": "real",
-      "control": "textfield",
+      "control": "text",
       "visible": true,
       "defaultValue": 0.8,
       "defaultExpression": "0.8",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "min_inclination",
@@ -9305,7 +9957,8 @@
       "visible": true,
       "defaultValue": -999.0,
       "defaultExpression": "-999",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "proform_performance_400i",
@@ -9319,7 +9972,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "proform_treadmill_c700",
@@ -9333,7 +9987,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "sram_axs_controller",
@@ -9346,7 +10001,8 @@
       "visible": false,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "proform_treadmill_c960i",
@@ -9360,7 +10016,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "mqtt_host",
@@ -9373,7 +10030,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "mqtt_port",
@@ -9386,7 +10044,8 @@
       "visible": true,
       "defaultValue": 1883,
       "defaultExpression": "1883",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "mqtt_username",
@@ -9399,7 +10058,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "mqtt_password",
@@ -9412,7 +10072,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "mqtt_deviceid",
@@ -9425,7 +10086,8 @@
       "visible": true,
       "defaultValue": "default",
       "defaultExpression": "\"default\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "peloton_auto_start_with_intro",
@@ -9438,7 +10100,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "peloton_auto_start_without_intro",
@@ -9451,7 +10114,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "nordictrack_tseries5_treadmill",
@@ -9465,7 +10129,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "proform_carbon_tl_PFTL59722c",
@@ -9479,7 +10144,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "nordictrack_gx_44_pro",
@@ -9493,7 +10159,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_bike_model"
+      "virtualParent": "nordictrack_bike_model",
+      "restartRequired": true
     },
     {
       "key": "csafe_elliptical_port",
@@ -9506,7 +10173,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "osc_ip",
@@ -9519,7 +10187,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "osc_port",
@@ -9532,7 +10201,8 @@
       "visible": true,
       "defaultValue": 9000,
       "defaultExpression": "9000",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "strava_treadmill",
@@ -9545,7 +10215,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "iconsole_rower",
@@ -9558,7 +10229,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "proform_treadmill_1500_pro",
@@ -9572,7 +10244,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "proform_505_cst_80_44",
@@ -9586,7 +10259,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "proform_trainer_8_0",
@@ -9600,7 +10274,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "tile_biggears_swap",
@@ -9613,7 +10288,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "treadmill_follow_wattage",
@@ -9626,7 +10302,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "fit_file_garmin_device_training_effect",
@@ -9639,7 +10316,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "proform_treadmill_705_cst_V80_44",
@@ -9653,7 +10331,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "peloton_accesstoken",
@@ -9666,7 +10345,8 @@
       "visible": false,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "peloton_refreshtoken",
@@ -9679,7 +10359,8 @@
       "visible": false,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "peloton_lastrefresh",
@@ -9692,7 +10373,8 @@
       "visible": false,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "peloton_expires",
@@ -9705,7 +10387,8 @@
       "visible": false,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "peloton_code",
@@ -9718,7 +10401,8 @@
       "visible": false,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "nordictrack_treadmill_1750_adb",
@@ -9732,7 +10416,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "tile_preset_powerzone_1_enabled",
@@ -9745,7 +10430,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_powerzone_1_order",
@@ -9761,7 +10447,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_preset_powerzone_1_value",
@@ -9774,7 +10461,8 @@
       "visible": true,
       "defaultValue": 1.0,
       "defaultExpression": "1.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_powerzone_1_label",
@@ -9787,7 +10475,8 @@
       "visible": true,
       "defaultValue": "Zone 1",
       "defaultExpression": "\"Zone 1\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_powerzone_1_color",
@@ -9800,7 +10489,8 @@
       "visible": true,
       "defaultValue": "white",
       "defaultExpression": "\"white\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_powerzone_2_enabled",
@@ -9813,7 +10503,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_powerzone_2_order",
@@ -9829,7 +10520,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_preset_powerzone_2_value",
@@ -9842,7 +10534,8 @@
       "visible": true,
       "defaultValue": 2.0,
       "defaultExpression": "2.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_powerzone_2_label",
@@ -9855,7 +10548,8 @@
       "visible": true,
       "defaultValue": "Zone 2",
       "defaultExpression": "\"Zone 2\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_powerzone_2_color",
@@ -9868,7 +10562,8 @@
       "visible": true,
       "defaultValue": "limegreen",
       "defaultExpression": "\"limegreen\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_powerzone_3_enabled",
@@ -9881,7 +10576,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_powerzone_3_order",
@@ -9897,7 +10593,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_preset_powerzone_3_value",
@@ -9910,7 +10607,8 @@
       "visible": true,
       "defaultValue": 3.0,
       "defaultExpression": "3.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_powerzone_3_label",
@@ -9923,7 +10621,8 @@
       "visible": true,
       "defaultValue": "Zone 3",
       "defaultExpression": "\"Zone 3\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_powerzone_3_color",
@@ -9936,7 +10635,8 @@
       "visible": true,
       "defaultValue": "gold",
       "defaultExpression": "\"gold\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_powerzone_4_enabled",
@@ -9949,7 +10649,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_powerzone_4_order",
@@ -9965,7 +10666,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_preset_powerzone_4_value",
@@ -9978,7 +10680,8 @@
       "visible": true,
       "defaultValue": 4.0,
       "defaultExpression": "4.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_powerzone_4_label",
@@ -9991,7 +10694,8 @@
       "visible": true,
       "defaultValue": "Zone 4",
       "defaultExpression": "\"Zone 4\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_powerzone_4_color",
@@ -10004,7 +10708,8 @@
       "visible": true,
       "defaultValue": "orange",
       "defaultExpression": "\"orange\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_powerzone_5_enabled",
@@ -10017,7 +10722,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_powerzone_5_order",
@@ -10033,7 +10739,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_preset_powerzone_5_value",
@@ -10046,7 +10753,8 @@
       "visible": true,
       "defaultValue": 5.0,
       "defaultExpression": "5.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_powerzone_5_label",
@@ -10059,7 +10767,8 @@
       "visible": true,
       "defaultValue": "Zone 5",
       "defaultExpression": "\"Zone 5\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_powerzone_5_color",
@@ -10072,7 +10781,8 @@
       "visible": true,
       "defaultValue": "darkorange",
       "defaultExpression": "\"darkorange\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_powerzone_6_enabled",
@@ -10085,7 +10795,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_powerzone_6_order",
@@ -10101,7 +10812,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_preset_powerzone_6_value",
@@ -10114,7 +10826,8 @@
       "visible": true,
       "defaultValue": 6.0,
       "defaultExpression": "6.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_powerzone_6_label",
@@ -10127,7 +10840,8 @@
       "visible": true,
       "defaultValue": "Zone 6",
       "defaultExpression": "\"Zone 6\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_powerzone_6_color",
@@ -10140,7 +10854,8 @@
       "visible": true,
       "defaultValue": "orangered",
       "defaultExpression": "\"orangered\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_powerzone_7_enabled",
@@ -10153,7 +10868,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_powerzone_7_order",
@@ -10169,7 +10885,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_preset_powerzone_7_value",
@@ -10182,7 +10899,8 @@
       "visible": true,
       "defaultValue": 7.0,
       "defaultExpression": "7.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_powerzone_7_label",
@@ -10195,7 +10913,8 @@
       "visible": true,
       "defaultValue": "Zone 7",
       "defaultExpression": "\"Zone 7\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_preset_powerzone_7_color",
@@ -10208,7 +10927,8 @@
       "visible": true,
       "defaultValue": "red",
       "defaultExpression": "\"red\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "proform_bike_PFEVEX71316_0",
@@ -10222,7 +10942,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_bike_model"
+      "virtualParent": "nordictrack_bike_model",
+      "restartRequired": true
     },
     {
       "key": "real_inclination_to_virtual_treamill_bridge",
@@ -10235,7 +10956,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "stryd_inclination_instead_treadmill",
@@ -10248,7 +10970,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "domyos_elliptical_fmts",
@@ -10261,7 +10984,8 @@
       "visible": false,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "proform_xbike",
@@ -10275,7 +10999,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_bike_model"
+      "virtualParent": "nordictrack_bike_model",
+      "restartRequired": true
     },
     {
       "key": "proform_225_csx_PFEX32925_INT_0",
@@ -10289,7 +11014,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_bike_model"
+      "virtualParent": "nordictrack_bike_model",
+      "restartRequired": true
     },
     {
       "key": "peloton_current_user_id",
@@ -10302,7 +11028,8 @@
       "visible": false,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "trainprogram_pid_ignore_inclination",
@@ -10315,7 +11042,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_hr_time_in_zone_1_enabled",
@@ -10328,7 +11056,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_hr_time_in_zone_1_order",
@@ -10344,7 +11073,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_hr_time_in_zone_2_enabled",
@@ -10357,7 +11087,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_hr_time_in_zone_2_order",
@@ -10373,7 +11104,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_hr_time_in_zone_3_enabled",
@@ -10386,7 +11118,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_hr_time_in_zone_3_order",
@@ -10402,7 +11135,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_hr_time_in_zone_4_enabled",
@@ -10415,7 +11149,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_hr_time_in_zone_4_order",
@@ -10431,7 +11166,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_hr_time_in_zone_5_enabled",
@@ -10444,7 +11180,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_hr_time_in_zone_5_order",
@@ -10460,7 +11197,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "zwift_gear_ui_aligned",
@@ -10473,7 +11211,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tacxneo2_disable_negative_inclination",
@@ -10486,7 +11225,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "proform_performance_300i",
@@ -10500,7 +11240,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "android_antbike",
@@ -10513,7 +11254,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "tile_coretemperature_enabled",
@@ -10526,7 +11268,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_coretemperature_order",
@@ -10542,7 +11285,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "nordictrack_t65s_treadmill_81_miles",
@@ -10556,7 +11300,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "nordictrack_elite_800",
@@ -10570,7 +11315,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "ios_btdevice_native",
@@ -10583,7 +11329,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "inclinationResistancePoints",
@@ -10596,7 +11343,8 @@
       "visible": false,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "floatingwindow_type",
@@ -10610,12 +11358,16 @@
       "defaultValue": 0,
       "defaultExpression": "0",
       "options": {
-        "source": "inline",
         "values": [
+          0,
+          1
+        ],
+        "labels": [
           "Classic",
           "Horizontal"
         ]
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "horizon_treadmill_7_0_at_24",
@@ -10628,7 +11380,8 @@
       "visible": false,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "nordictrack_treadmill_ultra_le",
@@ -10642,7 +11395,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "tile_heat_time_in_zone_1_enabled",
@@ -10655,7 +11409,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_heat_time_in_zone_1_order",
@@ -10671,7 +11426,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_heat_time_in_zone_2_enabled",
@@ -10684,7 +11440,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_heat_time_in_zone_2_order",
@@ -10700,7 +11457,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_heat_time_in_zone_3_enabled",
@@ -10713,7 +11471,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_heat_time_in_zone_3_order",
@@ -10729,7 +11488,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_heat_time_in_zone_4_enabled",
@@ -10742,7 +11502,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_heat_time_in_zone_4_order",
@@ -10758,7 +11519,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "proform_treadmill_carbon_tls",
@@ -10772,7 +11534,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "proform_treadmill_995i",
@@ -10786,7 +11549,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "rogue_echo_bike",
@@ -10799,7 +11563,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "fit_file_garmin_device_training_effect_device",
@@ -10942,7 +11707,8 @@
           "Tacx",
           "Zwift"
         ]
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_hr_time_in_zone_individual_mode",
@@ -10955,7 +11721,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "wahoo_without_wheel_diameter",
@@ -10968,7 +11735,8 @@
       "visible": false,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "technogym_group_cycle",
@@ -10981,7 +11749,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "ant_bike_device_number",
@@ -10994,7 +11763,8 @@
       "visible": true,
       "defaultValue": 0,
       "defaultExpression": "0",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "ant_heart_device_number",
@@ -11007,7 +11777,8 @@
       "visible": true,
       "defaultValue": 0,
       "defaultExpression": "0",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "peloton_treadmill_walk_level",
@@ -11034,7 +11805,8 @@
           "9",
           "10"
         ]
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "pid_heart_zone_erg_mode_watt_step",
@@ -11047,7 +11819,8 @@
       "visible": true,
       "defaultValue": 5,
       "defaultExpression": "5",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "automatic_virtual_shifting_enabled",
@@ -11060,7 +11833,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "automatic_virtual_shifting_gear_up_cadence",
@@ -11073,7 +11847,8 @@
       "visible": true,
       "defaultValue": 95,
       "defaultExpression": "95",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "automatic_virtual_shifting_gear_up_time",
@@ -11086,7 +11861,8 @@
       "visible": true,
       "defaultValue": 2.0,
       "defaultExpression": "2.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "automatic_virtual_shifting_gear_down_cadence",
@@ -11099,7 +11875,8 @@
       "visible": true,
       "defaultValue": 65,
       "defaultExpression": "65",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "automatic_virtual_shifting_gear_down_time",
@@ -11112,7 +11889,8 @@
       "visible": true,
       "defaultValue": 2.0,
       "defaultExpression": "2.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "automatic_virtual_shifting_profile",
@@ -11126,13 +11904,18 @@
       "defaultValue": 0,
       "defaultExpression": "0",
       "options": {
-        "source": "inline",
         "values": [
+          0,
+          1,
+          2
+        ],
+        "labels": [
           "Cruise",
           "Climb",
           "Sprint"
         ]
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "automatic_virtual_shifting_climb_gear_up_cadence",
@@ -11145,7 +11928,8 @@
       "visible": true,
       "defaultValue": 95,
       "defaultExpression": "95",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "automatic_virtual_shifting_climb_gear_up_time",
@@ -11158,7 +11942,8 @@
       "visible": true,
       "defaultValue": 2.0,
       "defaultExpression": "2.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "automatic_virtual_shifting_climb_gear_down_cadence",
@@ -11171,7 +11956,8 @@
       "visible": true,
       "defaultValue": 65,
       "defaultExpression": "65",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "automatic_virtual_shifting_climb_gear_down_time",
@@ -11184,7 +11970,8 @@
       "visible": true,
       "defaultValue": 2.0,
       "defaultExpression": "2.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "automatic_virtual_shifting_sprint_gear_up_cadence",
@@ -11197,7 +11984,8 @@
       "visible": true,
       "defaultValue": 95,
       "defaultExpression": "95",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "automatic_virtual_shifting_sprint_gear_up_time",
@@ -11210,7 +11998,8 @@
       "visible": true,
       "defaultValue": 2.0,
       "defaultExpression": "2.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "automatic_virtual_shifting_sprint_gear_down_cadence",
@@ -11223,7 +12012,8 @@
       "visible": true,
       "defaultValue": 65,
       "defaultExpression": "65",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "automatic_virtual_shifting_sprint_gear_down_time",
@@ -11236,7 +12026,8 @@
       "visible": true,
       "defaultValue": 2.0,
       "defaultExpression": "2.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_auto_virtual_shifting_cruise_enabled",
@@ -11249,7 +12040,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_auto_virtual_shifting_cruise_order",
@@ -11279,7 +12071,8 @@
           "defaultExpression": "72",
           "defaultValue": 72
         }
-      ]
+      ],
+      "restartRequired": false
     },
     {
       "key": "tile_auto_virtual_shifting_climb_enabled",
@@ -11292,7 +12085,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_auto_virtual_shifting_climb_order",
@@ -11322,7 +12116,8 @@
           "defaultExpression": "73",
           "defaultValue": 73
         }
-      ]
+      ],
+      "restartRequired": false
     },
     {
       "key": "tile_auto_virtual_shifting_sprint_enabled",
@@ -11335,7 +12130,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_auto_virtual_shifting_sprint_order",
@@ -11365,7 +12161,8 @@
           "defaultExpression": "74",
           "defaultValue": 74
         }
-      ]
+      ],
+      "restartRequired": false
     },
     {
       "key": "proform_rower_ip",
@@ -11378,7 +12175,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "ftms_elliptical",
@@ -11394,7 +12192,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.bluetoothDevices"
-      }
+      },
+      "restartRequired": true
     },
     {
       "key": "calories_active_only",
@@ -11407,7 +12206,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "height",
@@ -11420,7 +12220,8 @@
       "visible": true,
       "defaultValue": 175.0,
       "defaultExpression": "175.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "calories_from_hr",
@@ -11433,7 +12234,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "bike_power_offset",
@@ -11446,7 +12248,8 @@
       "visible": true,
       "defaultValue": 0,
       "defaultExpression": "0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "chart_display_mode",
@@ -11460,13 +12263,18 @@
       "defaultValue": 0,
       "defaultExpression": "0",
       "options": {
-        "source": "inline",
         "values": [
+          0,
+          1,
+          2
+        ],
+        "labels": [
           "Both Charts",
           "Heart Rate Only",
           "Power Only"
         ]
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "zwift_play_vibration",
@@ -11479,7 +12287,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "toorxtreadmill_discovery_completed",
@@ -11492,7 +12301,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "taurua_ic90",
@@ -11505,7 +12315,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "proform_csx210",
@@ -11519,7 +12330,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_bike_model"
+      "virtualParent": "nordictrack_bike_model",
+      "restartRequired": true
     },
     {
       "key": "confirm_stop_workout",
@@ -11532,7 +12344,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "proform_rower_750r",
@@ -11545,7 +12358,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "virtual_device_force_treadmill",
@@ -11558,7 +12372,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "proform_trainer_9_0",
@@ -11572,7 +12387,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "iconcept_ftms_treadmill_inclination_table",
@@ -11585,7 +12401,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "skandika_wiri_x2000_protocol",
@@ -11598,7 +12415,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "nordictrack_series_7",
@@ -11612,7 +12430,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "kettler_usb_serialport",
@@ -11625,7 +12444,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "kettler_usb_baudrate",
@@ -11644,7 +12464,8 @@
           "9600",
           "57600"
         ]
-      }
+      },
+      "restartRequired": true
     },
     {
       "key": "nordictrack_se7i",
@@ -11657,7 +12478,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "treadmill_speed_max",
@@ -11670,7 +12492,8 @@
       "visible": true,
       "defaultValue": 100.0,
       "defaultExpression": "100",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "intervalsicu_accesstoken",
@@ -11683,7 +12506,8 @@
       "visible": false,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "intervalsicu_refreshtoken",
@@ -11696,7 +12520,8 @@
       "visible": false,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "intervalsicu_athlete_id",
@@ -11709,7 +12534,8 @@
       "visible": false,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "intervalsicu_upload_enabled",
@@ -11722,7 +12548,8 @@
       "visible": false,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "intervalsicu_suffix",
@@ -11735,7 +12562,8 @@
       "visible": false,
       "defaultValue": "#QZ",
       "defaultExpression": "\"#QZ\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "intervalsicu_date_prefix",
@@ -11748,7 +12576,8 @@
       "visible": false,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "proform_treadmill_sport_3_0",
@@ -11762,7 +12591,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "rouvy_compatibility",
@@ -11775,7 +12605,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "tile_negative_inclination_enabled",
@@ -11788,7 +12619,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_negative_inclination_order",
@@ -11804,7 +12636,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_avg_pace_enabled",
@@ -11817,7 +12650,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_avg_pace_order",
@@ -11833,7 +12667,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "garmin_email",
@@ -11846,7 +12681,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "garmin_password",
@@ -11859,7 +12695,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "garmin_upload_enabled",
@@ -11872,7 +12709,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "rpe_feel_popup_enabled",
@@ -11885,7 +12723,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "garmin_access_token",
@@ -11898,7 +12737,8 @@
       "visible": false,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "garmin_refresh_token",
@@ -11911,7 +12751,8 @@
       "visible": false,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "garmin_token_type",
@@ -11924,7 +12765,8 @@
       "visible": false,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "garmin_domain",
@@ -11943,7 +12785,8 @@
           "Global (garmin.com)",
           "China (garmin.cn)"
         ]
-      }
+      },
+      "restartRequired": true
     },
     {
       "key": "garmin_last_refresh",
@@ -11956,7 +12799,8 @@
       "visible": false,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "power_sensor_cadence_instead_treadmill",
@@ -11969,7 +12813,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "garmin_oauth1_token",
@@ -11982,7 +12827,8 @@
       "visible": false,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "garmin_oauth1_token_secret",
@@ -11995,7 +12841,8 @@
       "visible": false,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "domyos_treadmill_sync_start",
@@ -12008,7 +12855,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "garmin_device_serial",
@@ -12021,7 +12869,8 @@
       "visible": true,
       "defaultValue": "3313379353",
       "defaultExpression": "\"3313379353\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "treadmill_speed_min",
@@ -12034,7 +12883,8 @@
       "visible": true,
       "defaultValue": 0.0,
       "defaultExpression": "0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "peloton_treadmill_walking_min_speed",
@@ -12047,7 +12897,8 @@
       "visible": true,
       "defaultValue": 0.0,
       "defaultExpression": "0.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "peloton_treadmill_running_min_speed",
@@ -12060,7 +12911,8 @@
       "visible": true,
       "defaultValue": 0.0,
       "defaultExpression": "0.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "trainprogram_auto_lap_on_segment",
@@ -12073,7 +12925,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "power_avg_3s",
@@ -12082,7 +12935,7 @@
       "parent": "Advanced Settings",
       "type": "boolean",
       "qmlType": "bool",
-      "control": "select",
+      "control": "switch",
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
@@ -12093,7 +12946,8 @@
           "3 seconds",
           "5 seconds"
         ]
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "tile_power_avg_enabled",
@@ -12106,7 +12960,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_power_avg_order",
@@ -12122,7 +12977,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "life_fitness_ic5",
@@ -12135,7 +12991,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "technogym_bike",
@@ -12148,7 +13005,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "kingsmith_r2_enable_hw_buttons",
@@ -12161,7 +13019,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "treadmill_direct_distance",
@@ -12174,11 +13033,12 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "domyos_treadmill_ts100",
-      "name": "TS100 (Fixed 15\u00b0 Inclination)",
+      "name": "TS100 (Fixed 15° Inclination)",
       "description": null,
       "parent": "Domyos Treadmill Options",
       "type": "boolean",
@@ -12187,7 +13047,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "thinkrider_controller",
@@ -12200,7 +13061,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "weight_kg_unit",
@@ -12209,11 +13071,12 @@
       "parent": "General Options",
       "type": "boolean",
       "qmlType": "bool",
-      "control": "text",
+      "control": "switch",
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "virtual_device_rower_pm5",
@@ -12226,7 +13089,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "tile_heart_show_as_percent",
@@ -12239,7 +13103,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_hrv_enabled",
@@ -12252,7 +13117,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_hrv_order",
@@ -12268,7 +13134,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "nordictrack_gx_4_5_pro",
@@ -12282,7 +13149,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_bike_model"
+      "virtualParent": "nordictrack_bike_model",
+      "restartRequired": true
     },
     {
       "key": "step_gain",
@@ -12295,7 +13163,8 @@
       "visible": true,
       "defaultValue": 1.0,
       "defaultExpression": "1.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "sportstech_esx500",
@@ -12308,7 +13177,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "proform_bike_325_csx_PFEX439210INT_0",
@@ -12322,7 +13192,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_bike_model"
+      "virtualParent": "nordictrack_bike_model",
+      "restartRequired": true
     },
     {
       "key": "proform_carbon_tlx_treadmill",
@@ -12336,7 +13207,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "nordictrack_vr21",
@@ -12350,7 +13222,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_bike_model"
+      "virtualParent": "nordictrack_bike_model",
+      "restartRequired": true
     },
     {
       "key": "gymstick_gx6_0_elliptical",
@@ -12363,12 +13236,13 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "cadence_sensor_as_treadmill",
       "name": "Cadence Sensor as a Treadmill",
-      "description": "If your equipment doesn\u2019t have Bluetooth, these settings allow you to use a cadence sensor so it will work with QZ as a bike or treadmill. Default is off.",
+      "description": "If your equipment doesn’t have Bluetooth, these settings allow you to use a cadence sensor so it will work with QZ as a bike or treadmill. Default is off.",
       "parent": "Cadence Sensor Options",
       "type": "boolean",
       "qmlType": "bool",
@@ -12376,7 +13250,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "proform_trainer_8_0_pftl59721_int_0",
@@ -12390,7 +13265,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "proform_carbon_tl_PFTL59723_6",
@@ -12404,7 +13280,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "toputure_teb1",
@@ -12417,7 +13294,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "ios_live_activity_compact_leading_metric",
@@ -12433,7 +13311,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.metrics"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "ios_live_activity_compact_trailing_metric",
@@ -12449,7 +13328,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.metrics"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "nordictrack_treadmill_commercial_le",
@@ -12463,7 +13343,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "umay_s100_treadmill",
@@ -12476,7 +13357,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "gym_mode",
@@ -12489,7 +13371,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "tile_grade_adjusted_pace_enabled",
@@ -12502,7 +13385,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "tile_grade_adjusted_pace_order",
@@ -12518,7 +13402,8 @@
       "options": {
         "source": "expression",
         "expression": "rootItem.tile_order"
-      }
+      },
+      "restartRequired": false
     },
     {
       "key": "cycplus_bc2_controller",
@@ -12531,7 +13416,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "lifespan_bike",
@@ -12544,7 +13430,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "power_sensor_speed_inclination_coeff_a",
@@ -12557,12 +13444,13 @@
       "visible": true,
       "defaultValue": 0.0,
       "defaultExpression": "0.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "power_sensor_speed_inclination_coeff_b",
       "name": "Power Sensor Speed/Incline Coefficient B",
-      "description": "Custom coefficients for power sensor inclination calculation using formula: vwatts = (A + B \u00d7 speed) \u00d7 inclination. For Stryd sensors use: A = -0.96, B = 1.33 Examples with these values: \u2022 8 km/h, 10% incline: (-0.96 + 1.33\u00d78) \u00d7 10 = 97W added \u2022 11 km/h, 10% incline: (-0.96 + 1.33\u00d711) \u00d7 10 = 137W added If both A and B are 0, QZ will use the default formula: 9.8 \u00d7 weight \u00d7 (inclination/100). Default: A = -0.96, B = 1.33",
+      "description": "Custom coefficients for power sensor inclination calculation using formula: vwatts = (A + B × speed) × inclination. For Stryd sensors use: A = -0.96, B = 1.33 Examples with these values: • 8 km/h, 10% incline: (-0.96 + 1.33×8) × 10 = 97W added • 11 km/h, 10% incline: (-0.96 + 1.33×11) × 10 = 137W added If both A and B are 0, QZ will use the default formula: 9.8 × weight × (inclination/100). Default: A = -0.96, B = 1.33",
       "parent": "Power Sensor Options",
       "type": "number",
       "qmlType": "double",
@@ -12570,7 +13458,8 @@
       "visible": true,
       "defaultValue": 0.0,
       "defaultExpression": "0.0",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "proform_carbon_tlx_v84_314_treadmill",
@@ -12584,7 +13473,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "cscbike_custom_resistance_power_table",
@@ -12597,7 +13487,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "cscbike_custom_resistance_level_1",
@@ -12610,7 +13501,8 @@
       "visible": true,
       "defaultValue": 1.0,
       "defaultExpression": "1",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "cscbike_custom_watt_1",
@@ -12623,7 +13515,8 @@
       "visible": true,
       "defaultValue": 100.0,
       "defaultExpression": "100",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "cscbike_custom_resistance_level_2",
@@ -12636,7 +13529,8 @@
       "visible": true,
       "defaultValue": 15.0,
       "defaultExpression": "15",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "cscbike_custom_watt_2",
@@ -12649,7 +13543,8 @@
       "visible": true,
       "defaultValue": 300.0,
       "defaultExpression": "300",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "applewatch_as_treadmill_speed",
@@ -12662,7 +13557,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "gears_custom_table_enabled",
@@ -12675,7 +13571,8 @@
       "visible": false,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "gears_custom_table",
@@ -12688,7 +13585,8 @@
       "visible": false,
       "defaultValue": "1|1\n2|2\n3|3\n4|4\n5|5\n6|6\n7|7\n8|8\n9|9\n10|10\n11|11\n12|12\n13|13\n14|14\n15|15\n16|16\n17|17\n18|18\n19|19\n20|20\n21|21\n22|22\n23|23\n24|24",
       "defaultExpression": "\"1|1\\n2|2\\n3|3\\n4|4\\n5|5\\n6|6\\n7|7\\n8|8\\n9|9\\n10|10\\n11|11\\n12|12\\n13|13\\n14|14\\n15|15\\n16|16\\n17|17\\n18|18\\n19|19\\n20|20\\n21|21\\n22|22\\n23|23\\n24|24\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "proform_treadmill_cst_505_pftl59420_0",
@@ -12702,7 +13600,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "domyos_run100e",
@@ -12715,7 +13614,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcuts_enabled",
@@ -12728,7 +13628,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_speed_plus",
@@ -12741,7 +13642,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_speed_minus",
@@ -12754,7 +13656,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_inclination_plus",
@@ -12767,7 +13670,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_inclination_minus",
@@ -12780,7 +13684,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_resistance_plus",
@@ -12793,7 +13698,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_resistance_minus",
@@ -12806,7 +13712,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_peloton_resistance_plus",
@@ -12819,7 +13726,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_peloton_resistance_minus",
@@ -12832,7 +13740,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_target_resistance_plus",
@@ -12845,7 +13754,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_target_resistance_minus",
@@ -12858,7 +13768,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_target_power_plus",
@@ -12871,7 +13782,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_target_power_minus",
@@ -12884,7 +13796,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_target_zone_plus",
@@ -12897,7 +13810,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_target_zone_minus",
@@ -12910,7 +13824,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_target_speed_plus",
@@ -12923,7 +13838,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_target_speed_minus",
@@ -12936,7 +13852,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_target_incline_plus",
@@ -12949,7 +13866,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_target_incline_minus",
@@ -12962,7 +13880,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_fan_plus",
@@ -12975,7 +13894,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_fan_minus",
@@ -12988,7 +13908,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_peloton_offset_plus",
@@ -13001,7 +13922,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_peloton_offset_minus",
@@ -13014,7 +13936,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_peloton_remaining_plus",
@@ -13027,7 +13950,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_peloton_remaining_minus",
@@ -13040,7 +13964,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_remaining_time_plus",
@@ -13053,7 +13978,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_remaining_time_minus",
@@ -13066,7 +13992,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_gears_plus",
@@ -13079,7 +14006,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_gears_minus",
@@ -13092,7 +14020,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_pid_hr_plus",
@@ -13105,7 +14034,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_pid_hr_minus",
@@ -13118,7 +14048,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_ext_incline_plus",
@@ -13131,7 +14062,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_ext_incline_minus",
@@ -13144,7 +14076,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_biggears_plus",
@@ -13157,7 +14090,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_biggears_minus",
@@ -13170,7 +14104,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_avs_cruise",
@@ -13183,7 +14118,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_avs_climb",
@@ -13196,7 +14132,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_avs_sprint",
@@ -13209,7 +14146,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_power_avg",
@@ -13222,7 +14160,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_erg_mode",
@@ -13235,7 +14174,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_auto_resistance",
@@ -13248,7 +14188,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_preset_resistance_1",
@@ -13261,7 +14202,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_preset_resistance_2",
@@ -13274,7 +14216,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_preset_resistance_3",
@@ -13287,7 +14230,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_preset_resistance_4",
@@ -13300,7 +14244,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_preset_resistance_5",
@@ -13313,7 +14258,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_preset_speed_1",
@@ -13326,7 +14272,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_preset_speed_2",
@@ -13339,7 +14286,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_preset_speed_3",
@@ -13352,7 +14300,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_preset_speed_4",
@@ -13365,7 +14314,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_preset_speed_5",
@@ -13378,7 +14328,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_preset_inclination_1",
@@ -13391,7 +14342,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_preset_inclination_2",
@@ -13404,7 +14356,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_preset_inclination_3",
@@ -13417,7 +14370,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_preset_inclination_4",
@@ -13430,7 +14384,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_preset_inclination_5",
@@ -13443,7 +14398,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_preset_powerzone_1",
@@ -13456,7 +14412,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_preset_powerzone_2",
@@ -13469,7 +14426,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_preset_powerzone_3",
@@ -13482,7 +14440,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_preset_powerzone_4",
@@ -13495,7 +14454,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_preset_powerzone_5",
@@ -13508,7 +14468,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_preset_powerzone_6",
@@ -13521,7 +14482,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_preset_powerzone_7",
@@ -13534,7 +14496,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_lap",
@@ -13547,7 +14510,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_start_stop",
@@ -13560,7 +14524,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "proform_treadmill_105_cst",
@@ -13574,7 +14539,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "garmin_last_seen_cycling_ftp_create_time",
@@ -13587,7 +14553,8 @@
       "visible": false,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "garmin_last_seen_running_ftp_create_time",
@@ -13600,7 +14567,8 @@
       "visible": false,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "trainprogram_warmup_speed",
@@ -13613,7 +14581,8 @@
       "visible": true,
       "defaultValue": 420.0,
       "defaultExpression": "420",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "trainprogram_cooldown_speed",
@@ -13626,7 +14595,8 @@
       "visible": true,
       "defaultValue": 420.0,
       "defaultExpression": "420",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "trainprogram_rest_speed",
@@ -13639,7 +14609,8 @@
       "visible": true,
       "defaultValue": 420.0,
       "defaultExpression": "420",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "shortcut_stop",
@@ -13652,7 +14623,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "garmin_download_workouts_on_start",
@@ -13665,7 +14637,8 @@
       "visible": true,
       "defaultValue": true,
       "defaultExpression": "true",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "trainprogram_clipboard_workout_enabled",
@@ -13678,7 +14651,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "horizon_treadmill_omega_z",
@@ -13691,7 +14665,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "app_language",
@@ -13705,9 +14680,74 @@
       "defaultValue": "auto",
       "defaultExpression": "\"auto\"",
       "options": {
-        "source": "expression",
-        "expression": "appLanguageOptions"
-      }
+        "values": [
+          "auto",
+          "en",
+          "it",
+          "de",
+          "fr",
+          "es",
+          "pt",
+          "pt_BR",
+          "ru",
+          "zh_CN",
+          "zh_TW",
+          "ja",
+          "ko",
+          "ar",
+          "tr",
+          "vi",
+          "pl",
+          "uk",
+          "nl",
+          "th",
+          "id",
+          "ro",
+          "cs",
+          "el",
+          "sv",
+          "hu",
+          "fi",
+          "no",
+          "da",
+          "he",
+          "ca"
+        ],
+        "labels": [
+          "Auto (System)",
+          "English",
+          "Italian",
+          "German",
+          "French",
+          "Spanish",
+          "Portuguese",
+          "Portuguese (Brazil)",
+          "Russian",
+          "Chinese (Simplified)",
+          "Chinese (Traditional)",
+          "Japanese",
+          "Korean",
+          "Arabic",
+          "Turkish",
+          "Vietnamese",
+          "Polish",
+          "Ukrainian",
+          "Dutch",
+          "Thai",
+          "Indonesian",
+          "Romanian",
+          "Czech",
+          "Greek",
+          "Swedish",
+          "Hungarian",
+          "Finnish",
+          "Norwegian",
+          "Danish",
+          "Hebrew",
+          "Catalan"
+        ]
+      },
+      "restartRequired": true
     },
     {
       "key": "treadmill_force_running_activity",
@@ -13720,7 +14760,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "trainprogram_sound_on_segment",
@@ -13733,7 +14774,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": false
     },
     {
       "key": "freebeat_serialport",
@@ -13746,7 +14788,8 @@
       "visible": true,
       "defaultValue": "",
       "defaultExpression": "\"\"",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "waterrower_usb",
@@ -13759,7 +14802,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "virtual_device_tacx",
@@ -13772,7 +14816,984 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
+    },
+    {
+      "key": "ant_garmin",
+      "name": "Garmin ANT+",
+      "description": null,
+      "parent": "Garmin Options",
+      "type": "boolean",
+      "qmlType": "bool",
+      "control": "switch",
+      "visible": true,
+      "defaultValue": false,
+      "defaultExpression": "false",
+      "options": null,
+      "restartRequired": false
+    },
+    {
+      "key": "garmin_expires_at",
+      "name": "Garmin Access Token Expiry",
+      "description": null,
+      "parent": "Garmin Options",
+      "type": "string",
+      "qmlType": "var",
+      "control": "text",
+      "visible": false,
+      "defaultValue": null,
+      "defaultExpression": "0",
+      "options": null,
+      "restartRequired": false
+    },
+    {
+      "key": "garmin_refresh_token_expires_at",
+      "name": "Garmin Refresh Token Expiry",
+      "description": null,
+      "parent": "Garmin Options",
+      "type": "string",
+      "qmlType": "var",
+      "control": "text",
+      "visible": false,
+      "defaultValue": null,
+      "defaultExpression": "0",
+      "options": null,
+      "restartRequired": false
+    },
+    {
+      "key": "mywhoosh_link_camera_value",
+      "name": "Camera Action",
+      "description": null,
+      "parent": "OpenBikeControl",
+      "type": "integer",
+      "qmlType": "int",
+      "control": "text",
+      "visible": true,
+      "defaultValue": 1,
+      "defaultExpression": "1",
+      "options": null,
+      "restartRequired": false
+    },
+    {
+      "key": "mywhoosh_link_emote_value",
+      "name": "Emote Action",
+      "description": null,
+      "parent": "OpenBikeControl",
+      "type": "integer",
+      "qmlType": "int",
+      "control": "text",
+      "visible": true,
+      "defaultValue": 1,
+      "defaultExpression": "1",
+      "options": null,
+      "restartRequired": false
+    },
+    {
+      "key": "mywhoosh_link_enabled",
+      "name": "Enable OpenBikeControl",
+      "description": null,
+      "parent": "OpenBikeControl",
+      "type": "boolean",
+      "qmlType": "bool",
+      "control": "switch",
+      "visible": true,
+      "defaultValue": false,
+      "defaultExpression": "false",
+      "options": null,
+      "restartRequired": true
+    },
+    {
+      "key": "mywhoosh_link_left_down",
+      "name": "Left Controller Down",
+      "description": null,
+      "parent": "OpenBikeControl",
+      "type": "integer",
+      "qmlType": "int",
+      "control": "select",
+      "visible": true,
+      "defaultValue": 2,
+      "defaultExpression": "2",
+      "options": {
+        "values": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16
+        ],
+        "labels": [
+          "Disabled",
+          "Gear Up",
+          "Gear Down",
+          "Steer Left",
+          "Steer Right",
+          "U-Turn",
+          "Camera Angle",
+          "Emote",
+          "Tuck",
+          "Nav Up",
+          "Nav Down",
+          "Nav Left",
+          "Nav Right",
+          "Select/Confirm",
+          "Back/Cancel",
+          "Menu",
+          "Home"
+        ]
+      },
+      "restartRequired": true
+    },
+    {
+      "key": "mywhoosh_link_left_left",
+      "name": "Left Controller Left",
+      "description": null,
+      "parent": "OpenBikeControl",
+      "type": "integer",
+      "qmlType": "int",
+      "control": "select",
+      "visible": true,
+      "defaultValue": 0,
+      "defaultExpression": "0",
+      "options": {
+        "values": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16
+        ],
+        "labels": [
+          "Disabled",
+          "Gear Up",
+          "Gear Down",
+          "Steer Left",
+          "Steer Right",
+          "U-Turn",
+          "Camera Angle",
+          "Emote",
+          "Tuck",
+          "Nav Up",
+          "Nav Down",
+          "Nav Left",
+          "Nav Right",
+          "Select/Confirm",
+          "Back/Cancel",
+          "Menu",
+          "Home"
+        ]
+      },
+      "restartRequired": true
+    },
+    {
+      "key": "mywhoosh_link_left_power",
+      "name": "Left Controller Power",
+      "description": null,
+      "parent": "OpenBikeControl",
+      "type": "integer",
+      "qmlType": "int",
+      "control": "select",
+      "visible": true,
+      "defaultValue": 0,
+      "defaultExpression": "0",
+      "options": {
+        "values": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16
+        ],
+        "labels": [
+          "Disabled",
+          "Gear Up",
+          "Gear Down",
+          "Steer Left",
+          "Steer Right",
+          "U-Turn",
+          "Camera Angle",
+          "Emote",
+          "Tuck",
+          "Nav Up",
+          "Nav Down",
+          "Nav Left",
+          "Nav Right",
+          "Select/Confirm",
+          "Back/Cancel",
+          "Menu",
+          "Home"
+        ]
+      },
+      "restartRequired": true
+    },
+    {
+      "key": "mywhoosh_link_left_right",
+      "name": "Left Controller Right",
+      "description": null,
+      "parent": "OpenBikeControl",
+      "type": "integer",
+      "qmlType": "int",
+      "control": "select",
+      "visible": true,
+      "defaultValue": 0,
+      "defaultExpression": "0",
+      "options": {
+        "values": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16
+        ],
+        "labels": [
+          "Disabled",
+          "Gear Up",
+          "Gear Down",
+          "Steer Left",
+          "Steer Right",
+          "U-Turn",
+          "Camera Angle",
+          "Emote",
+          "Tuck",
+          "Nav Up",
+          "Nav Down",
+          "Nav Left",
+          "Nav Right",
+          "Select/Confirm",
+          "Back/Cancel",
+          "Menu",
+          "Home"
+        ]
+      },
+      "restartRequired": true
+    },
+    {
+      "key": "mywhoosh_link_left_shoulder",
+      "name": "Left Controller Shoulder",
+      "description": null,
+      "parent": "OpenBikeControl",
+      "type": "integer",
+      "qmlType": "int",
+      "control": "select",
+      "visible": true,
+      "defaultValue": 5,
+      "defaultExpression": "5",
+      "options": {
+        "values": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16
+        ],
+        "labels": [
+          "Disabled",
+          "Gear Up",
+          "Gear Down",
+          "Steer Left",
+          "Steer Right",
+          "U-Turn",
+          "Camera Angle",
+          "Emote",
+          "Tuck",
+          "Nav Up",
+          "Nav Down",
+          "Nav Left",
+          "Nav Right",
+          "Select/Confirm",
+          "Back/Cancel",
+          "Menu",
+          "Home"
+        ]
+      },
+      "restartRequired": true
+    },
+    {
+      "key": "mywhoosh_link_left_up",
+      "name": "Left Controller Up",
+      "description": null,
+      "parent": "OpenBikeControl",
+      "type": "integer",
+      "qmlType": "int",
+      "control": "select",
+      "visible": true,
+      "defaultValue": 1,
+      "defaultExpression": "1",
+      "options": {
+        "values": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16
+        ],
+        "labels": [
+          "Disabled",
+          "Gear Up",
+          "Gear Down",
+          "Steer Left",
+          "Steer Right",
+          "U-Turn",
+          "Camera Angle",
+          "Emote",
+          "Tuck",
+          "Nav Up",
+          "Nav Down",
+          "Nav Left",
+          "Nav Right",
+          "Select/Confirm",
+          "Back/Cancel",
+          "Menu",
+          "Home"
+        ]
+      },
+      "restartRequired": true
+    },
+    {
+      "key": "mywhoosh_link_override_gears",
+      "name": "OpenBikeControl Override Gears",
+      "description": null,
+      "parent": "OpenBikeControl",
+      "type": "boolean",
+      "qmlType": "bool",
+      "control": "switch",
+      "visible": true,
+      "defaultValue": false,
+      "defaultExpression": "false",
+      "options": null,
+      "restartRequired": true
+    },
+    {
+      "key": "mywhoosh_link_right_a",
+      "name": "Right Controller A",
+      "description": null,
+      "parent": "OpenBikeControl",
+      "type": "integer",
+      "qmlType": "int",
+      "control": "select",
+      "visible": true,
+      "defaultValue": 0,
+      "defaultExpression": "0",
+      "options": {
+        "values": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16
+        ],
+        "labels": [
+          "Disabled",
+          "Gear Up",
+          "Gear Down",
+          "Steer Left",
+          "Steer Right",
+          "U-Turn",
+          "Camera Angle",
+          "Emote",
+          "Tuck",
+          "Nav Up",
+          "Nav Down",
+          "Nav Left",
+          "Nav Right",
+          "Select/Confirm",
+          "Back/Cancel",
+          "Menu",
+          "Home"
+        ]
+      },
+      "restartRequired": true
+    },
+    {
+      "key": "mywhoosh_link_right_b",
+      "name": "Right Controller B",
+      "description": null,
+      "parent": "OpenBikeControl",
+      "type": "integer",
+      "qmlType": "int",
+      "control": "select",
+      "visible": true,
+      "defaultValue": 7,
+      "defaultExpression": "7",
+      "options": {
+        "values": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16
+        ],
+        "labels": [
+          "Disabled",
+          "Gear Up",
+          "Gear Down",
+          "Steer Left",
+          "Steer Right",
+          "U-Turn",
+          "Camera Angle",
+          "Emote",
+          "Tuck",
+          "Nav Up",
+          "Nav Down",
+          "Nav Left",
+          "Nav Right",
+          "Select/Confirm",
+          "Back/Cancel",
+          "Menu",
+          "Home"
+        ]
+      },
+      "restartRequired": true
+    },
+    {
+      "key": "mywhoosh_link_right_power",
+      "name": "Right Controller Power",
+      "description": null,
+      "parent": "OpenBikeControl",
+      "type": "integer",
+      "qmlType": "int",
+      "control": "select",
+      "visible": true,
+      "defaultValue": 0,
+      "defaultExpression": "0",
+      "options": {
+        "values": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16
+        ],
+        "labels": [
+          "Disabled",
+          "Gear Up",
+          "Gear Down",
+          "Steer Left",
+          "Steer Right",
+          "U-Turn",
+          "Camera Angle",
+          "Emote",
+          "Tuck",
+          "Nav Up",
+          "Nav Down",
+          "Nav Left",
+          "Nav Right",
+          "Select/Confirm",
+          "Back/Cancel",
+          "Menu",
+          "Home"
+        ]
+      },
+      "restartRequired": true
+    },
+    {
+      "key": "mywhoosh_link_right_shoulder",
+      "name": "Right Controller Shoulder",
+      "description": null,
+      "parent": "OpenBikeControl",
+      "type": "integer",
+      "qmlType": "int",
+      "control": "select",
+      "visible": true,
+      "defaultValue": 0,
+      "defaultExpression": "0",
+      "options": {
+        "values": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16
+        ],
+        "labels": [
+          "Disabled",
+          "Gear Up",
+          "Gear Down",
+          "Steer Left",
+          "Steer Right",
+          "U-Turn",
+          "Camera Angle",
+          "Emote",
+          "Tuck",
+          "Nav Up",
+          "Nav Down",
+          "Nav Left",
+          "Nav Right",
+          "Select/Confirm",
+          "Back/Cancel",
+          "Menu",
+          "Home"
+        ]
+      },
+      "restartRequired": true
+    },
+    {
+      "key": "mywhoosh_link_right_y",
+      "name": "Right Controller Y",
+      "description": null,
+      "parent": "OpenBikeControl",
+      "type": "integer",
+      "qmlType": "int",
+      "control": "select",
+      "visible": true,
+      "defaultValue": 6,
+      "defaultExpression": "6",
+      "options": {
+        "values": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16
+        ],
+        "labels": [
+          "Disabled",
+          "Gear Up",
+          "Gear Down",
+          "Steer Left",
+          "Steer Right",
+          "U-Turn",
+          "Camera Angle",
+          "Emote",
+          "Tuck",
+          "Nav Up",
+          "Nav Down",
+          "Nav Left",
+          "Nav Right",
+          "Select/Confirm",
+          "Back/Cancel",
+          "Menu",
+          "Home"
+        ]
+      },
+      "restartRequired": true
+    },
+    {
+      "key": "mywhoosh_link_right_z",
+      "name": "Right Controller Z",
+      "description": null,
+      "parent": "OpenBikeControl",
+      "type": "integer",
+      "qmlType": "int",
+      "control": "select",
+      "visible": true,
+      "defaultValue": 0,
+      "defaultExpression": "0",
+      "options": {
+        "values": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16
+        ],
+        "labels": [
+          "Disabled",
+          "Gear Up",
+          "Gear Down",
+          "Steer Left",
+          "Steer Right",
+          "U-Turn",
+          "Camera Angle",
+          "Emote",
+          "Tuck",
+          "Nav Up",
+          "Nav Down",
+          "Nav Left",
+          "Nav Right",
+          "Select/Confirm",
+          "Back/Cancel",
+          "Menu",
+          "Home"
+        ]
+      },
+      "restartRequired": true
+    },
+    {
+      "key": "peloton_bike_ocr",
+      "name": "Peloton Bike OCR",
+      "description": null,
+      "parent": "Peloton Options",
+      "type": "boolean",
+      "qmlType": "bool",
+      "control": "switch",
+      "visible": true,
+      "defaultValue": false,
+      "defaultExpression": "false",
+      "options": null,
+      "restartRequired": true
+    },
+    {
+      "key": "service_changed",
+      "name": "Bluetooth Service Changed State",
+      "description": null,
+      "parent": "Advanced Settings",
+      "type": "boolean",
+      "qmlType": "bool",
+      "control": "switch",
+      "visible": false,
+      "defaultValue": false,
+      "defaultExpression": "false",
+      "options": null,
+      "restartRequired": false
+    },
+    {
+      "key": "watt_bike_emulator",
+      "name": "Wattbike Emulator",
+      "description": null,
+      "parent": "Bike Options",
+      "type": "boolean",
+      "qmlType": "bool",
+      "control": "switch",
+      "visible": true,
+      "defaultValue": false,
+      "defaultExpression": "false",
+      "options": null,
+      "restartRequired": true
+    },
+    {
+      "key": "zwiftplay_gear_lb",
+      "name": "Left Button Gear Action",
+      "description": null,
+      "parent": "Zwift Play Options",
+      "type": "integer",
+      "qmlType": "int",
+      "control": "select",
+      "visible": true,
+      "defaultValue": 0,
+      "defaultExpression": "0",
+      "options": {
+        "values": [
+          0,
+          1,
+          2
+        ],
+        "labels": [
+          "Disabled",
+          "Gear Up",
+          "Gear Down"
+        ]
+      },
+      "restartRequired": false
+    },
+    {
+      "key": "zwiftplay_gear_ls1",
+      "name": "Left Shift 1 Gear Action",
+      "description": null,
+      "parent": "Zwift Play Options",
+      "type": "integer",
+      "qmlType": "int",
+      "control": "select",
+      "visible": true,
+      "defaultValue": 2,
+      "defaultExpression": "2",
+      "options": {
+        "values": [
+          0,
+          1,
+          2
+        ],
+        "labels": [
+          "Disabled",
+          "Gear Up",
+          "Gear Down"
+        ]
+      },
+      "restartRequired": false
+    },
+    {
+      "key": "zwiftplay_gear_ls2",
+      "name": "Left Shift 2 Gear Action",
+      "description": null,
+      "parent": "Zwift Play Options",
+      "type": "integer",
+      "qmlType": "int",
+      "control": "select",
+      "visible": true,
+      "defaultValue": 2,
+      "defaultExpression": "2",
+      "options": {
+        "values": [
+          0,
+          1,
+          2
+        ],
+        "labels": [
+          "Disabled",
+          "Gear Up",
+          "Gear Down"
+        ]
+      },
+      "restartRequired": false
+    },
+    {
+      "key": "zwiftplay_gear_paddle_left",
+      "name": "Left Paddle Gear Action",
+      "description": null,
+      "parent": "Zwift Play Options",
+      "type": "integer",
+      "qmlType": "int",
+      "control": "select",
+      "visible": true,
+      "defaultValue": 2,
+      "defaultExpression": "2",
+      "options": {
+        "values": [
+          0,
+          1,
+          2
+        ],
+        "labels": [
+          "Disabled",
+          "Gear Up",
+          "Gear Down"
+        ]
+      },
+      "restartRequired": false
+    },
+    {
+      "key": "zwiftplay_gear_paddle_right",
+      "name": "Right Paddle Gear Action",
+      "description": null,
+      "parent": "Zwift Play Options",
+      "type": "integer",
+      "qmlType": "int",
+      "control": "select",
+      "visible": true,
+      "defaultValue": 1,
+      "defaultExpression": "1",
+      "options": {
+        "values": [
+          0,
+          1,
+          2
+        ],
+        "labels": [
+          "Disabled",
+          "Gear Up",
+          "Gear Down"
+        ]
+      },
+      "restartRequired": false
+    },
+    {
+      "key": "zwiftplay_gear_rb",
+      "name": "Right Button Gear Action",
+      "description": null,
+      "parent": "Zwift Play Options",
+      "type": "integer",
+      "qmlType": "int",
+      "control": "select",
+      "visible": true,
+      "defaultValue": 0,
+      "defaultExpression": "0",
+      "options": {
+        "values": [
+          0,
+          1,
+          2
+        ],
+        "labels": [
+          "Disabled",
+          "Gear Up",
+          "Gear Down"
+        ]
+      },
+      "restartRequired": false
+    },
+    {
+      "key": "zwiftplay_gear_rs1",
+      "name": "Right Shift 1 Gear Action",
+      "description": null,
+      "parent": "Zwift Play Options",
+      "type": "integer",
+      "qmlType": "int",
+      "control": "select",
+      "visible": true,
+      "defaultValue": 1,
+      "defaultExpression": "1",
+      "options": {
+        "values": [
+          0,
+          1,
+          2
+        ],
+        "labels": [
+          "Disabled",
+          "Gear Up",
+          "Gear Down"
+        ]
+      },
+      "restartRequired": false
+    },
+    {
+      "key": "zwiftplay_gear_rs2",
+      "name": "Right Shift 2 Gear Action",
+      "description": null,
+      "parent": "Zwift Play Options",
+      "type": "integer",
+      "qmlType": "int",
+      "control": "select",
+      "visible": true,
+      "defaultValue": 1,
+      "defaultExpression": "1",
+      "options": {
+        "values": [
+          0,
+          1,
+          2
+        ],
+        "labels": [
+          "Disabled",
+          "Gear Up",
+          "Gear Down"
+        ]
+      },
+      "restartRequired": false
     },
     {
       "key": "nordictrack_incline_trainer_x7i_ntl15010_0",
@@ -13786,7 +15807,8 @@
       "defaultValue": false,
       "defaultExpression": "false",
       "options": null,
-      "virtualParent": "nordictrack_treadmill_model"
+      "virtualParent": "nordictrack_treadmill_model",
+      "restartRequired": true
     },
     {
       "key": "custom_inclination_resistance_table_enabled",
@@ -13799,7 +15821,8 @@
       "visible": true,
       "defaultValue": false,
       "defaultExpression": "false",
-      "options": null
+      "options": null,
+      "restartRequired": true
     },
     {
       "key": "custom_inclination_resistance_table",
@@ -13812,7 +15835,3305 @@
       "visible": true,
       "defaultValue": "0|4\n1|6\n2|8\n3|10\n4|11\n5|11.5\n6|12\n8|13\n10|14\n12|15\n15|16",
       "defaultExpression": "\"0|4\\n1|6\\n2|8\\n3|10\\n4|11\\n5|11.5\\n6|12\\n8|13\\n10|14\\n12|15\\n15|16\"",
-      "options": null
+      "options": null,
+      "restartRequired": true
     }
-  ]
+  ],
+  "legacyHierarchy": {
+    "source": "src/settings.qml AccordionElement nesting",
+    "nodes": [
+      {
+        "key": "generalOptionsAccordion",
+        "name": "General Options",
+        "parent": null,
+        "depth": 0,
+        "sourceLine": 2840
+      },
+      {
+        "key": "heartRateOptionsAccordion",
+        "name": "Heart Rate Options",
+        "parent": null,
+        "depth": 0,
+        "sourceLine": 3390
+      },
+      {
+        "key": "heartRateZoneAccordion",
+        "name": "Heart Rate Zone Options",
+        "parent": "heartRateOptionsAccordion",
+        "depth": 1,
+        "sourceLine": 3585
+      },
+      {
+        "key": "heartRatemaxOverrideAccordion",
+        "name": "Heart Rate Max Override",
+        "parent": "heartRateZoneAccordion",
+        "depth": 2,
+        "sourceLine": 3719
+      },
+      {
+        "key": "powerFromHeartRateAccordion",
+        "name": "Power from Heart Rate Options",
+        "parent": "heartRateZoneAccordion",
+        "depth": 2,
+        "sourceLine": 3820
+      },
+      {
+        "key": "bikeOptionsAccordion",
+        "name": "Bike Options",
+        "parent": null,
+        "depth": 0,
+        "sourceLine": 3946
+      },
+      {
+        "key": "openBikeControlAccordion",
+        "name": "OpenBikeControl",
+        "parent": "bikeOptionsAccordion",
+        "depth": 1,
+        "sourceLine": 4222
+      },
+      {
+        "key": "automaticVirtualShiftingAccordion",
+        "name": "Automatic Virtual Shifting",
+        "parent": "bikeOptionsAccordion",
+        "depth": 1,
+        "sourceLine": 4837
+      },
+      {
+        "key": "schwinnBikeAccordion",
+        "name": "Schwinn Bike Options",
+        "parent": "bikeOptionsAccordion",
+        "depth": 1,
+        "sourceLine": 5274
+      },
+      {
+        "key": "horizonBikeAccordion",
+        "name": "Horizon Bike Options",
+        "parent": "bikeOptionsAccordion",
+        "depth": 1,
+        "sourceLine": 5361
+      },
+      {
+        "key": "echelonBikeOptionsAccordion",
+        "name": "Echelon Bike Options",
+        "parent": "bikeOptionsAccordion",
+        "depth": 1,
+        "sourceLine": 5393
+      },
+      {
+        "key": "inspireBikeAccordion",
+        "name": "Inspire Bike Options",
+        "parent": "bikeOptionsAccordion",
+        "depth": 1,
+        "sourceLine": 5494
+      },
+      {
+        "key": "renphoBikeAccordion",
+        "name": "Renpho Bike Options",
+        "parent": "bikeOptionsAccordion",
+        "depth": 1,
+        "sourceLine": 5533
+      },
+      {
+        "key": "hammerBikeAccordion",
+        "name": "Hammer Racer Bike Options",
+        "parent": "bikeOptionsAccordion",
+        "depth": 1,
+        "sourceLine": 5584
+      },
+      {
+        "key": "cardioFitBikeAccordion",
+        "name": "CardioFIT Bike Options",
+        "parent": "bikeOptionsAccordion",
+        "depth": 1,
+        "sourceLine": 5626
+      },
+      {
+        "key": "yesoulBikeAccordion",
+        "name": "Yesoul Bike Options",
+        "parent": "bikeOptionsAccordion",
+        "depth": 1,
+        "sourceLine": 5647
+      },
+      {
+        "key": "skandikaBikeAccordion",
+        "name": "Skandika Bike Options",
+        "parent": "bikeOptionsAccordion",
+        "depth": 1,
+        "sourceLine": 5690
+      },
+      {
+        "key": "fitplusBikeAccordion",
+        "name": "Fitplus Bike Options",
+        "parent": "bikeOptionsAccordion",
+        "depth": 1,
+        "sourceLine": 5726
+      },
+      {
+        "key": "lifespanBikeAccordion",
+        "name": "LifeSpan Bike Options",
+        "parent": "bikeOptionsAccordion",
+        "depth": 1,
+        "sourceLine": 5793
+      },
+      {
+        "key": "flywheelBikeAccordion",
+        "name": "Flywheel Bike Options",
+        "parent": "bikeOptionsAccordion",
+        "depth": 1,
+        "sourceLine": 5817
+      },
+      {
+        "key": "domyosBikeAccordion",
+        "name": "Domyos Bike Options",
+        "parent": "bikeOptionsAccordion",
+        "depth": 1,
+        "sourceLine": 5879
+      },
+      {
+        "key": "proformBikeAccordion",
+        "name": "Proform/Norditrack Options",
+        "parent": "bikeOptionsAccordion",
+        "depth": 1,
+        "sourceLine": 6012
+      },
+      {
+        "key": "computrainerBikeAccordion",
+        "name": "Computrainer Bike Options",
+        "parent": "bikeOptionsAccordion",
+        "depth": 1,
+        "sourceLine": 6300
+      },
+      {
+        "key": "kettlerUsbBikeAccordion",
+        "name": "Kettler USB Bike Options",
+        "parent": "bikeOptionsAccordion",
+        "depth": 1,
+        "sourceLine": 6333
+      },
+      {
+        "key": "freebeatBikeAccordion",
+        "name": "Freebeat Bike Options",
+        "parent": "bikeOptionsAccordion",
+        "depth": 1,
+        "sourceLine": 6397
+      },
+      {
+        "key": "m3iBikeAccordion",
+        "name": "M3i Bike Options",
+        "parent": "bikeOptionsAccordion",
+        "depth": 1,
+        "sourceLine": 6432
+      },
+      {
+        "key": "soleBikeAccordion",
+        "name": "Sole Bike Options",
+        "parent": "bikeOptionsAccordion",
+        "depth": 1,
+        "sourceLine": 6525
+      },
+      {
+        "key": "technogymBikeAccordion",
+        "name": "Technogym Bike Options",
+        "parent": "bikeOptionsAccordion",
+        "depth": 1,
+        "sourceLine": 6549
+      },
+      {
+        "key": "uiAntOptionsAccordion",
+        "name": "Ant+ Options (only for some Android)",
+        "parent": null,
+        "depth": 0,
+        "sourceLine": 6658
+      },
+      {
+        "key": "uiGeneralOptionsAccordion",
+        "name": "General UI Options",
+        "parent": null,
+        "depth": 0,
+        "sourceLine": 6889
+      },
+      {
+        "key": "themesOptionsAccordion",
+        "name": "UI Themes",
+        "parent": "uiGeneralOptionsAccordion",
+        "depth": 1,
+        "sourceLine": 7204
+      },
+      {
+        "key": "pelotonAccordion",
+        "name": "Peloton Options",
+        "parent": null,
+        "depth": 0,
+        "sourceLine": 7400
+      },
+      {
+        "key": "zwiftUsernameTextField",
+        "name": "Zwift Options",
+        "parent": null,
+        "depth": 0,
+        "sourceLine": 8232
+      },
+      {
+        "key": "garminOptionsAccordion",
+        "name": "Garmin Options",
+        "parent": null,
+        "depth": 0,
+        "sourceLine": 8592
+      },
+      {
+        "key": "trainingProgramOptionsAccordion",
+        "name": "Training Program Options",
+        "parent": null,
+        "depth": 0,
+        "sourceLine": 9689
+      },
+      {
+        "key": "treadmillAccordion",
+        "name": "Treadmill Options",
+        "parent": null,
+        "depth": 0,
+        "sourceLine": 10615
+      },
+      {
+        "key": "proformTreadmillAccordion",
+        "name": "Proform/Nordictrack Options",
+        "parent": "treadmillAccordion",
+        "depth": 1,
+        "sourceLine": 11111
+      },
+      {
+        "key": "pafersTreadmillAccordion",
+        "name": "Pafers Options",
+        "parent": "treadmillAccordion",
+        "depth": 1,
+        "sourceLine": 11487
+      },
+      {
+        "key": "kingsmithTreadmillAccordion",
+        "name": "KingSmith Options",
+        "parent": "treadmillAccordion",
+        "depth": 1,
+        "sourceLine": 11572
+      },
+      {
+        "key": "runnerTTreadmillAccordion",
+        "name": "RunnerT Options",
+        "parent": "treadmillAccordion",
+        "depth": 1,
+        "sourceLine": 11682
+      },
+      {
+        "key": "domyosTreadmillAccordion",
+        "name": "Domyos Treadmill Options",
+        "parent": "treadmillAccordion",
+        "depth": 1,
+        "sourceLine": 11733
+      },
+      {
+        "key": "soleTreadmillAccordion",
+        "name": "Sole Treadmill Options",
+        "parent": "treadmillAccordion",
+        "depth": 1,
+        "sourceLine": 11971
+      },
+      {
+        "key": "technogymTreadmillAccordion",
+        "name": "Technogym Options",
+        "parent": "treadmillAccordion",
+        "depth": 1,
+        "sourceLine": 12065
+      },
+      {
+        "key": "fitshowAccordion",
+        "name": "Fitshow Treadmill Options",
+        "parent": "treadmillAccordion",
+        "depth": 1,
+        "sourceLine": 12090
+      },
+      {
+        "key": "eslinkerTreadmillAccordion",
+        "name": "ESLinker Treadmill Options",
+        "parent": "treadmillAccordion",
+        "depth": 1,
+        "sourceLine": 12179
+      },
+      {
+        "key": "horizonTreadmillAccordion",
+        "name": "Horizon Treadmill Options",
+        "parent": "treadmillAccordion",
+        "depth": 1,
+        "sourceLine": 12230
+      },
+      {
+        "key": "bowflexTreadmillAccordion",
+        "name": "Bowflex Treadmill Options",
+        "parent": "treadmillAccordion",
+        "depth": 1,
+        "sourceLine": 12466
+      },
+      {
+        "key": "toorxTreadmillAccordion",
+        "name": "Toorx/iConsole Options",
+        "parent": null,
+        "depth": 0,
+        "sourceLine": 12493
+      },
+      {
+        "key": "ftmsRowerTextField",
+        "name": "Rower Options",
+        "parent": null,
+        "depth": 0,
+        "sourceLine": 12848
+      },
+      {
+        "key": "csaferowerSerialPortTextField",
+        "name": "PM3, PM4 Options",
+        "parent": "ftmsRowerTextField",
+        "depth": 1,
+        "sourceLine": 12855
+      },
+      {
+        "key": "proformRowerIPTextField",
+        "name": "Proform/Nordictrack Rower Options",
+        "parent": "ftmsRowerTextField",
+        "depth": 1,
+        "sourceLine": 12946
+      },
+      {
+        "key": "ellipticalAccordion",
+        "name": "Elliptical Options",
+        "parent": null,
+        "depth": 0,
+        "sourceLine": 13010
+      },
+      {
+        "key": "domyosEllipticalAccordion",
+        "name": "Domyos Elliptical Options",
+        "parent": "ellipticalAccordion",
+        "depth": 1,
+        "sourceLine": 13019
+      },
+      {
+        "key": "proformEllipticalAccordion",
+        "name": "Proform/Nordictrack Elliptical Options",
+        "parent": "ellipticalAccordion",
+        "depth": 1,
+        "sourceLine": 13154
+      },
+      {
+        "key": "soleEllipticalAccordion",
+        "name": "Sole Elliptical Options",
+        "parent": "ellipticalAccordion",
+        "depth": 1,
+        "sourceLine": 13266
+      },
+      {
+        "key": "advancedSettingsAccordion",
+        "name": "Advanced Settings",
+        "parent": null,
+        "depth": 0,
+        "sourceLine": 13328
+      },
+      {
+        "key": "accesoriesAccordion",
+        "name": "Accessories",
+        "parent": null,
+        "depth": 0,
+        "sourceLine": 14284
+      },
+      {
+        "key": "cadenceSensorOptionsAccordion",
+        "name": "Cadence Sensor Options",
+        "parent": "accesoriesAccordion",
+        "depth": 1,
+        "sourceLine": 14293
+      },
+      {
+        "key": "powerSensorOptionsAccordion",
+        "name": "Power Sensor Options",
+        "parent": "accesoriesAccordion",
+        "depth": 1,
+        "sourceLine": 14615
+      },
+      {
+        "key": "eliteAccesoriesAccordion",
+        "name": "Elite™ Products",
+        "parent": "accesoriesAccordion",
+        "depth": 1,
+        "sourceLine": 14948
+      },
+      {
+        "key": "eliteRizerOptionsAccordion",
+        "name": "Elite Rizer Options",
+        "parent": "eliteAccesoriesAccordion",
+        "depth": 2,
+        "sourceLine": 14956
+      },
+      {
+        "key": "eliteSterzoSmartOptionsAccordion",
+        "name": "Elite Sterzo Smart Options",
+        "parent": "eliteAccesoriesAccordion",
+        "depth": 2,
+        "sourceLine": 15024
+      },
+      {
+        "key": "ftmsAccessoryOptionsAccordion",
+        "name": "SmartSpin2k Options",
+        "parent": "accesoriesAccordion",
+        "depth": 1,
+        "sourceLine": 15071
+      },
+      {
+        "key": "ftmsAccessoryAdvancedOptionsAccordion",
+        "name": "Advanced SmartSpin2k Calibration",
+        "parent": "ftmsAccessoryOptionsAccordion",
+        "depth": 2,
+        "sourceLine": 15202
+      },
+      {
+        "key": "fitmetriaFanFitOptionsAccordion",
+        "name": "Fitmetria Fitfan™ Options",
+        "parent": "accesoriesAccordion",
+        "depth": 1,
+        "sourceLine": 15403
+      },
+      {
+        "key": "headWindModeTextField",
+        "name": "Wahoo Kickr HeadWind Options",
+        "parent": "accesoriesAccordion",
+        "depth": 1,
+        "sourceLine": 15504
+      },
+      {
+        "key": "eliteAriaModeTextField",
+        "name": "Elite Aria Options",
+        "parent": "accesoriesAccordion",
+        "depth": 1,
+        "sourceLine": 15597
+      },
+      {
+        "key": "zwiftDevPollTimeTextField",
+        "name": "Zwift Devices Options",
+        "parent": "accesoriesAccordion",
+        "depth": 1,
+        "sourceLine": 15802
+      },
+      {
+        "key": "mapsAccordion",
+        "name": "Maps 🗺️",
+        "parent": null,
+        "depth": 0,
+        "sourceLine": 16137
+      },
+      {
+        "key": "experimentalFeatureAccordion",
+        "name": "Experimental Features",
+        "parent": null,
+        "depth": 0,
+        "sourceLine": 16231
+      },
+      {
+        "key": "virtualDeviceAccordion",
+        "name": "Enable Virtual Device",
+        "parent": "experimentalFeatureAccordion",
+        "depth": 1,
+        "sourceLine": 16369
+      },
+      {
+        "key": "virtualBeviceBluetoothAccordion",
+        "name": "Virtual Device Bluetooth",
+        "parent": "virtualDeviceAccordion",
+        "depth": 2,
+        "sourceLine": 16375
+      },
+      {
+        "key": "dirconAccordion",
+        "name": "Wahoo direct connect",
+        "parent": "virtualDeviceAccordion",
+        "depth": 2,
+        "sourceLine": 16636
+      },
+      {
+        "key": "mqttAccordion",
+        "name": "MQTT Settings",
+        "parent": "experimentalFeatureAccordion",
+        "depth": 1,
+        "sourceLine": 16736
+      },
+      {
+        "key": "oscAccordion",
+        "name": "OSC Settings",
+        "parent": "experimentalFeatureAccordion",
+        "depth": 1,
+        "sourceLine": 16927
+      },
+      {
+        "key": "templateSettingsAccordion",
+        "name": "Template Settings",
+        "parent": "experimentalFeatureAccordion",
+        "depth": 1,
+        "sourceLine": 17040
+      }
+    ],
+    "settingNodeByKey": {
+      "age": "generalOptionsAccordion",
+      "android_antbike": "uiAntOptionsAccordion",
+      "android_documents_folder": "experimentalFeatureAccordion",
+      "android_notification": "zwiftUsernameTextField",
+      "android_wakelock": "experimentalFeatureAccordion",
+      "ant_bike_device_number": "technogymBikeAccordion",
+      "ant_cadence": "uiAntOptionsAccordion",
+      "ant_garmin": "garminOptionsAccordion",
+      "ant_heart": "uiAntOptionsAccordion",
+      "ant_heart_device_number": "uiAntOptionsAccordion",
+      "ant_speed_gain": "uiAntOptionsAccordion",
+      "ant_speed_offset": "uiAntOptionsAccordion",
+      "antbike": "garminOptionsAccordion",
+      "app_language": "generalOptionsAccordion",
+      "applewatch_as_treadmill_speed": "experimentalFeatureAccordion",
+      "applewatch_fakedevice": "experimentalFeatureAccordion",
+      "asviva_bike": "toorxTreadmillAccordion",
+      "atletica_lightspeed_treadmill": "fitshowAccordion",
+      "autolap_distance": "advancedSettingsAccordion",
+      "automatic_virtual_shifting_climb_gear_down_cadence": "automaticVirtualShiftingAccordion",
+      "automatic_virtual_shifting_climb_gear_down_time": "automaticVirtualShiftingAccordion",
+      "automatic_virtual_shifting_climb_gear_up_cadence": "automaticVirtualShiftingAccordion",
+      "automatic_virtual_shifting_climb_gear_up_time": "automaticVirtualShiftingAccordion",
+      "automatic_virtual_shifting_enabled": "automaticVirtualShiftingAccordion",
+      "automatic_virtual_shifting_gear_down_cadence": "automaticVirtualShiftingAccordion",
+      "automatic_virtual_shifting_gear_down_time": "automaticVirtualShiftingAccordion",
+      "automatic_virtual_shifting_gear_up_cadence": "automaticVirtualShiftingAccordion",
+      "automatic_virtual_shifting_gear_up_time": "automaticVirtualShiftingAccordion",
+      "automatic_virtual_shifting_profile": "automaticVirtualShiftingAccordion",
+      "automatic_virtual_shifting_sprint_gear_down_cadence": "automaticVirtualShiftingAccordion",
+      "automatic_virtual_shifting_sprint_gear_down_time": "automaticVirtualShiftingAccordion",
+      "automatic_virtual_shifting_sprint_gear_up_cadence": "automaticVirtualShiftingAccordion",
+      "automatic_virtual_shifting_sprint_gear_up_time": "automaticVirtualShiftingAccordion",
+      "battery_service": "experimentalFeatureAccordion",
+      "bh_spada_2": "toorxTreadmillAccordion",
+      "bh_spada_2_watt": "toorxTreadmillAccordion",
+      "bike_cadence_sensor": "pelotonAccordion",
+      "bike_heartrate_service": "heartRateOptionsAccordion",
+      "bike_power_offset": "bikeOptionsAccordion",
+      "bike_power_sensor": "virtualBeviceBluetoothAccordion",
+      "bike_resistance_gain_f": "bikeOptionsAccordion",
+      "bike_resistance_offset": "bikeOptionsAccordion",
+      "bike_resistance_start": "bikeOptionsAccordion",
+      "bike_weight": "bikeOptionsAccordion",
+      "bluetooth_30m_hangs": "experimentalFeatureAccordion",
+      "bluetooth_relaxed": "experimentalFeatureAccordion",
+      "cadence_gain": "advancedSettingsAccordion",
+      "cadence_offset": "advancedSettingsAccordion",
+      "cadence_sensor_as_bike": "cadenceSensorOptionsAccordion",
+      "cadence_sensor_as_treadmill": "cadenceSensorOptionsAccordion",
+      "cadence_sensor_name": "cadenceSensorOptionsAccordion",
+      "cadence_sensor_speed_ratio": "cadenceSensorOptionsAccordion",
+      "calories_active_only": "heartRateOptionsAccordion",
+      "calories_from_hr": "heartRateOptionsAccordion",
+      "chart_display_mode": "uiGeneralOptionsAccordion",
+      "computrainer_serialport": "computrainerBikeAccordion",
+      "confirm_stop_workout": "advancedSettingsAccordion",
+      "continuous_moving": "generalOptionsAccordion",
+      "crrGain": "bikeOptionsAccordion",
+      "csafe_rower": "csaferowerSerialPortTextField",
+      "cscbike_custom_resistance_level_1": "cadenceSensorOptionsAccordion",
+      "cscbike_custom_resistance_level_2": "cadenceSensorOptionsAccordion",
+      "cscbike_custom_resistance_power_table": "cadenceSensorOptionsAccordion",
+      "cscbike_custom_watt_1": "cadenceSensorOptionsAccordion",
+      "cscbike_custom_watt_2": "cadenceSensorOptionsAccordion",
+      "cwGain": "bikeOptionsAccordion",
+      "dircon_id": "dirconAccordion",
+      "dircon_server_base_port": "dirconAccordion",
+      "dircon_yes": "openBikeControlAccordion",
+      "dkn_endurun_treadmill": "toorxTreadmillAccordion",
+      "domyos_bike_500_profile_v1": "domyosBikeAccordion",
+      "domyos_bike_500_profile_v2": "domyosBikeAccordion",
+      "domyos_bike_cadence_filter": "domyosBikeAccordion",
+      "domyos_bike_display_calories": "domyosBikeAccordion",
+      "domyos_elliptical_inclination": "domyosEllipticalAccordion",
+      "domyos_elliptical_speed_ratio": "domyosEllipticalAccordion",
+      "domyos_run100e": "domyosTreadmillAccordion",
+      "domyos_treadmill_button_10kmh": "domyosTreadmillAccordion",
+      "domyos_treadmill_button_16kmh": "domyosTreadmillAccordion",
+      "domyos_treadmill_button_22kmh": "domyosTreadmillAccordion",
+      "domyos_treadmill_button_5kmh": "domyosTreadmillAccordion",
+      "domyos_treadmill_buttons": "domyosTreadmillAccordion",
+      "domyos_treadmill_display_invert": "domyosTreadmillAccordion",
+      "domyos_treadmill_distance_display": "domyosTreadmillAccordion",
+      "domyos_treadmill_sync_start": "domyosTreadmillAccordion",
+      "domyos_treadmill_t900a": "domyosTreadmillAccordion",
+      "domyos_treadmill_ts100": "domyosTreadmillAccordion",
+      "domyosbike_notfmts": "domyosBikeAccordion",
+      "echelon_resistance_gain": "echelonBikeOptionsAccordion",
+      "echelon_resistance_offset": "echelonBikeOptionsAccordion",
+      "echelon_watttable": "echelonBikeOptionsAccordion",
+      "elite_rizer_gain": "eliteRizerOptionsAccordion",
+      "elite_rizer_name": "eliteRizerOptionsAccordion",
+      "elite_sterzo_smart_name": "eliteSterzoSmartOptionsAccordion",
+      "enerfit_SPX_9500": "toorxTreadmillAccordion",
+      "ergDataPoints": "advancedSettingsAccordion",
+      "eslinker_cadenza": "eslinkerTreadmillAccordion",
+      "eslinker_costaway": "eslinkerTreadmillAccordion",
+      "eslinker_ypoo": "eslinkerTreadmillAccordion",
+      "fakedevice_elliptical": "experimentalFeatureAccordion",
+      "fakedevice_rower": "experimentalFeatureAccordion",
+      "fakedevice_treadmill": "experimentalFeatureAccordion",
+      "filter_device": "advancedSettingsAccordion",
+      "fit_file_garmin_device_training_effect": "garminOptionsAccordion",
+      "fit_file_garmin_device_training_effect_device": "garminOptionsAccordion",
+      "fitfiu_mc_v460": "runnerTTreadmillAccordion",
+      "fitmetria_fanfit_enable": "eliteAriaModeTextField",
+      "fitmetria_fanfit_max": "eliteAriaModeTextField",
+      "fitmetria_fanfit_min": "eliteAriaModeTextField",
+      "fitmetria_fanfit_mode": "eliteAriaModeTextField",
+      "fitplus_bike": "fitplusBikeAccordion",
+      "fitshow_anyrun": "fitshowAccordion",
+      "fitshow_treadmill_miles": "bowflexTreadmillAccordion",
+      "fitshow_truetimer": "fitshowAccordion",
+      "fitshow_user_id": "fitshowAccordion",
+      "floating_height": "uiGeneralOptionsAccordion",
+      "floating_startup": "uiGeneralOptionsAccordion",
+      "floating_transparency": "uiGeneralOptionsAccordion",
+      "floating_width": "uiGeneralOptionsAccordion",
+      "floatingwindow_type": "uiGeneralOptionsAccordion",
+      "flywheel_filter": "flywheelBikeAccordion",
+      "flywheel_life_fitness_ic8": "flywheelBikeAccordion",
+      "force_resistance_instead_inclination": "advancedSettingsAccordion",
+      "freebeat_serialport": "freebeatBikeAccordion",
+      "freemotion_coachbike_b22_7": "proformBikeAccordion",
+      "ftms_accessory_name": "ftmsAccessoryOptionsAccordion",
+      "ftms_bike": "bikeOptionsAccordion",
+      "ftms_elliptical": "ellipticalAccordion",
+      "ftms_rower": "ftmsRowerTextField",
+      "ftms_treadmill": "treadmillAccordion",
+      "ftp": "generalOptionsAccordion",
+      "ftp_run": "generalOptionsAccordion",
+      "fytter_ri08_bike": "toorxTreadmillAccordion",
+      "garmin_bluetooth_compatibility": "garminOptionsAccordion",
+      "garmin_companion": "garminOptionsAccordion",
+      "garmin_device_serial": "garminOptionsAccordion",
+      "garmin_domain": "garminOptionsAccordion",
+      "garmin_download_workouts_on_start": "garminOptionsAccordion",
+      "garmin_email": "garminOptionsAccordion",
+      "garmin_expires_at": "garminOptionsAccordion",
+      "garmin_password": "garminOptionsAccordion",
+      "garmin_refresh_token_expires_at": "garminOptionsAccordion",
+      "garmin_upload_enabled": "garminOptionsAccordion",
+      "gears_current_value_f": "bikeOptionsAccordion",
+      "gears_from_bike": "echelonBikeOptionsAccordion",
+      "gears_gain": "bikeOptionsAccordion",
+      "gears_offset": "bikeOptionsAccordion",
+      "gears_restore_value": "bikeOptionsAccordion",
+      "gears_volume_debouncing": "zwiftDevPollTimeTextField",
+      "gears_zwift_ratio": "zwiftDevPollTimeTextField",
+      "gpx_loop": "mapsAccordion",
+      "gym_mode": "experimentalFeatureAccordion",
+      "gymstick_gx6_0_elliptical": "ellipticalAccordion",
+      "hammer_racer_s": "hammerBikeAccordion",
+      "heart_ignore_builtin": "heartRateOptionsAccordion",
+      "heart_max_override_enable": "heartRatemaxOverrideAccordion",
+      "heart_max_override_value": "heartRatemaxOverrideAccordion",
+      "heart_rate_belt_name": "heartRateOptionsAccordion",
+      "heart_rate_resting": "heartRatemaxOverrideAccordion",
+      "heart_rate_zone1": "heartRateZoneAccordion",
+      "heart_rate_zone2": "heartRateZoneAccordion",
+      "heart_rate_zone3": "heartRateZoneAccordion",
+      "heart_rate_zone4": "heartRateZoneAccordion",
+      "height": "generalOptionsAccordion",
+      "hertz_xr_770": "toorxTreadmillAccordion",
+      "hop_sport_hs_090h_bike": "toorxTreadmillAccordion",
+      "horizon_gr7_cadence_multiplier": "horizonBikeAccordion",
+      "horizon_paragon_x": "horizonTreadmillAccordion",
+      "horizon_treadmill_7_8": "horizonTreadmillAccordion",
+      "horizon_treadmill_disable_pause": "horizonTreadmillAccordion",
+      "horizon_treadmill_force_ftms": "horizonTreadmillAccordion",
+      "horizon_treadmill_omega_z": "horizonTreadmillAccordion",
+      "horizon_treadmill_profile_user1": "horizonTreadmillAccordion",
+      "horizon_treadmill_profile_user2": "horizonTreadmillAccordion",
+      "horizon_treadmill_profile_user3": "horizonTreadmillAccordion",
+      "horizon_treadmill_profile_user4": "horizonTreadmillAccordion",
+      "horizon_treadmill_profile_user5": "horizonTreadmillAccordion",
+      "horizon_treadmill_suspend_stats_pause": "horizonTreadmillAccordion",
+      "iconcept_ftms_treadmill_inclination_table": "toorxTreadmillAccordion",
+      "iconsole_elliptical": "toorxTreadmillAccordion",
+      "iconsole_rower": "toorxTreadmillAccordion",
+      "inclination_delay_seconds": "advancedSettingsAccordion",
+      "inspire_peloton_formula": "inspireBikeAccordion",
+      "inspire_peloton_formula2": "inspireBikeAccordion",
+      "instant_power_on_pause": "advancedSettingsAccordion",
+      "ios_btdevice_native": "experimentalFeatureAccordion",
+      "ios_cache_heart_device": "experimentalFeatureAccordion",
+      "ios_live_activity_compact_leading_metric": "uiGeneralOptionsAccordion",
+      "ios_live_activity_compact_trailing_metric": "uiGeneralOptionsAccordion",
+      "ios_peloton_workaround": "experimentalFeatureAccordion",
+      "jll_IC400_bike": "toorxTreadmillAccordion",
+      "jtx_fitness_sprint_treadmill": "toorxTreadmillAccordion",
+      "kcal_ignore_builtin": "heartRateOptionsAccordion",
+      "kettler_usb_baudrate": "kettlerUsbBikeAccordion",
+      "kettler_usb_serialport": "kettlerUsbBikeAccordion",
+      "kingsmith_encrypt_g1_walking_pad": "kingsmithTreadmillAccordion",
+      "kingsmith_encrypt_v2": "kingsmithTreadmillAccordion",
+      "kingsmith_encrypt_v3": "kingsmithTreadmillAccordion",
+      "kingsmith_encrypt_v4": "kingsmithTreadmillAccordion",
+      "kingsmith_encrypt_v5": "kingsmithTreadmillAccordion",
+      "kingsmith_r2_enable_hw_buttons": "kingsmithTreadmillAccordion",
+      "life_fitness_ic5": "flywheelBikeAccordion",
+      "lifespan_bike": "lifespanBikeAccordion",
+      "log_debug": "experimentalFeatureAccordion",
+      "m3i_bike_id": "m3iBikeAccordion",
+      "m3i_bike_kcal": "m3iBikeAccordion",
+      "m3i_bike_qt_search": "m3iBikeAccordion",
+      "m3i_bike_speed_buffsize": "m3iBikeAccordion",
+      "maps_type": "mapsAccordion",
+      "miles_unit": "generalOptionsAccordion",
+      "min_inclination": "advancedSettingsAccordion",
+      "mqtt_deviceid": "mqttAccordion",
+      "mqtt_host": "mqttAccordion",
+      "mqtt_password": "mqttAccordion",
+      "mqtt_port": "mqttAccordion",
+      "mqtt_username": "mqttAccordion",
+      "mywhoosh_link_camera_value": "openBikeControlAccordion",
+      "mywhoosh_link_emote_value": "openBikeControlAccordion",
+      "mywhoosh_link_enabled": "openBikeControlAccordion",
+      "mywhoosh_link_left_down": "openBikeControlAccordion",
+      "mywhoosh_link_left_left": "openBikeControlAccordion",
+      "mywhoosh_link_left_power": "openBikeControlAccordion",
+      "mywhoosh_link_left_right": "openBikeControlAccordion",
+      "mywhoosh_link_left_shoulder": "openBikeControlAccordion",
+      "mywhoosh_link_left_up": "openBikeControlAccordion",
+      "mywhoosh_link_override_gears": "openBikeControlAccordion",
+      "mywhoosh_link_right_a": "openBikeControlAccordion",
+      "mywhoosh_link_right_b": "openBikeControlAccordion",
+      "mywhoosh_link_right_power": "openBikeControlAccordion",
+      "mywhoosh_link_right_shoulder": "openBikeControlAccordion",
+      "mywhoosh_link_right_y": "openBikeControlAccordion",
+      "mywhoosh_link_right_z": "openBikeControlAccordion",
+      "nordictrack_10_treadmill": "proformTreadmillAccordion",
+      "nordictrack_2950_ip": "proformTreadmillAccordion",
+      "nordictrack_GX4_5_bike": "proformBikeAccordion",
+      "nordictrack_elite_800": "proformTreadmillAccordion",
+      "nordictrack_elliptical_c7_5": "proformEllipticalAccordion",
+      "nordictrack_elliptical_s700": "proformEllipticalAccordion",
+      "nordictrack_gx_2_7": "proformBikeAccordion",
+      "nordictrack_gx_44_pro": "proformBikeAccordion",
+      "nordictrack_gx_4_5_pro": "proformBikeAccordion",
+      "nordictrack_ifit_adb_remote": "proformEllipticalAccordion",
+      "nordictrack_incline_trainer_x7i": "proformTreadmillAccordion",
+      "nordictrack_incline_trainer_x7i_ntl15010_0": "proformTreadmillAccordion",
+      "nordictrack_s20_treadmill": "proformTreadmillAccordion",
+      "nordictrack_s20i_treadmill": "proformTreadmillAccordion",
+      "nordictrack_s30_treadmill": "proformTreadmillAccordion",
+      "nordictrack_se7i": "proformEllipticalAccordion",
+      "nordictrack_series_7": "proformTreadmillAccordion",
+      "nordictrack_t65s_83_treadmill": "proformTreadmillAccordion",
+      "nordictrack_t65s_treadmill": "proformTreadmillAccordion",
+      "nordictrack_t65s_treadmill_81_miles": "proformTreadmillAccordion",
+      "nordictrack_t70_treadmill": "proformTreadmillAccordion",
+      "nordictrack_treadmill_1750_adb": "proformTreadmillAccordion",
+      "nordictrack_treadmill_commercial_le": "proformTreadmillAccordion",
+      "nordictrack_treadmill_exp_5i": "proformTreadmillAccordion",
+      "nordictrack_treadmill_t8_5s": "proformTreadmillAccordion",
+      "nordictrack_treadmill_ultra_le": "proformTreadmillAccordion",
+      "nordictrack_treadmill_x14i": "proformTreadmillAccordion",
+      "nordictrack_tseries5_treadmill": "proformTreadmillAccordion",
+      "nordictrack_vr21": "proformBikeAccordion",
+      "nordictrack_x22i": "proformTreadmillAccordion",
+      "nordictrackadbbike_resistance": "proformBikeAccordion",
+      "norditrack_s25_treadmill": "proformTreadmillAccordion",
+      "norditrack_s25i_treadmill": "proformTreadmillAccordion",
+      "osc_ip": "oscAccordion",
+      "osc_port": "oscAccordion",
+      "pace_default": "trainingProgramOptionsAccordion",
+      "pacef_10km": "trainingProgramOptionsAccordion",
+      "pacef_1mile": "trainingProgramOptionsAccordion",
+      "pacef_5km": "trainingProgramOptionsAccordion",
+      "pacef_halfmarathon": "trainingProgramOptionsAccordion",
+      "pacef_marathon": "trainingProgramOptionsAccordion",
+      "pafers_treadmill": "pafersTreadmillAccordion",
+      "pafers_treadmill_bh_iboxster_plus": "pafersTreadmillAccordion",
+      "pause_on_start": "generalOptionsAccordion",
+      "pause_on_start_treadmill": "treadmillAccordion",
+      "peloton_auto_start_with_intro": "pelotonAccordion",
+      "peloton_auto_start_without_intro": "pelotonAccordion",
+      "peloton_bike_ocr": "pelotonAccordion",
+      "peloton_companion_workout_ocr": "pelotonAccordion",
+      "peloton_date": "pelotonAccordion",
+      "peloton_date_format": "pelotonAccordion",
+      "peloton_description_link": "pelotonAccordion",
+      "peloton_difficulty": "pelotonAccordion",
+      "peloton_gain": "pelotonAccordion",
+      "peloton_heartrate_metric": "pelotonAccordion",
+      "peloton_offset": "pelotonAccordion",
+      "peloton_rower_level": "pelotonAccordion",
+      "peloton_spinups_autoresistance": "pelotonAccordion",
+      "peloton_treadmill_level": "pelotonAccordion",
+      "peloton_treadmill_running_min_speed": "pelotonAccordion",
+      "peloton_treadmill_walk_level": "pelotonAccordion",
+      "peloton_treadmill_walking_min_speed": "pelotonAccordion",
+      "peloton_workout_ocr": "pelotonAccordion",
+      "pid_heart_zone_erg_mode_watt_step": "trainingProgramOptionsAccordion",
+      "poll_device_time": "zwiftDevPollTimeTextField",
+      "power_avg_3s": "advancedSettingsAccordion",
+      "power_avg_5s": "advancedSettingsAccordion",
+      "power_hr_hr1": "powerFromHeartRateAccordion",
+      "power_hr_hr2": "powerFromHeartRateAccordion",
+      "power_hr_pwr1": "powerFromHeartRateAccordion",
+      "power_hr_pwr2": "powerFromHeartRateAccordion",
+      "power_sensor_as_bike": "powerSensorOptionsAccordion",
+      "power_sensor_as_treadmill": "powerSensorOptionsAccordion",
+      "power_sensor_cadence_instead_treadmill": "powerSensorOptionsAccordion",
+      "power_sensor_name": "powerSensorOptionsAccordion",
+      "power_sensor_speed_inclination_coeff_a": "powerSensorOptionsAccordion",
+      "power_sensor_speed_inclination_coeff_b": "powerSensorOptionsAccordion",
+      "powr_sensor_running_cadence_double": "powerSensorOptionsAccordion",
+      "powr_sensor_running_cadence_half_on_strava": "powerSensorOptionsAccordion",
+      "proform_2000_treadmill": "proformTreadmillAccordion",
+      "proform_225_csx_PFEX32925_INT_0": "proformBikeAccordion",
+      "proform_505_cst_80_44": "proformTreadmillAccordion",
+      "proform_595i_proshox2": "proformTreadmillAccordion",
+      "proform_8_5_treadmill": "proformTreadmillAccordion",
+      "proform_bike_225_csx": "proformBikeAccordion",
+      "proform_bike_325_csx": "proformBikeAccordion",
+      "proform_bike_325_csx_PFEX439210INT_0": "proformBikeAccordion",
+      "proform_bike_PFEVEX71316_0": "proformBikeAccordion",
+      "proform_bike_PFEVEX71316_1": "proformBikeAccordion",
+      "proform_bike_sb": "proformBikeAccordion",
+      "proform_carbon_tl": "proformTreadmillAccordion",
+      "proform_carbon_tl_PFTL59720": "proformTreadmillAccordion",
+      "proform_carbon_tl_PFTL59722c": "proformTreadmillAccordion",
+      "proform_carbon_tl_PFTL59723_6": "proformTreadmillAccordion",
+      "proform_carbon_tlx_treadmill": "proformTreadmillAccordion",
+      "proform_carbon_tlx_v84_314_treadmill": "proformTreadmillAccordion",
+      "proform_csx210": "proformBikeAccordion",
+      "proform_cycle_trainer_300_ci": "proformBikeAccordion",
+      "proform_cycle_trainer_400": "proformBikeAccordion",
+      "proform_elliptical_ip": "proformEllipticalAccordion",
+      "proform_hybrid_trainer_PFEL03815": "proformEllipticalAccordion",
+      "proform_hybrid_trainer_xt": "proformEllipticalAccordion",
+      "proform_performance_300i": "proformTreadmillAccordion",
+      "proform_performance_400i": "proformTreadmillAccordion",
+      "proform_pro_1000_treadmill": "proformTreadmillAccordion",
+      "proform_proshox2": "proformTreadmillAccordion",
+      "proform_rower_750r": "proformRowerIPTextField",
+      "proform_rower_ip": "proformRowerIPTextField",
+      "proform_rower_sport_rl": "proformRowerIPTextField",
+      "proform_studio": "proformBikeAccordion",
+      "proform_studio_NTEX71021": "proformBikeAccordion",
+      "proform_tdf_10": "proformBikeAccordion",
+      "proform_tdf_10_0": "proformBikeAccordion",
+      "proform_tdf_jonseed_watt": "proformBikeAccordion",
+      "proform_tour_de_france_clc": "proformBikeAccordion",
+      "proform_trainer_8_0": "proformTreadmillAccordion",
+      "proform_trainer_8_0_pftl59721_int_0": "proformTreadmillAccordion",
+      "proform_trainer_9_0": "proformTreadmillAccordion",
+      "proform_treadmill_105_cst": "proformTreadmillAccordion",
+      "proform_treadmill_1500_pro": "proformTreadmillAccordion",
+      "proform_treadmill_1800i": "proformTreadmillAccordion",
+      "proform_treadmill_505_cst": "proformTreadmillAccordion",
+      "proform_treadmill_575i": "proformTreadmillAccordion",
+      "proform_treadmill_705_cst": "proformTreadmillAccordion",
+      "proform_treadmill_705_cst_V78_239": "proformTreadmillAccordion",
+      "proform_treadmill_705_cst_V80_44": "proformTreadmillAccordion",
+      "proform_treadmill_8_0": "proformTreadmillAccordion",
+      "proform_treadmill_8_7": "proformTreadmillAccordion",
+      "proform_treadmill_995i": "proformTreadmillAccordion",
+      "proform_treadmill_9_0": "proformTreadmillAccordion",
+      "proform_treadmill_c700": "proformTreadmillAccordion",
+      "proform_treadmill_c960i": "proformTreadmillAccordion",
+      "proform_treadmill_cadence_lt": "proformTreadmillAccordion",
+      "proform_treadmill_carbon_t7": "proformTreadmillAccordion",
+      "proform_treadmill_carbon_tls": "proformTreadmillAccordion",
+      "proform_treadmill_cst_505_pftl59420_0": "proformTreadmillAccordion",
+      "proform_treadmill_l6_0s": "proformTreadmillAccordion",
+      "proform_treadmill_se": "proformTreadmillAccordion",
+      "proform_treadmill_sport_3_0": "proformTreadmillAccordion",
+      "proform_treadmill_sport_70": "proformTreadmillAccordion",
+      "proform_treadmill_sport_8_5": "proformTreadmillAccordion",
+      "proform_treadmill_z1300i": "proformTreadmillAccordion",
+      "proform_wheel_ratio": "proformBikeAccordion",
+      "proform_xbike": "proformBikeAccordion",
+      "proformtdf1ip": "proformBikeAccordion",
+      "proformtdf4ip": "proformBikeAccordion",
+      "proformtreadmillip": "proformTreadmillAccordion",
+      "pzp_password": "pelotonAccordion",
+      "pzp_username": "pelotonAccordion",
+      "race_mode": "experimentalFeatureAccordion",
+      "real_inclination_to_virtual_treamill_bridge": "advancedSettingsAccordion",
+      "reebok_fr30_treadmill": "toorxTreadmillAccordion",
+      "renpho_bike_double_resistance": "renphoBikeAccordion",
+      "renpho_bike_knob_gears": "renphoBikeAccordion",
+      "renpho_peloton_conversion_v2": "renphoBikeAccordion",
+      "restore_specific_gear": "bikeOptionsAccordion",
+      "rogue_echo_bike": "cadenceSensorOptionsAccordion",
+      "rolling_resistance": "bikeOptionsAccordion",
+      "rpe_feel_popup_enabled": "garminOptionsAccordion",
+      "run_cadence_sensor": "experimentalFeatureAccordion",
+      "schwinn_bike_resistance": "schwinnBikeAccordion",
+      "schwinn_bike_resistance_v2": "schwinnBikeAccordion",
+      "schwinn_bike_resistance_v3": "schwinnBikeAccordion",
+      "schwinn_resistance_smooth": "schwinnBikeAccordion",
+      "service_changed": "advancedSettingsAccordion",
+      "sex": "generalOptionsAccordion",
+      "skandika_wiri_x2000_protocol": "skandikaBikeAccordion",
+      "sole_elliptical_e55": "soleEllipticalAccordion",
+      "sole_elliptical_inclination": "soleEllipticalAccordion",
+      "sole_treadmill_f63": "soleTreadmillAccordion",
+      "sole_treadmill_f65": "soleTreadmillAccordion",
+      "sole_treadmill_inclination": "soleTreadmillAccordion",
+      "sole_treadmill_inclination_fast": "soleTreadmillAccordion",
+      "sole_treadmill_miles": "soleTreadmillAccordion",
+      "sole_treadmill_tt8": "soleTreadmillAccordion",
+      "sp_ht_9600ie": "cardioFitBikeAccordion",
+      "speed_gain": "advancedSettingsAccordion",
+      "speed_offset": "advancedSettingsAccordion",
+      "speed_power_based": "bikeOptionsAccordion",
+      "sportstech_esx500": "fitplusBikeAccordion",
+      "sportstech_sx600": "fitplusBikeAccordion",
+      "ss2k_max_resistance": "ftmsAccessoryOptionsAccordion",
+      "ss2k_min_resistance": "ftmsAccessoryOptionsAccordion",
+      "ss2k_peloton": "ftmsAccessoryOptionsAccordion",
+      "ss2k_resistance_sample_1": "ftmsAccessoryAdvancedOptionsAccordion",
+      "ss2k_resistance_sample_2": "ftmsAccessoryAdvancedOptionsAccordion",
+      "ss2k_resistance_sample_3": "ftmsAccessoryAdvancedOptionsAccordion",
+      "ss2k_resistance_sample_4": "ftmsAccessoryAdvancedOptionsAccordion",
+      "ss2k_shift_step": "ftmsAccessoryOptionsAccordion",
+      "ss2k_shift_step_sample_1": "ftmsAccessoryAdvancedOptionsAccordion",
+      "ss2k_shift_step_sample_2": "ftmsAccessoryAdvancedOptionsAccordion",
+      "ss2k_shift_step_sample_3": "ftmsAccessoryAdvancedOptionsAccordion",
+      "ss2k_shift_step_sample_4": "ftmsAccessoryAdvancedOptionsAccordion",
+      "step_gain": "treadmillAccordion",
+      "strava_auth_external_webbrowser": "advancedSettingsAccordion",
+      "strava_date_prefix": "advancedSettingsAccordion",
+      "strava_suffix": "advancedSettingsAccordion",
+      "strava_treadmill": "advancedSettingsAccordion",
+      "strava_upload_mode": "advancedSettingsAccordion",
+      "strava_virtual_activity": "advancedSettingsAccordion",
+      "stryd_add_inclination_gain": "powerSensorOptionsAccordion",
+      "stryd_inclination_instead_treadmill": "powerSensorOptionsAccordion",
+      "stryd_speed_instead_treadmill": "powerSensorOptionsAccordion",
+      "taurua_ic90": "toorxTreadmillAccordion",
+      "tdf_10_ip": "proformBikeAccordion",
+      "technogym_bike": "technogymBikeAccordion",
+      "technogym_group_cycle": "technogymBikeAccordion",
+      "technogym_myrun_treadmill_experimental": "technogymTreadmillAccordion",
+      "theme_background_color": "themesOptionsAccordion",
+      "theme_status_bar_background_color": "themesOptionsAccordion",
+      "theme_tile_background_color": "themesOptionsAccordion",
+      "theme_tile_icon_enabled": "themesOptionsAccordion",
+      "theme_tile_secondline_textsize": "themesOptionsAccordion",
+      "theme_tile_shadow_color": "themesOptionsAccordion",
+      "theme_tile_shadow_enabled": "themesOptionsAccordion",
+      "toorx_3_0": "toorxTreadmillAccordion",
+      "toorx_65s_evo": "toorxTreadmillAccordion",
+      "toorx_bike": "toorxTreadmillAccordion",
+      "toorx_bike_srx_500": "toorxTreadmillAccordion",
+      "toorx_ftms": "toorxTreadmillAccordion",
+      "toorx_ftms_treadmill": "toorxTreadmillAccordion",
+      "toorx_srx_3500": "toorxTreadmillAccordion",
+      "toorxtreadmill_discovery_completed": "toorxTreadmillAccordion",
+      "top_bar_enabled": "uiGeneralOptionsAccordion",
+      "trainprogram_auto_lap_on_segment": "trainingProgramOptionsAccordion",
+      "trainprogram_clipboard_workout_enabled": "trainingProgramOptionsAccordion",
+      "trainprogram_cooldown_speed": "trainingProgramOptionsAccordion",
+      "trainprogram_incline_max": "trainingProgramOptionsAccordion",
+      "trainprogram_incline_min": "trainingProgramOptionsAccordion",
+      "trainprogram_period_seconds": "trainingProgramOptionsAccordion",
+      "trainprogram_pid_hr_pushy_zone_limit": "trainingProgramOptionsAccordion",
+      "trainprogram_pid_hr_recovery_zone_limit": "trainingProgramOptionsAccordion",
+      "trainprogram_pid_ignore_inclination": "trainingProgramOptionsAccordion",
+      "trainprogram_pid_pushy": "trainingProgramOptionsAccordion",
+      "trainprogram_random": "trainingProgramOptionsAccordion",
+      "trainprogram_resistance_max": "trainingProgramOptionsAccordion",
+      "trainprogram_resistance_min": "trainingProgramOptionsAccordion",
+      "trainprogram_rest_speed": "trainingProgramOptionsAccordion",
+      "trainprogram_sound_on_segment": "trainingProgramOptionsAccordion",
+      "trainprogram_speed_max": "trainingProgramOptionsAccordion",
+      "trainprogram_speed_min": "trainingProgramOptionsAccordion",
+      "trainprogram_stop_at_end": "trainingProgramOptionsAccordion",
+      "trainprogram_total": "trainingProgramOptionsAccordion",
+      "trainprogram_warmup_speed": "trainingProgramOptionsAccordion",
+      "treadmillDataPoints": "advancedSettingsAccordion",
+      "treadmill_difficulty_gain_or_offset": "treadmillAccordion",
+      "treadmill_direct_distance": "treadmillAccordion",
+      "treadmill_follow_wattage": "trainingProgramOptionsAccordion",
+      "treadmill_force_running_activity": "treadmillAccordion",
+      "treadmill_force_speed": "treadmillAccordion",
+      "treadmill_incline_max": "treadmillAccordion",
+      "treadmill_incline_min": "treadmillAccordion",
+      "treadmill_pid_heart_max": "trainingProgramOptionsAccordion",
+      "treadmill_pid_heart_min": "trainingProgramOptionsAccordion",
+      "treadmill_pid_heart_zone": "trainingProgramOptionsAccordion",
+      "treadmill_simulate_inclination_with_speed": "treadmillAccordion",
+      "treadmill_speed_max": "treadmillAccordion",
+      "treadmill_speed_min": "treadmillAccordion",
+      "treadmill_step_incline": "advancedSettingsAccordion",
+      "treadmill_step_speed": "treadmillAccordion",
+      "trx_route_key": "toorxTreadmillAccordion",
+      "ui_zoom": "generalOptionsAccordion",
+      "umay_s100_treadmill": "runnerTTreadmillAccordion",
+      "user_email": "generalOptionsAccordion",
+      "user_nickname": "generalOptionsAccordion",
+      "virtual_device_echelon": "virtualBeviceBluetoothAccordion",
+      "virtual_device_enabled": "experimentalFeatureAccordion",
+      "virtual_device_force_bike": "treadmillAccordion",
+      "virtual_device_force_treadmill": "virtualBeviceBluetoothAccordion",
+      "virtual_device_ifit": "virtualBeviceBluetoothAccordion",
+      "virtual_device_onlyheart": "virtualBeviceBluetoothAccordion",
+      "virtual_device_rower": "virtualBeviceBluetoothAccordion",
+      "virtual_device_rower_pm5": "virtualBeviceBluetoothAccordion",
+      "virtual_device_tacx": "virtualBeviceBluetoothAccordion",
+      "virtualbike_forceresistance": "virtualBeviceBluetoothAccordion",
+      "virtufit_etappe": "fitplusBikeAccordion",
+      "volume_change_gears": "advancedSettingsAccordion",
+      "wahoo_rgt_dircon": "dirconAccordion",
+      "waterrower_usb": "ftmsRowerTextField",
+      "watt_bike_emulator": "zwiftUsernameTextField",
+      "watt_gain": "advancedSettingsAccordion",
+      "watt_ignore_builtin": "advancedSettingsAccordion",
+      "watt_offset": "advancedSettingsAccordion",
+      "weight": "generalOptionsAccordion",
+      "weight_kg_unit": "generalOptionsAccordion",
+      "yesoul_peloton_formula": "yesoulBikeAccordion",
+      "zero_zt2500_treadmill": "runnerTTreadmillAccordion",
+      "zwift_api_autoinclination": "zwiftUsernameTextField",
+      "zwift_api_poll": "zwiftUsernameTextField",
+      "zwift_click": "zwiftDevPollTimeTextField",
+      "zwift_erg": "bikeOptionsAccordion",
+      "zwift_erg_filter": "bikeOptionsAccordion",
+      "zwift_erg_filter_down": "bikeOptionsAccordion",
+      "zwift_erg_resistance_down": "bikeOptionsAccordion",
+      "zwift_erg_resistance_up": "bikeOptionsAccordion",
+      "zwift_gear_ui_aligned": "zwiftUsernameTextField",
+      "zwift_inclination_gain": "advancedSettingsAccordion",
+      "zwift_inclination_offset": "advancedSettingsAccordion",
+      "zwift_negative_inclination_x2": "advancedSettingsAccordion",
+      "zwift_ocr": "zwiftUsernameTextField",
+      "zwift_ocr_climb_portal": "zwiftUsernameTextField",
+      "zwift_password": "zwiftUsernameTextField",
+      "zwift_play": "zwiftDevPollTimeTextField",
+      "zwift_play_emulator": "zwiftUsernameTextField",
+      "zwift_play_vibration": "zwiftDevPollTimeTextField",
+      "zwift_username": "zwiftUsernameTextField",
+      "zwift_workout_ocr": "zwiftUsernameTextField",
+      "zwiftplay_gear_lb": "zwiftDevPollTimeTextField",
+      "zwiftplay_gear_ls1": "zwiftDevPollTimeTextField",
+      "zwiftplay_gear_ls2": "zwiftDevPollTimeTextField",
+      "zwiftplay_gear_paddle_left": "zwiftDevPollTimeTextField",
+      "zwiftplay_gear_paddle_right": "zwiftDevPollTimeTextField",
+      "zwiftplay_gear_rb": "zwiftDevPollTimeTextField",
+      "zwiftplay_gear_rs1": "zwiftDevPollTimeTextField",
+      "zwiftplay_gear_rs2": "zwiftDevPollTimeTextField",
+      "zwiftplay_swap": "zwiftDevPollTimeTextField"
+    },
+    "virtualNodeByKey": {
+      "nordictrack_bike_model": "proformBikeAccordion",
+      "nordictrack_treadmill_model": "proformTreadmillAccordion"
+    },
+    "pageNodeByKey": {
+      "page_custom_gear_table": "bikeOptionsAccordion",
+      "page_custom_inclination_resistance_table": "bikeOptionsAccordion",
+      "page_inclination_overrides": "treadmillAccordion",
+      "page_wahoo_options": "bikeOptionsAccordion"
+    }
+  },
+  "legacyLayout": {
+    "source": "legacy QML visual order and NewPageElement navigation",
+    "sourceFileByKey": {
+      "age": "settings.qml",
+      "android_antbike": "settings.qml",
+      "android_documents_folder": "settings.qml",
+      "android_notification": "settings.qml",
+      "android_wakelock": "settings.qml",
+      "ant_bike_device_number": "settings.qml",
+      "ant_cadence": "settings.qml",
+      "ant_garmin": "settings.qml",
+      "ant_heart": "settings.qml",
+      "ant_heart_device_number": "settings.qml",
+      "ant_speed_gain": "settings.qml",
+      "ant_speed_offset": "settings.qml",
+      "antbike": "settings.qml",
+      "app_language": "settings.qml",
+      "app_opening": "settings.qml",
+      "applewatch_as_treadmill_speed": "settings.qml",
+      "applewatch_fakedevice": "settings.qml",
+      "asviva_bike": "settings.qml",
+      "atletica_lightspeed_treadmill": "settings.qml",
+      "autolap_distance": "settings.qml",
+      "automatic_virtual_shifting_climb_gear_down_cadence": "settings.qml",
+      "automatic_virtual_shifting_climb_gear_down_time": "settings.qml",
+      "automatic_virtual_shifting_climb_gear_up_cadence": "settings.qml",
+      "automatic_virtual_shifting_climb_gear_up_time": "settings.qml",
+      "automatic_virtual_shifting_enabled": "settings.qml",
+      "automatic_virtual_shifting_gear_down_cadence": "settings.qml",
+      "automatic_virtual_shifting_gear_down_time": "settings.qml",
+      "automatic_virtual_shifting_gear_up_cadence": "settings.qml",
+      "automatic_virtual_shifting_gear_up_time": "settings.qml",
+      "automatic_virtual_shifting_profile": "settings.qml",
+      "automatic_virtual_shifting_sprint_gear_down_cadence": "settings.qml",
+      "automatic_virtual_shifting_sprint_gear_down_time": "settings.qml",
+      "automatic_virtual_shifting_sprint_gear_up_cadence": "settings.qml",
+      "automatic_virtual_shifting_sprint_gear_up_time": "settings.qml",
+      "battery_service": "settings.qml",
+      "bh_spada_2": "settings.qml",
+      "bh_spada_2_watt": "settings.qml",
+      "bike_cadence_sensor": "settings.qml",
+      "bike_heartrate_service": "settings.qml",
+      "bike_power_offset": "settings.qml",
+      "bike_power_sensor": "settings.qml",
+      "bike_resistance_gain_f": "settings.qml",
+      "bike_resistance_offset": "settings.qml",
+      "bike_resistance_start": "settings.qml",
+      "bike_weight": "settings.qml",
+      "bluetooth_30m_hangs": "settings.qml",
+      "bluetooth_relaxed": "settings.qml",
+      "cadence_gain": "settings.qml",
+      "cadence_offset": "settings.qml",
+      "cadence_sensor_as_bike": "settings.qml",
+      "cadence_sensor_as_treadmill": "settings.qml",
+      "cadence_sensor_name": "settings.qml",
+      "cadence_sensor_speed_ratio": "settings.qml",
+      "calories_active_only": "settings.qml",
+      "calories_from_hr": "settings.qml",
+      "chart_display_mode": "settings.qml",
+      "computrainer_serialport": "settings.qml",
+      "confirm_stop_workout": "settings.qml",
+      "continuous_moving": "settings.qml",
+      "crrGain": "settings.qml",
+      "csafe_elliptical_port": "settings.qml",
+      "csafe_rower": "settings.qml",
+      "cscbike_custom_resistance_level_1": "settings.qml",
+      "cscbike_custom_resistance_level_2": "settings.qml",
+      "cscbike_custom_resistance_power_table": "settings.qml",
+      "cscbike_custom_watt_1": "settings.qml",
+      "cscbike_custom_watt_2": "settings.qml",
+      "custom_inclination_resistance_table": "settings.qml",
+      "custom_inclination_resistance_table_enabled": "settings.qml",
+      "cwGain": "settings.qml",
+      "cycplus_bc2_controller": "settings.qml",
+      "dircon_id": "settings.qml",
+      "dircon_server_base_port": "settings.qml",
+      "dircon_yes": "settings.qml",
+      "dkn_endurun_treadmill": "settings.qml",
+      "domyos_bike_500_profile_v1": "settings.qml",
+      "domyos_bike_500_profile_v2": "settings.qml",
+      "domyos_bike_cadence_filter": "settings.qml",
+      "domyos_bike_display_calories": "settings.qml",
+      "domyos_elliptical_fmts": "settings.qml",
+      "domyos_elliptical_inclination": "settings.qml",
+      "domyos_elliptical_speed_ratio": "settings.qml",
+      "domyos_run100e": "settings.qml",
+      "domyos_treadmill_button_10kmh": "settings.qml",
+      "domyos_treadmill_button_16kmh": "settings.qml",
+      "domyos_treadmill_button_22kmh": "settings.qml",
+      "domyos_treadmill_button_5kmh": "settings.qml",
+      "domyos_treadmill_buttons": "settings.qml",
+      "domyos_treadmill_display_invert": "settings.qml",
+      "domyos_treadmill_distance_display": "settings.qml",
+      "domyos_treadmill_sync_start": "settings.qml",
+      "domyos_treadmill_t900a": "settings.qml",
+      "domyos_treadmill_ts100": "settings.qml",
+      "domyosbike_notfmts": "settings.qml",
+      "domyostreadmill_notfmts": "settings.qml",
+      "echelon_resistance_gain": "settings.qml",
+      "echelon_resistance_offset": "settings.qml",
+      "echelon_watttable": "settings.qml",
+      "elite_rizer_gain": "settings.qml",
+      "elite_rizer_name": "settings.qml",
+      "elite_sterzo_smart_name": "settings.qml",
+      "enerfit_SPX_9500": "settings.qml",
+      "ergDataPoints": "settings.qml",
+      "eslinker_cadenza": "settings.qml",
+      "eslinker_costaway": "settings.qml",
+      "eslinker_ypoo": "settings.qml",
+      "fakedevice_elliptical": "settings.qml",
+      "fakedevice_rower": "settings.qml",
+      "fakedevice_treadmill": "settings.qml",
+      "filter_device": "settings.qml",
+      "fit_file_garmin_device_training_effect": "settings.qml",
+      "fit_file_garmin_device_training_effect_device": "settings.qml",
+      "fitfiu_mc_v460": "settings.qml",
+      "fitmetria_fanfit_enable": "settings.qml",
+      "fitmetria_fanfit_max": "settings.qml",
+      "fitmetria_fanfit_min": "settings.qml",
+      "fitmetria_fanfit_mode": "settings.qml",
+      "fitplus_bike": "settings.qml",
+      "fitshow_anyrun": "settings.qml",
+      "fitshow_treadmill_miles": "settings.qml",
+      "fitshow_truetimer": "settings.qml",
+      "fitshow_user_id": "settings.qml",
+      "floating_height": "settings.qml",
+      "floating_startup": "settings.qml",
+      "floating_transparency": "settings.qml",
+      "floating_width": "settings.qml",
+      "floatingwindow_type": "settings.qml",
+      "flywheel_filter": "settings.qml",
+      "flywheel_life_fitness_ic8": "settings.qml",
+      "force_resistance_instead_inclination": "settings.qml",
+      "freebeat_serialport": "settings.qml",
+      "freemotion_coachbike_b22_7": "settings.qml",
+      "ftms_accessory_name": "settings.qml",
+      "ftms_bike": "settings.qml",
+      "ftms_elliptical": "settings.qml",
+      "ftms_rower": "settings.qml",
+      "ftms_treadmill": "settings.qml",
+      "ftp": "settings.qml",
+      "ftp_run": "settings.qml",
+      "fytter_ri08_bike": "settings.qml",
+      "garmin_access_token": "settings.qml",
+      "garmin_bluetooth_compatibility": "settings.qml",
+      "garmin_companion": "settings.qml",
+      "garmin_device_serial": "settings.qml",
+      "garmin_domain": "settings.qml",
+      "garmin_download_workouts_on_start": "settings.qml",
+      "garmin_email": "settings.qml",
+      "garmin_expires_at": "settings.qml",
+      "garmin_last_refresh": "settings.qml",
+      "garmin_last_seen_cycling_ftp_create_time": "settings.qml",
+      "garmin_last_seen_running_ftp_create_time": "settings.qml",
+      "garmin_oauth1_token": "settings.qml",
+      "garmin_oauth1_token_secret": "settings.qml",
+      "garmin_password": "settings.qml",
+      "garmin_refresh_token": "settings.qml",
+      "garmin_refresh_token_expires_at": "settings.qml",
+      "garmin_token_type": "settings.qml",
+      "garmin_upload_enabled": "settings.qml",
+      "gear_circumference": "settings.qml",
+      "gear_cog_size": "settings.qml",
+      "gear_configuration": "settings.qml",
+      "gear_crankset_size": "settings.qml",
+      "gear_wheel_size": "settings.qml",
+      "gears_current_value": "settings.qml",
+      "gears_current_value_f": "settings.qml",
+      "gears_custom_table": "settings.qml",
+      "gears_custom_table_enabled": "settings.qml",
+      "gears_from_bike": "settings.qml",
+      "gears_gain": "settings.qml",
+      "gears_offset": "settings.qml",
+      "gears_restore_value": "settings.qml",
+      "gears_volume_debouncing": "settings.qml",
+      "gears_zwift_ratio": "settings.qml",
+      "gem_module_inclination": "settings.qml",
+      "gpx_loop": "settings.qml",
+      "gym_mode": "settings.qml",
+      "gymstick_gx6_0_elliptical": "settings.qml",
+      "hammer_racer_s": "settings.qml",
+      "heart_ignore_builtin": "settings.qml",
+      "heart_max_override_enable": "settings.qml",
+      "heart_max_override_value": "settings.qml",
+      "heart_rate_belt_name": "settings.qml",
+      "heart_rate_resting": "settings.qml",
+      "heart_rate_zone1": "settings.qml",
+      "heart_rate_zone2": "settings.qml",
+      "heart_rate_zone3": "settings.qml",
+      "heart_rate_zone4": "settings.qml",
+      "height": "settings.qml",
+      "hertz_xr_770": "settings.qml",
+      "hop_sport_hs_090h_bike": "settings.qml",
+      "horizon_gr7_cadence_multiplier": "settings.qml",
+      "horizon_paragon_x": "settings.qml",
+      "horizon_treadmill_7_0_at_24": "settings.qml",
+      "horizon_treadmill_7_8": "settings.qml",
+      "horizon_treadmill_disable_pause": "settings.qml",
+      "horizon_treadmill_force_ftms": "settings.qml",
+      "horizon_treadmill_omega_z": "settings.qml",
+      "horizon_treadmill_profile_user1": "settings.qml",
+      "horizon_treadmill_profile_user2": "settings.qml",
+      "horizon_treadmill_profile_user3": "settings.qml",
+      "horizon_treadmill_profile_user4": "settings.qml",
+      "horizon_treadmill_profile_user5": "settings.qml",
+      "horizon_treadmill_suspend_stats_pause": "settings.qml",
+      "iconcept_elliptical": "settings.qml",
+      "iconcept_ftms_treadmill_inclination_table": "settings.qml",
+      "iconsole_elliptical": "settings.qml",
+      "iconsole_rower": "settings.qml",
+      "inclinationResistancePoints": "settings.qml",
+      "inclination_delay_seconds": "settings.qml",
+      "inspire_peloton_formula": "settings.qml",
+      "inspire_peloton_formula2": "settings.qml",
+      "instant_power_on_pause": "settings.qml",
+      "intervalsicu_accesstoken": "settings.qml",
+      "intervalsicu_athlete_id": "settings.qml",
+      "intervalsicu_date_prefix": "settings.qml",
+      "intervalsicu_refreshtoken": "settings.qml",
+      "intervalsicu_suffix": "settings.qml",
+      "intervalsicu_upload_enabled": "settings.qml",
+      "ios_btdevice_native": "settings.qml",
+      "ios_cache_heart_device": "settings.qml",
+      "ios_live_activity_compact_leading_metric": "settings.qml",
+      "ios_live_activity_compact_trailing_metric": "settings.qml",
+      "ios_peloton_workaround": "settings.qml",
+      "jll_IC400_bike": "settings.qml",
+      "jtx_fitness_sprint_treadmill": "settings.qml",
+      "kcal_ignore_builtin": "settings.qml",
+      "kettler_usb_baudrate": "settings.qml",
+      "kettler_usb_serialport": "settings.qml",
+      "kingsmith_encrypt_g1_walking_pad": "settings.qml",
+      "kingsmith_encrypt_v2": "settings.qml",
+      "kingsmith_encrypt_v3": "settings.qml",
+      "kingsmith_encrypt_v4": "settings.qml",
+      "kingsmith_encrypt_v5": "settings.qml",
+      "kingsmith_r2_enable_hw_buttons": "settings.qml",
+      "life_fitness_ic5": "settings.qml",
+      "lifespan_bike": "settings.qml",
+      "log_debug": "settings.qml",
+      "m3i_bike_id": "settings.qml",
+      "m3i_bike_kcal": "settings.qml",
+      "m3i_bike_qt_search": "settings.qml",
+      "m3i_bike_speed_buffsize": "settings.qml",
+      "maps_type": "settings.qml",
+      "miles_unit": "settings-tiles.qml",
+      "min_inclination": "settings.qml",
+      "mqtt_deviceid": "settings.qml",
+      "mqtt_host": "settings.qml",
+      "mqtt_password": "settings.qml",
+      "mqtt_port": "settings.qml",
+      "mqtt_username": "settings.qml",
+      "mywhoosh_link_camera_value": "settings.qml",
+      "mywhoosh_link_emote_value": "settings.qml",
+      "mywhoosh_link_enabled": "settings.qml",
+      "mywhoosh_link_left_down": "settings.qml",
+      "mywhoosh_link_left_left": "settings.qml",
+      "mywhoosh_link_left_power": "settings.qml",
+      "mywhoosh_link_left_right": "settings.qml",
+      "mywhoosh_link_left_shoulder": "settings.qml",
+      "mywhoosh_link_left_up": "settings.qml",
+      "mywhoosh_link_override_gears": "settings.qml",
+      "mywhoosh_link_right_a": "settings.qml",
+      "mywhoosh_link_right_b": "settings.qml",
+      "mywhoosh_link_right_power": "settings.qml",
+      "mywhoosh_link_right_shoulder": "settings.qml",
+      "mywhoosh_link_right_y": "settings.qml",
+      "mywhoosh_link_right_z": "settings.qml",
+      "nordictrack_10_treadmill": "settings.qml",
+      "nordictrack_2950_ip": "settings.qml",
+      "nordictrack_GX4_5_bike": "settings.qml",
+      "nordictrack_elite_800": "settings.qml",
+      "nordictrack_elliptical_c7_5": "settings.qml",
+      "nordictrack_elliptical_s700": "settings.qml",
+      "nordictrack_fs5i_treadmill": "settings.qml",
+      "nordictrack_gx_2_7": "settings.qml",
+      "nordictrack_gx_44_pro": "settings.qml",
+      "nordictrack_gx_4_5_pro": "settings.qml",
+      "nordictrack_ifit_adb_remote": "settings.qml",
+      "nordictrack_incline_trainer_x7i": "settings.qml",
+      "nordictrack_incline_trainer_x7i_ntl15010_0": "settings.qml",
+      "nordictrack_s20_treadmill": "settings.qml",
+      "nordictrack_s20i_treadmill": "settings.qml",
+      "nordictrack_s30_treadmill": "settings.qml",
+      "nordictrack_se7i": "settings.qml",
+      "nordictrack_series_7": "settings.qml",
+      "nordictrack_t65s_83_treadmill": "settings.qml",
+      "nordictrack_t65s_treadmill": "settings.qml",
+      "nordictrack_t65s_treadmill_81_miles": "settings.qml",
+      "nordictrack_t70_treadmill": "settings.qml",
+      "nordictrack_treadmill_1750_adb": "settings.qml",
+      "nordictrack_treadmill_commercial_le": "settings.qml",
+      "nordictrack_treadmill_exp_5i": "settings.qml",
+      "nordictrack_treadmill_t8_5s": "settings.qml",
+      "nordictrack_treadmill_ultra_le": "settings.qml",
+      "nordictrack_treadmill_x14i": "settings.qml",
+      "nordictrack_tseries5_treadmill": "settings.qml",
+      "nordictrack_vr21": "settings.qml",
+      "nordictrack_x22i": "settings.qml",
+      "nordictrackadbbike_resistance": "settings.qml",
+      "norditrack_s25_treadmill": "settings.qml",
+      "norditrack_s25i_treadmill": "settings.qml",
+      "osc_ip": "settings.qml",
+      "osc_port": "settings.qml",
+      "pace_default": "settings.qml",
+      "pacef_10km": "settings.qml",
+      "pacef_1mile": "settings.qml",
+      "pacef_5km": "settings.qml",
+      "pacef_halfmarathon": "settings.qml",
+      "pacef_marathon": "settings.qml",
+      "pafers_treadmill": "settings.qml",
+      "pafers_treadmill_bh_iboxster_plus": "settings.qml",
+      "pause_on_start": "settings.qml",
+      "pause_on_start_treadmill": "settings.qml",
+      "peloton_accesstoken": "settings.qml",
+      "peloton_auto_start_with_intro": "settings.qml",
+      "peloton_auto_start_without_intro": "settings.qml",
+      "peloton_bike_ocr": "settings.qml",
+      "peloton_cadence_metric": "settings.qml",
+      "peloton_code": "settings.qml",
+      "peloton_companion_workout_ocr": "settings.qml",
+      "peloton_current_user_id": "settings.qml",
+      "peloton_date": "settings.qml",
+      "peloton_date_format": "settings.qml",
+      "peloton_description_link": "settings.qml",
+      "peloton_difficulty": "settings.qml",
+      "peloton_expires": "settings.qml",
+      "peloton_gain": "settings.qml",
+      "peloton_heartrate_metric": "settings.qml",
+      "peloton_lastrefresh": "settings.qml",
+      "peloton_offset": "settings.qml",
+      "peloton_password": "settings.qml",
+      "peloton_refreshtoken": "settings.qml",
+      "peloton_rower_level": "settings.qml",
+      "peloton_spinups_autoresistance": "settings.qml",
+      "peloton_treadmill_level": "settings.qml",
+      "peloton_treadmill_running_min_speed": "settings.qml",
+      "peloton_treadmill_walk_level": "settings.qml",
+      "peloton_treadmill_walking_min_speed": "settings.qml",
+      "peloton_username": "settings.qml",
+      "peloton_workout_ocr": "settings.qml",
+      "pid_heart_zone_erg_mode_watt_step": "settings.qml",
+      "poll_device_time": "settings.qml",
+      "power_avg_3s": "settings.qml",
+      "power_avg_5s": "settings.qml",
+      "power_hr_hr1": "settings.qml",
+      "power_hr_hr2": "settings.qml",
+      "power_hr_pwr1": "settings.qml",
+      "power_hr_pwr2": "settings.qml",
+      "power_sensor_as_bike": "settings.qml",
+      "power_sensor_as_treadmill": "settings.qml",
+      "power_sensor_cadence_instead_treadmill": "settings.qml",
+      "power_sensor_name": "settings.qml",
+      "power_sensor_speed_inclination_coeff_a": "settings.qml",
+      "power_sensor_speed_inclination_coeff_b": "settings.qml",
+      "powr_sensor_running_cadence_double": "settings.qml",
+      "powr_sensor_running_cadence_half_on_strava": "settings.qml",
+      "profile_name": "settings.qml",
+      "proform_2000_treadmill": "settings.qml",
+      "proform_225_csx_PFEX32925_INT_0": "settings.qml",
+      "proform_505_cst_80_44": "settings.qml",
+      "proform_595i_proshox2": "settings.qml",
+      "proform_8_5_treadmill": "settings.qml",
+      "proform_bike_225_csx": "settings.qml",
+      "proform_bike_325_csx": "settings.qml",
+      "proform_bike_325_csx_PFEX439210INT_0": "settings.qml",
+      "proform_bike_PFEVEX71316_0": "settings.qml",
+      "proform_bike_PFEVEX71316_1": "settings.qml",
+      "proform_bike_sb": "settings.qml",
+      "proform_carbon_tl": "settings.qml",
+      "proform_carbon_tl_PFTL59720": "settings.qml",
+      "proform_carbon_tl_PFTL59722c": "settings.qml",
+      "proform_carbon_tl_PFTL59723_6": "settings.qml",
+      "proform_carbon_tlx_treadmill": "settings.qml",
+      "proform_carbon_tlx_v84_314_treadmill": "settings.qml",
+      "proform_csx210": "settings.qml",
+      "proform_cycle_trainer_300_ci": "settings.qml",
+      "proform_cycle_trainer_400": "settings.qml",
+      "proform_elliptical_ip": "settings.qml",
+      "proform_hybrid_trainer_PFEL03815": "settings.qml",
+      "proform_hybrid_trainer_xt": "settings.qml",
+      "proform_performance_300i": "settings.qml",
+      "proform_performance_400i": "settings.qml",
+      "proform_pro_1000_treadmill": "settings.qml",
+      "proform_proshox2": "settings.qml",
+      "proform_rower_750r": "settings.qml",
+      "proform_rower_ip": "settings.qml",
+      "proform_rower_sport_rl": "settings.qml",
+      "proform_studio": "settings.qml",
+      "proform_studio_NTEX71021": "settings.qml",
+      "proform_tdf_10": "settings.qml",
+      "proform_tdf_10_0": "settings.qml",
+      "proform_tdf_jonseed_watt": "settings.qml",
+      "proform_tour_de_france_clc": "settings.qml",
+      "proform_trainer_8_0": "settings.qml",
+      "proform_trainer_8_0_pftl59721_int_0": "settings.qml",
+      "proform_trainer_9_0": "settings.qml",
+      "proform_treadmill_105_cst": "settings.qml",
+      "proform_treadmill_1500_pro": "settings.qml",
+      "proform_treadmill_1800i": "settings.qml",
+      "proform_treadmill_505_cst": "settings.qml",
+      "proform_treadmill_575i": "settings.qml",
+      "proform_treadmill_705_cst": "settings.qml",
+      "proform_treadmill_705_cst_V78_239": "settings.qml",
+      "proform_treadmill_705_cst_V80_44": "settings.qml",
+      "proform_treadmill_8_0": "settings.qml",
+      "proform_treadmill_8_7": "settings.qml",
+      "proform_treadmill_995i": "settings.qml",
+      "proform_treadmill_9_0": "settings.qml",
+      "proform_treadmill_c700": "settings.qml",
+      "proform_treadmill_c960i": "settings.qml",
+      "proform_treadmill_cadence_lt": "settings.qml",
+      "proform_treadmill_carbon_t7": "settings.qml",
+      "proform_treadmill_carbon_tls": "settings.qml",
+      "proform_treadmill_cst_505_pftl59420_0": "settings.qml",
+      "proform_treadmill_l6_0s": "settings.qml",
+      "proform_treadmill_se": "settings.qml",
+      "proform_treadmill_sport_3_0": "settings.qml",
+      "proform_treadmill_sport_70": "settings.qml",
+      "proform_treadmill_sport_8_5": "settings.qml",
+      "proform_treadmill_z1300i": "settings.qml",
+      "proform_wheel_ratio": "settings.qml",
+      "proform_xbike": "settings.qml",
+      "proformtdf1ip": "settings.qml",
+      "proformtdf4ip": "settings.qml",
+      "proformtreadmillip": "settings.qml",
+      "pzp_password": "settings.qml",
+      "pzp_username": "settings.qml",
+      "race_mode": "settings.qml",
+      "real_inclination_to_virtual_treamill_bridge": "settings.qml",
+      "reebok_fr30_treadmill": "settings.qml",
+      "renpho_bike_double_resistance": "settings.qml",
+      "renpho_bike_knob_gears": "settings.qml",
+      "renpho_peloton_conversion_v2": "settings.qml",
+      "restore_specific_gear": "settings.qml",
+      "rogue_echo_bike": "settings.qml",
+      "rolling_resistance": "settings.qml",
+      "rouvy_compatibility": "settings.qml",
+      "rpe_feel_popup_enabled": "settings.qml",
+      "run_cadence_sensor": "settings.qml",
+      "saris_trainer": "settings.qml",
+      "schwinn_bike_resistance": "settings.qml",
+      "schwinn_bike_resistance_v2": "settings.qml",
+      "schwinn_bike_resistance_v3": "settings.qml",
+      "schwinn_resistance_smooth": "settings.qml",
+      "service_changed": "settings.qml",
+      "sex": "settings.qml",
+      "shortcut_auto_resistance": "settings-shortcuts.qml",
+      "shortcut_avs_climb": "settings-shortcuts.qml",
+      "shortcut_avs_cruise": "settings-shortcuts.qml",
+      "shortcut_avs_sprint": "settings-shortcuts.qml",
+      "shortcut_biggears_minus": "settings-shortcuts.qml",
+      "shortcut_biggears_plus": "settings-shortcuts.qml",
+      "shortcut_erg_mode": "settings-shortcuts.qml",
+      "shortcut_ext_incline_minus": "settings-shortcuts.qml",
+      "shortcut_ext_incline_plus": "settings-shortcuts.qml",
+      "shortcut_fan_minus": "settings-shortcuts.qml",
+      "shortcut_fan_plus": "settings-shortcuts.qml",
+      "shortcut_gears_minus": "settings-shortcuts.qml",
+      "shortcut_gears_plus": "settings-shortcuts.qml",
+      "shortcut_inclination_minus": "settings-shortcuts.qml",
+      "shortcut_inclination_plus": "settings-shortcuts.qml",
+      "shortcut_lap": "settings-shortcuts.qml",
+      "shortcut_peloton_offset_minus": "settings-shortcuts.qml",
+      "shortcut_peloton_offset_plus": "settings-shortcuts.qml",
+      "shortcut_peloton_remaining_minus": "settings-shortcuts.qml",
+      "shortcut_peloton_remaining_plus": "settings-shortcuts.qml",
+      "shortcut_peloton_resistance_minus": "settings-shortcuts.qml",
+      "shortcut_peloton_resistance_plus": "settings-shortcuts.qml",
+      "shortcut_pid_hr_minus": "settings-shortcuts.qml",
+      "shortcut_pid_hr_plus": "settings-shortcuts.qml",
+      "shortcut_power_avg": "settings-shortcuts.qml",
+      "shortcut_preset_inclination_1": "settings-shortcuts.qml",
+      "shortcut_preset_inclination_2": "settings-shortcuts.qml",
+      "shortcut_preset_inclination_3": "settings-shortcuts.qml",
+      "shortcut_preset_inclination_4": "settings-shortcuts.qml",
+      "shortcut_preset_inclination_5": "settings-shortcuts.qml",
+      "shortcut_preset_powerzone_1": "settings-shortcuts.qml",
+      "shortcut_preset_powerzone_2": "settings-shortcuts.qml",
+      "shortcut_preset_powerzone_3": "settings-shortcuts.qml",
+      "shortcut_preset_powerzone_4": "settings-shortcuts.qml",
+      "shortcut_preset_powerzone_5": "settings-shortcuts.qml",
+      "shortcut_preset_powerzone_6": "settings-shortcuts.qml",
+      "shortcut_preset_powerzone_7": "settings-shortcuts.qml",
+      "shortcut_preset_resistance_1": "settings-shortcuts.qml",
+      "shortcut_preset_resistance_2": "settings-shortcuts.qml",
+      "shortcut_preset_resistance_3": "settings-shortcuts.qml",
+      "shortcut_preset_resistance_4": "settings-shortcuts.qml",
+      "shortcut_preset_resistance_5": "settings-shortcuts.qml",
+      "shortcut_preset_speed_1": "settings-shortcuts.qml",
+      "shortcut_preset_speed_2": "settings-shortcuts.qml",
+      "shortcut_preset_speed_3": "settings-shortcuts.qml",
+      "shortcut_preset_speed_4": "settings-shortcuts.qml",
+      "shortcut_preset_speed_5": "settings-shortcuts.qml",
+      "shortcut_remaining_time_minus": "settings-shortcuts.qml",
+      "shortcut_remaining_time_plus": "settings-shortcuts.qml",
+      "shortcut_resistance_minus": "settings-shortcuts.qml",
+      "shortcut_resistance_plus": "settings-shortcuts.qml",
+      "shortcut_speed_minus": "settings-shortcuts.qml",
+      "shortcut_speed_plus": "settings-shortcuts.qml",
+      "shortcut_start_stop": "settings-shortcuts.qml",
+      "shortcut_stop": "settings-shortcuts.qml",
+      "shortcut_target_incline_minus": "settings-shortcuts.qml",
+      "shortcut_target_incline_plus": "settings-shortcuts.qml",
+      "shortcut_target_power_minus": "settings-shortcuts.qml",
+      "shortcut_target_power_plus": "settings-shortcuts.qml",
+      "shortcut_target_resistance_minus": "settings-shortcuts.qml",
+      "shortcut_target_resistance_plus": "settings-shortcuts.qml",
+      "shortcut_target_speed_minus": "settings-shortcuts.qml",
+      "shortcut_target_speed_plus": "settings-shortcuts.qml",
+      "shortcut_target_zone_minus": "settings-shortcuts.qml",
+      "shortcut_target_zone_plus": "settings-shortcuts.qml",
+      "shortcuts_enabled": "settings-shortcuts.qml",
+      "skandika_wiri_x2000_protocol": "settings.qml",
+      "skipLocationServicesDialog": "settings.qml",
+      "snode_bike": "settings.qml",
+      "sole_elliptical_e55": "settings.qml",
+      "sole_elliptical_inclination": "settings.qml",
+      "sole_treadmill_f63": "settings.qml",
+      "sole_treadmill_f65": "settings.qml",
+      "sole_treadmill_inclination": "settings.qml",
+      "sole_treadmill_inclination_fast": "settings.qml",
+      "sole_treadmill_miles": "settings.qml",
+      "sole_treadmill_tt8": "settings.qml",
+      "sp_ht_9600ie": "settings.qml",
+      "speed_gain": "settings.qml",
+      "speed_offset": "settings.qml",
+      "speed_power_based": "settings.qml",
+      "sportstech_esx500": "settings.qml",
+      "sportstech_sx600": "settings.qml",
+      "sram_axs_controller": "settings.qml",
+      "ss2k_max_resistance": "settings.qml",
+      "ss2k_min_resistance": "settings.qml",
+      "ss2k_peloton": "settings.qml",
+      "ss2k_resistance_sample_1": "settings.qml",
+      "ss2k_resistance_sample_2": "settings.qml",
+      "ss2k_resistance_sample_3": "settings.qml",
+      "ss2k_resistance_sample_4": "settings.qml",
+      "ss2k_shift_step": "settings.qml",
+      "ss2k_shift_step_sample_1": "settings.qml",
+      "ss2k_shift_step_sample_2": "settings.qml",
+      "ss2k_shift_step_sample_3": "settings.qml",
+      "ss2k_shift_step_sample_4": "settings.qml",
+      "step_gain": "settings.qml",
+      "strava_auth_external_webbrowser": "settings.qml",
+      "strava_date_prefix": "settings.qml",
+      "strava_suffix": "settings.qml",
+      "strava_treadmill": "settings.qml",
+      "strava_upload_mode": "settings.qml",
+      "strava_virtual_activity": "settings.qml",
+      "stryd_add_inclination_gain": "settings.qml",
+      "stryd_inclination_instead_treadmill": "settings.qml",
+      "stryd_speed_instead_treadmill": "settings.qml",
+      "tacx_neo2_peloton": "settings.qml",
+      "tacxneo2_disable_negative_inclination": "settings.qml",
+      "taurua_ic90": "settings.qml",
+      "tdf_10_ip": "settings.qml",
+      "technogym_bike": "settings.qml",
+      "technogym_group_cycle": "settings.qml",
+      "technogym_myrun_treadmill_experimental": "settings.qml",
+      "theme_background_color": "settings.qml",
+      "theme_status_bar_background_color": "settings.qml",
+      "theme_tile_background_color": "settings.qml",
+      "theme_tile_icon_enabled": "settings.qml",
+      "theme_tile_secondline_textsize": "settings.qml",
+      "theme_tile_shadow_color": "settings.qml",
+      "theme_tile_shadow_enabled": "settings.qml",
+      "thinkrider_controller": "settings.qml",
+      "tile_auto_virtual_shifting_climb_enabled": "settings-tiles.qml",
+      "tile_auto_virtual_shifting_climb_order": "settings-tiles.qml",
+      "tile_auto_virtual_shifting_cruise_enabled": "settings-tiles.qml",
+      "tile_auto_virtual_shifting_cruise_order": "settings-tiles.qml",
+      "tile_auto_virtual_shifting_sprint_enabled": "settings-tiles.qml",
+      "tile_auto_virtual_shifting_sprint_order": "settings-tiles.qml",
+      "tile_avg_pace_enabled": "settings-tiles.qml",
+      "tile_avg_pace_order": "settings-tiles.qml",
+      "tile_avg_watt_lap_enabled": "settings-tiles.qml",
+      "tile_avg_watt_lap_order": "settings-tiles.qml",
+      "tile_avgwatt_enabled": "settings-tiles.qml",
+      "tile_avgwatt_order": "settings-tiles.qml",
+      "tile_biggears_enabled": "settings-tiles.qml",
+      "tile_biggears_order": "settings-tiles.qml",
+      "tile_biggears_swap": "settings-tiles.qml",
+      "tile_cadence_color_enabled": "settings-tiles.qml",
+      "tile_cadence_enabled": "settings-tiles.qml",
+      "tile_cadence_order": "settings-tiles.qml",
+      "tile_calories_enabled": "settings-tiles.qml",
+      "tile_calories_order": "settings-tiles.qml",
+      "tile_coretemperature_enabled": "settings-tiles.qml",
+      "tile_coretemperature_order": "settings-tiles.qml",
+      "tile_datetime_enabled": "settings-tiles.qml",
+      "tile_datetime_order": "settings-tiles.qml",
+      "tile_elapsed_enabled": "settings-tiles.qml",
+      "tile_elapsed_order": "settings-tiles.qml",
+      "tile_elevation_enabled": "settings-tiles.qml",
+      "tile_elevation_order": "settings-tiles.qml",
+      "tile_erg_mode_enabled": "settings-tiles.qml",
+      "tile_erg_mode_order": "settings-tiles.qml",
+      "tile_ext_incline_enabled": "settings-tiles.qml",
+      "tile_ext_incline_order": "settings-tiles.qml",
+      "tile_fan_enabled": "settings-tiles.qml",
+      "tile_fan_order": "settings-tiles.qml",
+      "tile_ftp_enabled": "settings-tiles.qml",
+      "tile_ftp_order": "settings-tiles.qml",
+      "tile_gears_enabled": "settings-tiles.qml",
+      "tile_gears_order": "settings-tiles.qml",
+      "tile_grade_adjusted_pace_enabled": "settings-tiles.qml",
+      "tile_grade_adjusted_pace_order": "settings-tiles.qml",
+      "tile_ground_contact_enabled": "settings-tiles.qml",
+      "tile_ground_contact_order": "settings-tiles.qml",
+      "tile_heart_enabled": "settings-tiles.qml",
+      "tile_heart_order": "settings-tiles.qml",
+      "tile_heart_show_as_percent": "settings-tiles.qml",
+      "tile_heat_time_in_zone_1_enabled": "settings-tiles.qml",
+      "tile_heat_time_in_zone_1_order": "settings-tiles.qml",
+      "tile_heat_time_in_zone_2_enabled": "settings-tiles.qml",
+      "tile_heat_time_in_zone_2_order": "settings-tiles.qml",
+      "tile_heat_time_in_zone_3_enabled": "settings-tiles.qml",
+      "tile_heat_time_in_zone_3_order": "settings-tiles.qml",
+      "tile_heat_time_in_zone_4_enabled": "settings-tiles.qml",
+      "tile_heat_time_in_zone_4_order": "settings-tiles.qml",
+      "tile_hr_time_in_zone_1_enabled": "settings-tiles.qml",
+      "tile_hr_time_in_zone_1_order": "settings-tiles.qml",
+      "tile_hr_time_in_zone_2_enabled": "settings-tiles.qml",
+      "tile_hr_time_in_zone_2_order": "settings-tiles.qml",
+      "tile_hr_time_in_zone_3_enabled": "settings-tiles.qml",
+      "tile_hr_time_in_zone_3_order": "settings-tiles.qml",
+      "tile_hr_time_in_zone_4_enabled": "settings-tiles.qml",
+      "tile_hr_time_in_zone_4_order": "settings-tiles.qml",
+      "tile_hr_time_in_zone_5_enabled": "settings-tiles.qml",
+      "tile_hr_time_in_zone_5_order": "settings-tiles.qml",
+      "tile_hr_time_in_zone_individual_mode": "settings-tiles.qml",
+      "tile_hrv_enabled": "settings-tiles.qml",
+      "tile_hrv_order": "settings-tiles.qml",
+      "tile_inclination_enabled": "settings-tiles.qml",
+      "tile_inclination_order": "settings-tiles.qml",
+      "tile_instantaneous_stride_length_enabled": "settings-tiles.qml",
+      "tile_instantaneous_stride_length_order": "settings-tiles.qml",
+      "tile_jouls_enabled": "settings-tiles.qml",
+      "tile_jouls_order": "settings-tiles.qml",
+      "tile_lapelapsed_enabled": "settings-tiles.qml",
+      "tile_lapelapsed_order": "settings-tiles.qml",
+      "tile_mets_enabled": "settings-tiles.qml",
+      "tile_mets_order": "settings-tiles.qml",
+      "tile_moving_time_enabled": "settings-tiles.qml",
+      "tile_moving_time_order": "settings-tiles.qml",
+      "tile_negative_inclination_enabled": "settings-tiles.qml",
+      "tile_negative_inclination_order": "settings-tiles.qml",
+      "tile_nextrowstrainprogram_enabled": "settings-tiles.qml",
+      "tile_nextrowstrainprogram_order": "settings-tiles.qml",
+      "tile_odometer_enabled": "settings-tiles.qml",
+      "tile_odometer_order": "settings-tiles.qml",
+      "tile_pace_color_enabled": "settings-tiles.qml",
+      "tile_pace_enabled": "settings-tiles.qml",
+      "tile_pace_last500m_enabled": "settings-tiles.qml",
+      "tile_pace_last500m_order": "settings-tiles.qml",
+      "tile_pace_order": "settings-tiles.qml",
+      "tile_peloton_difficulty_enabled": "settings-tiles.qml",
+      "tile_peloton_difficulty_order": "settings-tiles.qml",
+      "tile_peloton_offset_enabled": "settings-tiles.qml",
+      "tile_peloton_offset_order": "settings-tiles.qml",
+      "tile_peloton_remaining_enabled": "settings-tiles.qml",
+      "tile_peloton_remaining_order": "settings-tiles.qml",
+      "tile_peloton_resistance_color_enabled": "settings-tiles.qml",
+      "tile_peloton_resistance_enabled": "settings-tiles.qml",
+      "tile_peloton_resistance_order": "settings-tiles.qml",
+      "tile_pid_hr_enabled": "settings-tiles.qml",
+      "tile_pid_hr_order": "settings-tiles.qml",
+      "tile_power_avg_enabled": "settings-tiles.qml",
+      "tile_power_avg_order": "settings-tiles.qml",
+      "tile_preset_inclination_1_color": "settings-tiles.qml",
+      "tile_preset_inclination_1_enabled": "settings-tiles.qml",
+      "tile_preset_inclination_1_label": "settings-tiles.qml",
+      "tile_preset_inclination_1_order": "settings-tiles.qml",
+      "tile_preset_inclination_1_value": "settings-tiles.qml",
+      "tile_preset_inclination_2_color": "settings-tiles.qml",
+      "tile_preset_inclination_2_enabled": "settings-tiles.qml",
+      "tile_preset_inclination_2_label": "settings-tiles.qml",
+      "tile_preset_inclination_2_order": "settings-tiles.qml",
+      "tile_preset_inclination_2_value": "settings-tiles.qml",
+      "tile_preset_inclination_3_color": "settings-tiles.qml",
+      "tile_preset_inclination_3_enabled": "settings-tiles.qml",
+      "tile_preset_inclination_3_label": "settings-tiles.qml",
+      "tile_preset_inclination_3_order": "settings-tiles.qml",
+      "tile_preset_inclination_3_value": "settings-tiles.qml",
+      "tile_preset_inclination_4_color": "settings-tiles.qml",
+      "tile_preset_inclination_4_enabled": "settings-tiles.qml",
+      "tile_preset_inclination_4_label": "settings-tiles.qml",
+      "tile_preset_inclination_4_order": "settings-tiles.qml",
+      "tile_preset_inclination_4_value": "settings-tiles.qml",
+      "tile_preset_inclination_5_color": "settings-tiles.qml",
+      "tile_preset_inclination_5_enabled": "settings-tiles.qml",
+      "tile_preset_inclination_5_label": "settings-tiles.qml",
+      "tile_preset_inclination_5_order": "settings-tiles.qml",
+      "tile_preset_inclination_5_value": "settings-tiles.qml",
+      "tile_preset_powerzone_1_color": "settings-tiles.qml",
+      "tile_preset_powerzone_1_enabled": "settings-tiles.qml",
+      "tile_preset_powerzone_1_label": "settings-tiles.qml",
+      "tile_preset_powerzone_1_order": "settings-tiles.qml",
+      "tile_preset_powerzone_1_value": "settings-tiles.qml",
+      "tile_preset_powerzone_2_color": "settings-tiles.qml",
+      "tile_preset_powerzone_2_enabled": "settings-tiles.qml",
+      "tile_preset_powerzone_2_label": "settings-tiles.qml",
+      "tile_preset_powerzone_2_order": "settings-tiles.qml",
+      "tile_preset_powerzone_2_value": "settings-tiles.qml",
+      "tile_preset_powerzone_3_color": "settings-tiles.qml",
+      "tile_preset_powerzone_3_enabled": "settings-tiles.qml",
+      "tile_preset_powerzone_3_label": "settings-tiles.qml",
+      "tile_preset_powerzone_3_order": "settings-tiles.qml",
+      "tile_preset_powerzone_3_value": "settings-tiles.qml",
+      "tile_preset_powerzone_4_color": "settings-tiles.qml",
+      "tile_preset_powerzone_4_enabled": "settings-tiles.qml",
+      "tile_preset_powerzone_4_label": "settings-tiles.qml",
+      "tile_preset_powerzone_4_order": "settings-tiles.qml",
+      "tile_preset_powerzone_4_value": "settings-tiles.qml",
+      "tile_preset_powerzone_5_color": "settings-tiles.qml",
+      "tile_preset_powerzone_5_enabled": "settings-tiles.qml",
+      "tile_preset_powerzone_5_label": "settings-tiles.qml",
+      "tile_preset_powerzone_5_order": "settings-tiles.qml",
+      "tile_preset_powerzone_5_value": "settings-tiles.qml",
+      "tile_preset_powerzone_6_color": "settings-tiles.qml",
+      "tile_preset_powerzone_6_enabled": "settings-tiles.qml",
+      "tile_preset_powerzone_6_label": "settings-tiles.qml",
+      "tile_preset_powerzone_6_order": "settings-tiles.qml",
+      "tile_preset_powerzone_6_value": "settings-tiles.qml",
+      "tile_preset_powerzone_7_color": "settings-tiles.qml",
+      "tile_preset_powerzone_7_enabled": "settings-tiles.qml",
+      "tile_preset_powerzone_7_label": "settings-tiles.qml",
+      "tile_preset_powerzone_7_order": "settings-tiles.qml",
+      "tile_preset_powerzone_7_value": "settings-tiles.qml",
+      "tile_preset_resistance_1_color": "settings-tiles.qml",
+      "tile_preset_resistance_1_enabled": "settings-tiles.qml",
+      "tile_preset_resistance_1_label": "settings-tiles.qml",
+      "tile_preset_resistance_1_order": "settings-tiles.qml",
+      "tile_preset_resistance_1_value": "settings-tiles.qml",
+      "tile_preset_resistance_2_color": "settings-tiles.qml",
+      "tile_preset_resistance_2_enabled": "settings-tiles.qml",
+      "tile_preset_resistance_2_label": "settings-tiles.qml",
+      "tile_preset_resistance_2_order": "settings-tiles.qml",
+      "tile_preset_resistance_2_value": "settings-tiles.qml",
+      "tile_preset_resistance_3_color": "settings-tiles.qml",
+      "tile_preset_resistance_3_enabled": "settings-tiles.qml",
+      "tile_preset_resistance_3_label": "settings-tiles.qml",
+      "tile_preset_resistance_3_order": "settings-tiles.qml",
+      "tile_preset_resistance_3_value": "settings-tiles.qml",
+      "tile_preset_resistance_4_color": "settings-tiles.qml",
+      "tile_preset_resistance_4_enabled": "settings-tiles.qml",
+      "tile_preset_resistance_4_label": "settings-tiles.qml",
+      "tile_preset_resistance_4_order": "settings-tiles.qml",
+      "tile_preset_resistance_4_value": "settings-tiles.qml",
+      "tile_preset_resistance_5_color": "settings-tiles.qml",
+      "tile_preset_resistance_5_enabled": "settings-tiles.qml",
+      "tile_preset_resistance_5_label": "settings-tiles.qml",
+      "tile_preset_resistance_5_order": "settings-tiles.qml",
+      "tile_preset_resistance_5_value": "settings-tiles.qml",
+      "tile_preset_speed_1_color": "settings-tiles.qml",
+      "tile_preset_speed_1_enabled": "settings-tiles.qml",
+      "tile_preset_speed_1_label": "settings-tiles.qml",
+      "tile_preset_speed_1_order": "settings-tiles.qml",
+      "tile_preset_speed_1_value": "settings-tiles.qml",
+      "tile_preset_speed_2_color": "settings-tiles.qml",
+      "tile_preset_speed_2_enabled": "settings-tiles.qml",
+      "tile_preset_speed_2_label": "settings-tiles.qml",
+      "tile_preset_speed_2_order": "settings-tiles.qml",
+      "tile_preset_speed_2_value": "settings-tiles.qml",
+      "tile_preset_speed_3_color": "settings-tiles.qml",
+      "tile_preset_speed_3_enabled": "settings-tiles.qml",
+      "tile_preset_speed_3_label": "settings-tiles.qml",
+      "tile_preset_speed_3_order": "settings-tiles.qml",
+      "tile_preset_speed_3_value": "settings-tiles.qml",
+      "tile_preset_speed_4_color": "settings-tiles.qml",
+      "tile_preset_speed_4_enabled": "settings-tiles.qml",
+      "tile_preset_speed_4_label": "settings-tiles.qml",
+      "tile_preset_speed_4_order": "settings-tiles.qml",
+      "tile_preset_speed_4_value": "settings-tiles.qml",
+      "tile_preset_speed_5_color": "settings-tiles.qml",
+      "tile_preset_speed_5_enabled": "settings-tiles.qml",
+      "tile_preset_speed_5_label": "settings-tiles.qml",
+      "tile_preset_speed_5_order": "settings-tiles.qml",
+      "tile_preset_speed_5_value": "settings-tiles.qml",
+      "tile_remainingtimetrainprogramrow_enabled": "settings-tiles.qml",
+      "tile_remainingtimetrainprogramrow_order": "settings-tiles.qml",
+      "tile_resistance_enabled": "settings-tiles.qml",
+      "tile_resistance_order": "settings-tiles.qml",
+      "tile_rss_enabled": "settings-tiles.qml",
+      "tile_rss_order": "settings-tiles.qml",
+      "tile_speed_enabled": "settings-tiles.qml",
+      "tile_speed_order": "settings-tiles.qml",
+      "tile_steering_angle_enabled": "settings-tiles.qml",
+      "tile_steering_angle_order": "settings-tiles.qml",
+      "tile_step_count_enabled": "settings-tiles.qml",
+      "tile_step_count_order": "settings-tiles.qml",
+      "tile_strokes_count_enabled": "settings-tiles.qml",
+      "tile_strokes_count_order": "settings-tiles.qml",
+      "tile_strokes_length_enabled": "settings-tiles.qml",
+      "tile_strokes_length_order": "settings-tiles.qml",
+      "tile_target_cadence_enabled": "settings-tiles.qml",
+      "tile_target_cadence_order": "settings-tiles.qml",
+      "tile_target_incline_enabled": "settings-tiles.qml",
+      "tile_target_incline_order": "settings-tiles.qml",
+      "tile_target_pace_enabled": "settings-tiles.qml",
+      "tile_target_pace_order": "settings-tiles.qml",
+      "tile_target_peloton_resistance_enabled": "settings-tiles.qml",
+      "tile_target_peloton_resistance_order": "settings-tiles.qml",
+      "tile_target_power_enabled": "settings-tiles.qml",
+      "tile_target_power_order": "settings-tiles.qml",
+      "tile_target_resistance_enabled": "settings-tiles.qml",
+      "tile_target_resistance_order": "settings-tiles.qml",
+      "tile_target_speed_enabled": "settings-tiles.qml",
+      "tile_target_speed_order": "settings-tiles.qml",
+      "tile_target_zone_enabled": "settings-tiles.qml",
+      "tile_target_zone_order": "settings-tiles.qml",
+      "tile_targetmets_enabled": "settings-tiles.qml",
+      "tile_targetmets_order": "settings-tiles.qml",
+      "tile_vertical_oscillation_enabled": "settings-tiles.qml",
+      "tile_vertical_oscillation_order": "settings-tiles.qml",
+      "tile_watt_color_enabled": "settings-tiles.qml",
+      "tile_watt_enabled": "settings-tiles.qml",
+      "tile_watt_kg_enabled": "settings-tiles.qml",
+      "tile_watt_kg_order": "settings-tiles.qml",
+      "tile_watt_order": "settings-tiles.qml",
+      "tile_weight_loss_enabled": "settings-tiles.qml",
+      "tile_weight_loss_order": "settings-tiles.qml",
+      "toorx_3_0": "settings.qml",
+      "toorx_65s_evo": "settings.qml",
+      "toorx_bike": "settings.qml",
+      "toorx_bike_srx_500": "settings.qml",
+      "toorx_ftms": "settings.qml",
+      "toorx_ftms_treadmill": "settings.qml",
+      "toorx_srx_3500": "settings.qml",
+      "toorxtreadmill_discovery_completed": "settings.qml",
+      "top_bar_enabled": "settings.qml",
+      "toputure_teb1": "settings.qml",
+      "trainprogram_auto_lap_on_segment": "settings.qml",
+      "trainprogram_clipboard_workout_enabled": "settings.qml",
+      "trainprogram_cooldown_speed": "settings.qml",
+      "trainprogram_incline_max": "settings.qml",
+      "trainprogram_incline_min": "settings.qml",
+      "trainprogram_period_seconds": "settings.qml",
+      "trainprogram_pid_hr_pushy_zone_limit": "settings.qml",
+      "trainprogram_pid_hr_recovery_zone_limit": "settings.qml",
+      "trainprogram_pid_ignore_inclination": "settings.qml",
+      "trainprogram_pid_pushy": "settings.qml",
+      "trainprogram_random": "settings.qml",
+      "trainprogram_resistance_max": "settings.qml",
+      "trainprogram_resistance_min": "settings.qml",
+      "trainprogram_rest_speed": "settings.qml",
+      "trainprogram_sound_on_segment": "settings.qml",
+      "trainprogram_speed_max": "settings.qml",
+      "trainprogram_speed_min": "settings.qml",
+      "trainprogram_stop_at_end": "settings.qml",
+      "trainprogram_total": "settings.qml",
+      "trainprogram_warmup_speed": "settings.qml",
+      "treadmillDataPoints": "settings.qml",
+      "treadmill_difficulty_gain_or_offset": "settings.qml",
+      "treadmill_direct_distance": "settings.qml",
+      "treadmill_follow_wattage": "settings.qml",
+      "treadmill_force_running_activity": "settings.qml",
+      "treadmill_force_speed": "settings.qml",
+      "treadmill_inclination_override_0": "settings-treadmill-inclination-override.qml",
+      "treadmill_inclination_override_05": "settings-treadmill-inclination-override.qml",
+      "treadmill_inclination_override_10": "settings-treadmill-inclination-override.qml",
+      "treadmill_inclination_override_100": "settings-treadmill-inclination-override.qml",
+      "treadmill_inclination_override_105": "settings-treadmill-inclination-override.qml",
+      "treadmill_inclination_override_110": "settings-treadmill-inclination-override.qml",
+      "treadmill_inclination_override_115": "settings-treadmill-inclination-override.qml",
+      "treadmill_inclination_override_120": "settings-treadmill-inclination-override.qml",
+      "treadmill_inclination_override_125": "settings-treadmill-inclination-override.qml",
+      "treadmill_inclination_override_130": "settings-treadmill-inclination-override.qml",
+      "treadmill_inclination_override_135": "settings-treadmill-inclination-override.qml",
+      "treadmill_inclination_override_140": "settings-treadmill-inclination-override.qml",
+      "treadmill_inclination_override_145": "settings-treadmill-inclination-override.qml",
+      "treadmill_inclination_override_15": "settings-treadmill-inclination-override.qml",
+      "treadmill_inclination_override_150": "settings-treadmill-inclination-override.qml",
+      "treadmill_inclination_override_20": "settings-treadmill-inclination-override.qml",
+      "treadmill_inclination_override_25": "settings-treadmill-inclination-override.qml",
+      "treadmill_inclination_override_30": "settings-treadmill-inclination-override.qml",
+      "treadmill_inclination_override_35": "settings-treadmill-inclination-override.qml",
+      "treadmill_inclination_override_40": "settings-treadmill-inclination-override.qml",
+      "treadmill_inclination_override_45": "settings-treadmill-inclination-override.qml",
+      "treadmill_inclination_override_50": "settings-treadmill-inclination-override.qml",
+      "treadmill_inclination_override_55": "settings-treadmill-inclination-override.qml",
+      "treadmill_inclination_override_60": "settings-treadmill-inclination-override.qml",
+      "treadmill_inclination_override_65": "settings-treadmill-inclination-override.qml",
+      "treadmill_inclination_override_70": "settings-treadmill-inclination-override.qml",
+      "treadmill_inclination_override_75": "settings-treadmill-inclination-override.qml",
+      "treadmill_inclination_override_80": "settings-treadmill-inclination-override.qml",
+      "treadmill_inclination_override_85": "settings-treadmill-inclination-override.qml",
+      "treadmill_inclination_override_90": "settings-treadmill-inclination-override.qml",
+      "treadmill_inclination_override_95": "settings-treadmill-inclination-override.qml",
+      "treadmill_inclination_ovveride_gain": "settings-treadmill-inclination-override.qml",
+      "treadmill_inclination_ovveride_offset": "settings-treadmill-inclination-override.qml",
+      "treadmill_incline_max": "settings.qml",
+      "treadmill_incline_min": "settings.qml",
+      "treadmill_pid_heart_max": "settings.qml",
+      "treadmill_pid_heart_min": "settings.qml",
+      "treadmill_pid_heart_zone": "settings.qml",
+      "treadmill_simulate_inclination_with_speed": "settings.qml",
+      "treadmill_speed_max": "settings.qml",
+      "treadmill_speed_min": "settings.qml",
+      "treadmill_step_incline": "settings.qml",
+      "treadmill_step_speed": "settings.qml",
+      "trx_route_key": "settings.qml",
+      "tts_act_cadence": "settings-tts.qml",
+      "tts_act_calories": "settings-tts.qml",
+      "tts_act_elapsed": "settings-tts.qml",
+      "tts_act_elevation": "settings-tts.qml",
+      "tts_act_ftp": "settings-tts.qml",
+      "tts_act_heart": "settings-tts.qml",
+      "tts_act_inclination": "settings-tts.qml",
+      "tts_act_jouls": "settings-tts.qml",
+      "tts_act_odometer": "settings-tts.qml",
+      "tts_act_pace": "settings-tts.qml",
+      "tts_act_peloton_resistance": "settings-tts.qml",
+      "tts_act_resistance": "settings-tts.qml",
+      "tts_act_speed": "settings-tts.qml",
+      "tts_act_target_cadence": "settings-tts.qml",
+      "tts_act_target_incline": "settings-tts.qml",
+      "tts_act_target_pace": "settings-tts.qml",
+      "tts_act_target_peloton_resistance": "settings-tts.qml",
+      "tts_act_target_power": "settings-tts.qml",
+      "tts_act_target_speed": "settings-tts.qml",
+      "tts_act_target_zone": "settings-tts.qml",
+      "tts_act_watt": "settings-tts.qml",
+      "tts_act_watt_kg": "settings-tts.qml",
+      "tts_avg_cadence": "settings-tts.qml",
+      "tts_avg_ftp": "settings-tts.qml",
+      "tts_avg_heart": "settings-tts.qml",
+      "tts_avg_pace": "settings-tts.qml",
+      "tts_avg_peloton_resistance": "settings-tts.qml",
+      "tts_avg_resistance": "settings-tts.qml",
+      "tts_avg_speed": "settings-tts.qml",
+      "tts_avg_watt": "settings-tts.qml",
+      "tts_avg_watt_kg": "settings-tts.qml",
+      "tts_description_enabled": "settings-tts.qml",
+      "tts_enabled": "settings-tts.qml",
+      "tts_max_cadence": "settings-tts.qml",
+      "tts_max_ftp": "settings-tts.qml",
+      "tts_max_heart": "settings-tts.qml",
+      "tts_max_pace": "settings-tts.qml",
+      "tts_max_peloton_resistance": "settings-tts.qml",
+      "tts_max_resistance": "settings-tts.qml",
+      "tts_max_speed": "settings-tts.qml",
+      "tts_max_watt": "settings-tts.qml",
+      "tts_max_watt_kg": "settings-tts.qml",
+      "tts_summary_sec": "settings-tts.qml",
+      "ui_zoom": "settings.qml",
+      "umay_s100_treadmill": "settings.qml",
+      "user_email": "settings.qml",
+      "user_nickname": "settings.qml",
+      "video_playback_window_s": "settings.qml",
+      "virtual_device_bluetooth": "settings.qml",
+      "virtual_device_echelon": "settings.qml",
+      "virtual_device_enabled": "settings.qml",
+      "virtual_device_force_bike": "settings.qml",
+      "virtual_device_force_treadmill": "settings.qml",
+      "virtual_device_ifit": "settings.qml",
+      "virtual_device_onlyheart": "settings.qml",
+      "virtual_device_rower": "settings.qml",
+      "virtual_device_rower_pm5": "settings.qml",
+      "virtual_device_tacx": "settings.qml",
+      "virtualbike_forceresistance": "settings.qml",
+      "virtufit_etappe": "settings.qml",
+      "volume_change_gears": "settings.qml",
+      "wahoo_rgt_dircon": "settings.qml",
+      "wahoo_without_wheel_diameter": "settings.qml",
+      "waterrower_usb": "settings.qml",
+      "watt_bike_emulator": "settings.qml",
+      "watt_gain": "settings.qml",
+      "watt_ignore_builtin": "settings.qml",
+      "watt_offset": "settings.qml",
+      "weight": "settings.qml",
+      "weight_kg_unit": "settings.qml",
+      "yesoul_peloton_formula": "settings.qml",
+      "zero_zt2500_treadmill": "settings.qml",
+      "zwift_api_autoinclination": "settings.qml",
+      "zwift_api_poll": "settings.qml",
+      "zwift_click": "settings.qml",
+      "zwift_erg": "settings.qml",
+      "zwift_erg_filter": "settings.qml",
+      "zwift_erg_filter_down": "settings.qml",
+      "zwift_erg_resistance_down": "settings.qml",
+      "zwift_erg_resistance_up": "settings.qml",
+      "zwift_gear_ui_aligned": "settings.qml",
+      "zwift_inclination_gain": "settings.qml",
+      "zwift_inclination_offset": "settings.qml",
+      "zwift_negative_inclination_x2": "settings.qml",
+      "zwift_ocr": "settings.qml",
+      "zwift_ocr_climb_portal": "settings.qml",
+      "zwift_password": "settings.qml",
+      "zwift_play": "settings.qml",
+      "zwift_play_emulator": "settings.qml",
+      "zwift_play_vibration": "settings.qml",
+      "zwift_username": "settings.qml",
+      "zwift_workout_ocr": "settings.qml",
+      "zwiftplay_gear_lb": "settings.qml",
+      "zwiftplay_gear_ls1": "settings.qml",
+      "zwiftplay_gear_ls2": "settings.qml",
+      "zwiftplay_gear_paddle_left": "settings.qml",
+      "zwiftplay_gear_paddle_right": "settings.qml",
+      "zwiftplay_gear_rb": "settings.qml",
+      "zwiftplay_gear_rs1": "settings.qml",
+      "zwiftplay_gear_rs2": "settings.qml",
+      "zwiftplay_swap": "settings.qml"
+    },
+    "itemOrderByKey": {
+      "age": 3044,
+      "android_antbike": 6586,
+      "android_documents_folder": 17371,
+      "android_notification": 756,
+      "android_wakelock": 17094,
+      "ant_bike_device_number": 6600,
+      "ant_cadence": 6692,
+      "ant_heart": 6793,
+      "ant_heart_device_number": 6807,
+      "ant_speed_gain": 6756,
+      "ant_speed_offset": 6719,
+      "antbike": 8663,
+      "app_language": 2904,
+      "applewatch_as_treadmill_speed": 17233,
+      "applewatch_fakedevice": 17177,
+      "asviva_bike": 12787,
+      "atletica_lightspeed_treadmill": 12119,
+      "autolap_distance": 14218,
+      "automatic_virtual_shifting_climb_gear_down_cadence": 5067,
+      "automatic_virtual_shifting_climb_gear_down_time": 5091,
+      "automatic_virtual_shifting_climb_gear_up_cadence": 5019,
+      "automatic_virtual_shifting_climb_gear_up_time": 5043,
+      "automatic_virtual_shifting_enabled": 4855,
+      "automatic_virtual_shifting_gear_down_cadence": 4961,
+      "automatic_virtual_shifting_gear_down_time": 4985,
+      "automatic_virtual_shifting_gear_up_cadence": 4913,
+      "automatic_virtual_shifting_gear_up_time": 4937,
+      "automatic_virtual_shifting_profile": 4885,
+      "automatic_virtual_shifting_sprint_gear_down_cadence": 5173,
+      "automatic_virtual_shifting_sprint_gear_down_time": 5197,
+      "automatic_virtual_shifting_sprint_gear_up_cadence": 5125,
+      "automatic_virtual_shifting_sprint_gear_up_time": 5149,
+      "battery_service": 16335,
+      "bh_spada_2": 12539,
+      "bh_spada_2_watt": 12553,
+      "bike_cadence_sensor": 7886,
+      "bike_heartrate_service": 3406,
+      "bike_power_offset": 4492,
+      "bike_power_sensor": 16561,
+      "bike_resistance_gain_f": 4530,
+      "bike_resistance_offset": 4454,
+      "bike_resistance_start": 4720,
+      "bike_weight": 4117,
+      "bluetooth_30m_hangs": 16307,
+      "bluetooth_relaxed": 16279,
+      "cadence_gain": 13614,
+      "cadence_offset": 13576,
+      "cadence_sensor_as_bike": 14324,
+      "cadence_sensor_as_treadmill": 14330,
+      "cadence_sensor_name": 14378,
+      "cadence_sensor_speed_ratio": 14425,
+      "calories_active_only": 3490,
+      "calories_from_hr": 3518,
+      "chart_display_mode": 7121,
+      "computrainer_serialport": 6315,
+      "confirm_stop_workout": 13395,
+      "continuous_moving": 3357,
+      "crrGain": 4155,
+      "csafe_elliptical_port": 13078,
+      "csafe_rower": 12869,
+      "cscbike_custom_resistance_level_1": 14516,
+      "cscbike_custom_resistance_level_2": 14562,
+      "cscbike_custom_resistance_power_table": 14489,
+      "cscbike_custom_watt_1": 14539,
+      "cscbike_custom_watt_2": 14585,
+      "cwGain": 4179,
+      "cycplus_bc2_controller": 15781,
+      "dircon_id": 16680,
+      "dircon_server_base_port": 16717,
+      "dircon_yes": 4237,
+      "dkn_endurun_treadmill": 12669,
+      "domyos_bike_500_profile_v1": 5945,
+      "domyos_bike_500_profile_v2": 5948,
+      "domyos_bike_cadence_filter": 5896,
+      "domyos_bike_display_calories": 5932,
+      "domyos_elliptical_inclination": 13058,
+      "domyos_elliptical_speed_ratio": 13034,
+      "domyos_run100e": 11792,
+      "domyos_treadmill_button_10kmh": 11873,
+      "domyos_treadmill_button_16kmh": 11896,
+      "domyos_treadmill_button_22kmh": 11919,
+      "domyos_treadmill_button_5kmh": 11850,
+      "domyos_treadmill_buttons": 11750,
+      "domyos_treadmill_display_invert": 11836,
+      "domyos_treadmill_distance_display": 11821,
+      "domyos_treadmill_sync_start": 11806,
+      "domyos_treadmill_t900a": 11764,
+      "domyos_treadmill_ts100": 11778,
+      "domyosbike_notfmts": 5919,
+      "echelon_resistance_gain": 5439,
+      "echelon_resistance_offset": 5463,
+      "echelon_watttable": 5414,
+      "elite_rizer_gain": 15007,
+      "elite_rizer_name": 14974,
+      "elite_sterzo_smart_name": 15042,
+      "enerfit_SPX_9500": 12596,
+      "ergDataPoints": 792,
+      "eslinker_cadenza": 12195,
+      "eslinker_costaway": 12222,
+      "eslinker_ypoo": 12209,
+      "fakedevice_elliptical": 17261,
+      "fakedevice_rower": 17288,
+      "fakedevice_treadmill": 17205,
+      "filter_device": 13349,
+      "fit_file_garmin_device_training_effect": 8963,
+      "fit_file_garmin_device_training_effect_device": 9210,
+      "fitfiu_mc_v460": 11699,
+      "fitmetria_fanfit_enable": 15421,
+      "fitmetria_fanfit_max": 15486,
+      "fitmetria_fanfit_min": 15462,
+      "fitmetria_fanfit_mode": 15437,
+      "fitplus_bike": 5744,
+      "fitshow_anyrun": 12106,
+      "fitshow_treadmill_miles": 12147,
+      "fitshow_truetimer": 12133,
+      "fitshow_user_id": 12161,
+      "floating_height": 7012,
+      "floating_startup": 7086,
+      "floating_transparency": 7049,
+      "floating_width": 6975,
+      "floatingwindow_type": 6925,
+      "flywheel_filter": 5834,
+      "flywheel_life_fitness_ic8": 5858,
+      "force_resistance_instead_inclination": 14191,
+      "freebeat_serialport": 6414,
+      "freemotion_coachbike_b22_7": 6098,
+      "ftms_accessory_name": 15089,
+      "ftms_bike": 5223,
+      "ftms_elliptical": 13104,
+      "ftms_rower": 12895,
+      "ftms_treadmill": 11068,
+      "ftp": 3123,
+      "ftp_run": 3160,
+      "fytter_ri08_bike": 12773,
+      "garmin_bluetooth_compatibility": 8609,
+      "garmin_companion": 8636,
+      "garmin_device_serial": 9663,
+      "garmin_domain": 8835,
+      "garmin_download_workouts_on_start": 8752,
+      "garmin_email": 8779,
+      "garmin_password": 8805,
+      "garmin_upload_enabled": 8698,
+      "gears_current_value_f": 4045,
+      "gears_from_bike": 5486,
+      "gears_gain": 4757,
+      "gears_offset": 4809,
+      "gears_restore_value": 3993,
+      "gears_volume_debouncing": 13858,
+      "gears_zwift_ratio": 15953,
+      "gem_module_inclination": 11541,
+      "gpx_loop": 16183,
+      "gym_mode": 16251,
+      "gymstick_gx6_0_elliptical": 13148,
+      "hammer_racer_s": 5599,
+      "heart_ignore_builtin": 3434,
+      "heart_max_override_enable": 3736,
+      "heart_max_override_value": 3751,
+      "heart_rate_belt_name": 3547,
+      "heart_rate_resting": 3789,
+      "heart_rate_zone1": 3602,
+      "heart_rate_zone2": 3627,
+      "heart_rate_zone3": 3652,
+      "heart_rate_zone4": 3677,
+      "height": 695,
+      "hertz_xr_770": 12801,
+      "hop_sport_hs_090h_bike": 12610,
+      "horizon_gr7_cadence_multiplier": 5376,
+      "horizon_paragon_x": 12247,
+      "horizon_treadmill_7_8": 12275,
+      "horizon_treadmill_disable_pause": 12304,
+      "horizon_treadmill_force_ftms": 12261,
+      "horizon_treadmill_omega_z": 12289,
+      "horizon_treadmill_profile_user1": 12334,
+      "horizon_treadmill_profile_user2": 12357,
+      "horizon_treadmill_profile_user3": 12380,
+      "horizon_treadmill_profile_user4": 12403,
+      "horizon_treadmill_profile_user5": 12426,
+      "horizon_treadmill_suspend_stats_pause": 12319,
+      "iconcept_elliptical": 13318,
+      "iconcept_ftms_treadmill_inclination_table": 12729,
+      "iconsole_elliptical": 12814,
+      "iconsole_rower": 12827,
+      "inclination_delay_seconds": 14254,
+      "inspire_peloton_formula": 5511,
+      "inspire_peloton_formula2": 5525,
+      "instant_power_on_pause": 13931,
+      "ios_btdevice_native": 17149,
+      "ios_cache_heart_device": 17316,
+      "ios_live_activity_compact_leading_metric": 7158,
+      "ios_live_activity_compact_trailing_metric": 7179,
+      "ios_peloton_workaround": 17122,
+      "jll_IC400_bike": 12759,
+      "jtx_fitness_sprint_treadmill": 12639,
+      "kcal_ignore_builtin": 3462,
+      "kettler_usb_baudrate": 6374,
+      "kettler_usb_serialport": 6350,
+      "kingsmith_encrypt_g1_walking_pad": 11592,
+      "kingsmith_encrypt_v2": 11589,
+      "kingsmith_encrypt_v3": 11592,
+      "kingsmith_encrypt_v4": 11592,
+      "kingsmith_encrypt_v5": 11592,
+      "kingsmith_r2_enable_hw_buttons": 11661,
+      "life_fitness_ic5": 5872,
+      "lifespan_bike": 5810,
+      "log_debug": 17399,
+      "m3i_bike_id": 6467,
+      "m3i_bike_kcal": 6517,
+      "m3i_bike_qt_search": 6452,
+      "m3i_bike_speed_buffsize": 6492,
+      "maps_type": 16158,
+      "miles_unit": 20,
+      "min_inclination": 14062,
+      "mqtt_deviceid": 16898,
+      "mqtt_host": 16753,
+      "mqtt_password": 16861,
+      "mqtt_port": 16788,
+      "mqtt_username": 16825,
+      "mywhoosh_link_enabled": 4233,
+      "mywhoosh_link_left_down": 4299,
+      "mywhoosh_link_left_left": 4311,
+      "mywhoosh_link_left_power": 4347,
+      "mywhoosh_link_left_right": 4323,
+      "mywhoosh_link_left_shoulder": 4335,
+      "mywhoosh_link_left_up": 4287,
+      "mywhoosh_link_override_gears": 4257,
+      "mywhoosh_link_right_a": 4379,
+      "mywhoosh_link_right_b": 4391,
+      "mywhoosh_link_right_power": 4427,
+      "mywhoosh_link_right_shoulder": 4415,
+      "mywhoosh_link_right_y": 4367,
+      "mywhoosh_link_right_z": 4403,
+      "nordictrack_10_treadmill": 11215,
+      "nordictrack_2950_ip": 11455,
+      "nordictrack_GX4_5_bike": 6103,
+      "nordictrack_elite_800": 11259,
+      "nordictrack_elliptical_c7_5": 13197,
+      "nordictrack_elliptical_s700": 13223,
+      "nordictrack_gx_2_7": 6102,
+      "nordictrack_gx_44_pro": 6109,
+      "nordictrack_gx_4_5_pro": 6114,
+      "nordictrack_ifit_adb_remote": 6279,
+      "nordictrack_incline_trainer_x7i": 11213,
+      "nordictrack_incline_trainer_x7i_ntl15010_0": 11273,
+      "nordictrack_s20_treadmill": 11226,
+      "nordictrack_s20i_treadmill": 11238,
+      "nordictrack_s30_treadmill": 11227,
+      "nordictrack_se7i": 13210,
+      "nordictrack_series_7": 11264,
+      "nordictrack_t65s_83_treadmill": 11224,
+      "nordictrack_t65s_treadmill": 11223,
+      "nordictrack_t65s_treadmill_81_miles": 11258,
+      "nordictrack_t70_treadmill": 11225,
+      "nordictrack_treadmill_1750_adb": 11256,
+      "nordictrack_treadmill_commercial_le": 11261,
+      "nordictrack_treadmill_exp_5i": 11243,
+      "nordictrack_treadmill_t8_5s": 11216,
+      "nordictrack_treadmill_ultra_le": 11260,
+      "nordictrack_treadmill_x14i": 11235,
+      "nordictrack_tseries5_treadmill": 11250,
+      "nordictrack_vr21": 6116,
+      "nordictrack_x22i": 11214,
+      "nordictrackadbbike_resistance": 6292,
+      "norditrack_s25_treadmill": 11211,
+      "norditrack_s25i_treadmill": 11212,
+      "osc_ip": 16944,
+      "osc_port": 16967,
+      "pace_default": 10322,
+      "pacef_10km": 10141,
+      "pacef_1mile": 10067,
+      "pacef_5km": 10104,
+      "pacef_halfmarathon": 10178,
+      "pacef_marathon": 10215,
+      "pafers_treadmill": 11504,
+      "pafers_treadmill_bh_iboxster_plus": 11518,
+      "pause_on_start": 3329,
+      "pause_on_start_treadmill": 10715,
+      "peloton_auto_start_with_intro": 7913,
+      "peloton_auto_start_without_intro": 7916,
+      "peloton_companion_workout_ocr": 8183,
+      "peloton_date": 8037,
+      "peloton_date_format": 8076,
+      "peloton_description_link": 8101,
+      "peloton_difficulty": 7513,
+      "peloton_gain": 7810,
+      "peloton_heartrate_metric": 7997,
+      "peloton_offset": 7848,
+      "peloton_rower_level": 7696,
+      "peloton_spinups_autoresistance": 8128,
+      "peloton_treadmill_level": 7552,
+      "peloton_treadmill_running_min_speed": 7661,
+      "peloton_treadmill_walk_level": 7590,
+      "peloton_treadmill_walking_min_speed": 7627,
+      "peloton_workout_ocr": 8156,
+      "pid_heart_zone_erg_mode_watt_step": 10361,
+      "poll_device_time": 11942,
+      "power_avg_3s": 13890,
+      "power_avg_5s": 13891,
+      "power_hr_hr1": 3862,
+      "power_hr_hr2": 3912,
+      "power_hr_pwr1": 3837,
+      "power_hr_pwr2": 3887,
+      "power_sensor_as_bike": 14632,
+      "power_sensor_as_treadmill": 14660,
+      "power_sensor_cadence_instead_treadmill": 14797,
+      "power_sensor_name": 14908,
+      "power_sensor_speed_inclination_coeff_a": 14851,
+      "power_sensor_speed_inclination_coeff_b": 14872,
+      "powr_sensor_running_cadence_double": 14688,
+      "powr_sensor_running_cadence_half_on_strava": 14716,
+      "proform_2000_treadmill": 11217,
+      "proform_225_csx_PFEX32925_INT_0": 6112,
+      "proform_505_cst_80_44": 11253,
+      "proform_595i_proshox2": 11239,
+      "proform_8_5_treadmill": 11219,
+      "proform_bike_225_csx": 6106,
+      "proform_bike_325_csx": 6107,
+      "proform_bike_325_csx_PFEX439210INT_0": 6115,
+      "proform_bike_PFEVEX71316_0": 6110,
+      "proform_bike_PFEVEX71316_1": 6100,
+      "proform_bike_sb": 6108,
+      "proform_carbon_tl": 11236,
+      "proform_carbon_tl_PFTL59720": 11244,
+      "proform_carbon_tl_PFTL59722c": 11251,
+      "proform_carbon_tl_PFTL59723_6": 11269,
+      "proform_carbon_tlx_treadmill": 11267,
+      "proform_carbon_tlx_v84_314_treadmill": 11270,
+      "proform_csx210": 6113,
+      "proform_cycle_trainer_300_ci": 6104,
+      "proform_cycle_trainer_400": 6105,
+      "proform_elliptical_ip": 13236,
+      "proform_hybrid_trainer_PFEL03815": 13184,
+      "proform_hybrid_trainer_xt": 13170,
+      "proform_performance_300i": 11257,
+      "proform_performance_400i": 11247,
+      "proform_pro_1000_treadmill": 11221,
+      "proform_proshox2": 11237,
+      "proform_rower_750r": 12973,
+      "proform_rower_ip": 12992,
+      "proform_rower_sport_rl": 12960,
+      "proform_studio": 6096,
+      "proform_studio_NTEX71021": 6097,
+      "proform_tdf_10": 6099,
+      "proform_tdf_10_0": 6101,
+      "proform_tdf_jonseed_watt": 6193,
+      "proform_tour_de_france_clc": 6095,
+      "proform_trainer_8_0": 11254,
+      "proform_trainer_8_0_pftl59721_int_0": 11268,
+      "proform_trainer_9_0": 11265,
+      "proform_treadmill_105_cst": 11272,
+      "proform_treadmill_1500_pro": 11252,
+      "proform_treadmill_1800i": 11228,
+      "proform_treadmill_505_cst": 11218,
+      "proform_treadmill_575i": 11246,
+      "proform_treadmill_705_cst": 11234,
+      "proform_treadmill_705_cst_V78_239": 11241,
+      "proform_treadmill_705_cst_V80_44": 11255,
+      "proform_treadmill_8_0": 11232,
+      "proform_treadmill_8_7": 11240,
+      "proform_treadmill_995i": 11263,
+      "proform_treadmill_9_0": 11233,
+      "proform_treadmill_c700": 11248,
+      "proform_treadmill_c960i": 11249,
+      "proform_treadmill_cadence_lt": 11231,
+      "proform_treadmill_carbon_t7": 11242,
+      "proform_treadmill_carbon_tls": 11262,
+      "proform_treadmill_cst_505_pftl59420_0": 11271,
+      "proform_treadmill_l6_0s": 11222,
+      "proform_treadmill_se": 11230,
+      "proform_treadmill_sport_3_0": 11266,
+      "proform_treadmill_sport_70": 11245,
+      "proform_treadmill_sport_8_5": 11220,
+      "proform_treadmill_z1300i": 11229,
+      "proform_wheel_ratio": 6028,
+      "proform_xbike": 6111,
+      "proformtdf1ip": 6207,
+      "proformtdf4ip": 6231,
+      "proformtreadmillip": 11431,
+      "pzp_password": 7771,
+      "pzp_username": 7734,
+      "race_mode": 16993,
+      "real_inclination_to_virtual_treamill_bridge": 14136,
+      "reebok_fr30_treadmill": 12654,
+      "renpho_bike_double_resistance": 5563,
+      "renpho_bike_knob_gears": 5576,
+      "renpho_peloton_conversion_v2": 5550,
+      "restore_specific_gear": 4023,
+      "rogue_echo_bike": 14462,
+      "rolling_resistance": 4085,
+      "rouvy_compatibility": 8571,
+      "rpe_feel_popup_enabled": 8725,
+      "run_cadence_sensor": 17021,
+      "saris_trainer": 5619,
+      "schwinn_bike_resistance": 5291,
+      "schwinn_bike_resistance_v2": 5305,
+      "schwinn_bike_resistance_v3": 5318,
+      "schwinn_resistance_smooth": 5332,
+      "sex": 3083,
+      "shortcut_auto_resistance": 313,
+      "shortcut_avs_climb": 318,
+      "shortcut_avs_cruise": 317,
+      "shortcut_avs_sprint": 319,
+      "shortcut_biggears_minus": 225,
+      "shortcut_biggears_plus": 224,
+      "shortcut_erg_mode": 305,
+      "shortcut_ext_incline_minus": 301,
+      "shortcut_ext_incline_plus": 300,
+      "shortcut_fan_minus": 291,
+      "shortcut_fan_plus": 290,
+      "shortcut_gears_minus": 220,
+      "shortcut_gears_plus": 219,
+      "shortcut_inclination_minus": 210,
+      "shortcut_inclination_plus": 209,
+      "shortcut_lap": 192,
+      "shortcut_peloton_offset_minus": 276,
+      "shortcut_peloton_offset_plus": 275,
+      "shortcut_peloton_remaining_minus": 281,
+      "shortcut_peloton_remaining_plus": 280,
+      "shortcut_peloton_resistance_minus": 271,
+      "shortcut_peloton_resistance_plus": 270,
+      "shortcut_pid_hr_minus": 296,
+      "shortcut_pid_hr_plus": 295,
+      "shortcut_power_avg": 309,
+      "shortcut_preset_inclination_1": 355,
+      "shortcut_preset_inclination_2": 356,
+      "shortcut_preset_inclination_3": 357,
+      "shortcut_preset_inclination_4": 358,
+      "shortcut_preset_inclination_5": 359,
+      "shortcut_preset_powerzone_1": 368,
+      "shortcut_preset_powerzone_2": 369,
+      "shortcut_preset_powerzone_3": 370,
+      "shortcut_preset_powerzone_4": 371,
+      "shortcut_preset_powerzone_5": 372,
+      "shortcut_preset_powerzone_6": 373,
+      "shortcut_preset_powerzone_7": 374,
+      "shortcut_preset_resistance_1": 329,
+      "shortcut_preset_resistance_2": 330,
+      "shortcut_preset_resistance_3": 331,
+      "shortcut_preset_resistance_4": 332,
+      "shortcut_preset_resistance_5": 333,
+      "shortcut_preset_speed_1": 342,
+      "shortcut_preset_speed_2": 343,
+      "shortcut_preset_speed_3": 344,
+      "shortcut_preset_speed_4": 345,
+      "shortcut_preset_speed_5": 346,
+      "shortcut_remaining_time_minus": 286,
+      "shortcut_remaining_time_plus": 285,
+      "shortcut_resistance_minus": 215,
+      "shortcut_resistance_plus": 214,
+      "shortcut_speed_minus": 205,
+      "shortcut_speed_plus": 204,
+      "shortcut_start_stop": 184,
+      "shortcut_stop": 188,
+      "shortcut_target_incline_minus": 258,
+      "shortcut_target_incline_plus": 257,
+      "shortcut_target_power_minus": 243,
+      "shortcut_target_power_plus": 242,
+      "shortcut_target_resistance_minus": 238,
+      "shortcut_target_resistance_plus": 237,
+      "shortcut_target_speed_minus": 253,
+      "shortcut_target_speed_plus": 252,
+      "shortcut_target_zone_minus": 248,
+      "shortcut_target_zone_plus": 247,
+      "shortcuts_enabled": 113,
+      "skandika_wiri_x2000_protocol": 5707,
+      "snode_bike": 5684,
+      "sole_elliptical_e55": 13296,
+      "sole_elliptical_inclination": 13282,
+      "sole_treadmill_f63": 12029,
+      "sole_treadmill_f65": 12043,
+      "sole_treadmill_inclination": 11988,
+      "sole_treadmill_inclination_fast": 12001,
+      "sole_treadmill_miles": 6541,
+      "sole_treadmill_tt8": 12057,
+      "sp_ht_9600ie": 5641,
+      "speed_gain": 13538,
+      "speed_offset": 13499,
+      "speed_power_based": 3966,
+      "sportstech_esx500": 5786,
+      "sportstech_sx600": 5772,
+      "ss2k_max_resistance": 15162,
+      "ss2k_min_resistance": 15186,
+      "ss2k_peloton": 15123,
+      "ss2k_resistance_sample_1": 15219,
+      "ss2k_resistance_sample_2": 15266,
+      "ss2k_resistance_sample_3": 15313,
+      "ss2k_resistance_sample_4": 15360,
+      "ss2k_shift_step": 15138,
+      "ss2k_shift_step_sample_1": 15242,
+      "ss2k_shift_step_sample_2": 15289,
+      "ss2k_shift_step_sample_3": 15336,
+      "ss2k_shift_step_sample_4": 15383,
+      "step_gain": 10982,
+      "strava_auth_external_webbrowser": 13721,
+      "strava_date_prefix": 13803,
+      "strava_suffix": 13685,
+      "strava_treadmill": 13776,
+      "strava_upload_mode": 13660,
+      "strava_virtual_activity": 13749,
+      "stryd_add_inclination_gain": 14824,
+      "stryd_inclination_instead_treadmill": 14770,
+      "stryd_speed_instead_treadmill": 14743,
+      "tacx_neo2_peloton": 5979,
+      "tacxneo2_disable_negative_inclination": 5993,
+      "taurua_ic90": 12624,
+      "tdf_10_ip": 6255,
+      "technogym_bike": 6566,
+      "technogym_group_cycle": 6580,
+      "technogym_myrun_treadmill_experimental": 12082,
+      "theme_background_color": 7235,
+      "theme_status_bar_background_color": 7349,
+      "theme_tile_background_color": 7269,
+      "theme_tile_icon_enabled": 7221,
+      "theme_tile_secondline_textsize": 7382,
+      "theme_tile_shadow_color": 7316,
+      "theme_tile_shadow_enabled": 7302,
+      "thinkrider_controller": 15744,
+      "tile_auto_virtual_shifting_climb_order": 5654,
+      "tile_auto_virtual_shifting_cruise_order": 5611,
+      "tile_auto_virtual_shifting_sprint_order": 5697,
+      "tile_avg_pace_order": 768,
+      "tile_avg_watt_lap_order": 1057,
+      "tile_avgwatt_order": 1011,
+      "tile_biggears_order": 2003,
+      "tile_biggears_swap": 2024,
+      "tile_cadence_color_enabled": 478,
+      "tile_cadence_order": 508,
+      "tile_calories_order": 629,
+      "tile_coretemperature_order": 5387,
+      "tile_datetime_order": 2228,
+      "tile_elapsed_order": 1286,
+      "tile_elevation_order": 554,
+      "tile_erg_mode_order": 2697,
+      "tile_ext_incline_order": 2453,
+      "tile_fan_order": 1196,
+      "tile_ftp_order": 1089,
+      "tile_gears_order": 1959,
+      "tile_grade_adjusted_pace_order": 800,
+      "tile_ground_contact_order": 2543,
+      "tile_heart_order": 1163,
+      "tile_heart_show_as_percent": 1133,
+      "tile_heat_time_in_zone_1_order": 5432,
+      "tile_heat_time_in_zone_2_order": 5477,
+      "tile_heat_time_in_zone_3_order": 5522,
+      "tile_heat_time_in_zone_4_order": 5567,
+      "tile_hr_time_in_zone_1_order": 5133,
+      "tile_hr_time_in_zone_2_order": 5178,
+      "tile_hr_time_in_zone_3_order": 5223,
+      "tile_hr_time_in_zone_4_order": 5268,
+      "tile_hr_time_in_zone_5_order": 5313,
+      "tile_hr_time_in_zone_individual_mode": 5350,
+      "tile_hrv_order": 5784,
+      "tile_inclination_order": 447,
+      "tile_instantaneous_stride_length_order": 2498,
+      "tile_jouls_order": 1241,
+      "tile_lapelapsed_order": 1499,
+      "tile_mets_order": 2151,
+      "tile_moving_time_order": 1331,
+      "tile_negative_inclination_order": 585,
+      "tile_nextrowstrainprogram_order": 2106,
+      "tile_odometer_order": 674,
+      "tile_pace_color_enabled": 718,
+      "tile_pace_last500m_order": 2633,
+      "tile_pace_order": 735,
+      "tile_peloton_offset_order": 1376,
+      "tile_peloton_remaining_order": 1421,
+      "tile_peloton_resistance_color_enabled": 1530,
+      "tile_peloton_resistance_order": 1546,
+      "tile_pid_hr_order": 2408,
+      "tile_power_avg_order": 5740,
+      "tile_preset_inclination_1_color": 3944,
+      "tile_preset_inclination_1_label": 3913,
+      "tile_preset_inclination_1_order": 3869,
+      "tile_preset_inclination_1_value": 3892,
+      "tile_preset_inclination_2_color": 4054,
+      "tile_preset_inclination_2_label": 4022,
+      "tile_preset_inclination_2_order": 3978,
+      "tile_preset_inclination_2_value": 4001,
+      "tile_preset_inclination_3_color": 4162,
+      "tile_preset_inclination_3_label": 4131,
+      "tile_preset_inclination_3_order": 4087,
+      "tile_preset_inclination_3_value": 4110,
+      "tile_preset_inclination_4_color": 4271,
+      "tile_preset_inclination_4_label": 4240,
+      "tile_preset_inclination_4_order": 4196,
+      "tile_preset_inclination_4_value": 4219,
+      "tile_preset_inclination_5_color": 4380,
+      "tile_preset_inclination_5_label": 4349,
+      "tile_preset_inclination_5_order": 4305,
+      "tile_preset_inclination_5_value": 4328,
+      "tile_preset_powerzone_1_color": 4480,
+      "tile_preset_powerzone_1_label": 4453,
+      "tile_preset_powerzone_1_order": 4413,
+      "tile_preset_powerzone_1_value": 4434,
+      "tile_preset_powerzone_2_color": 4581,
+      "tile_preset_powerzone_2_label": 4554,
+      "tile_preset_powerzone_2_order": 4514,
+      "tile_preset_powerzone_2_value": 4535,
+      "tile_preset_powerzone_3_color": 4682,
+      "tile_preset_powerzone_3_label": 4655,
+      "tile_preset_powerzone_3_order": 4615,
+      "tile_preset_powerzone_3_value": 4636,
+      "tile_preset_powerzone_4_color": 4783,
+      "tile_preset_powerzone_4_label": 4756,
+      "tile_preset_powerzone_4_order": 4716,
+      "tile_preset_powerzone_4_value": 4737,
+      "tile_preset_powerzone_5_color": 4884,
+      "tile_preset_powerzone_5_label": 4857,
+      "tile_preset_powerzone_5_order": 4817,
+      "tile_preset_powerzone_5_value": 4838,
+      "tile_preset_powerzone_6_color": 4985,
+      "tile_preset_powerzone_6_label": 4958,
+      "tile_preset_powerzone_6_order": 4918,
+      "tile_preset_powerzone_6_value": 4939,
+      "tile_preset_powerzone_7_color": 5086,
+      "tile_preset_powerzone_7_label": 5059,
+      "tile_preset_powerzone_7_order": 5019,
+      "tile_preset_powerzone_7_value": 5040,
+      "tile_preset_resistance_1_color": 2834,
+      "tile_preset_resistance_1_label": 2803,
+      "tile_preset_resistance_1_order": 2759,
+      "tile_preset_resistance_1_value": 2782,
+      "tile_preset_resistance_2_color": 2943,
+      "tile_preset_resistance_2_label": 2912,
+      "tile_preset_resistance_2_order": 2868,
+      "tile_preset_resistance_2_value": 2891,
+      "tile_preset_resistance_3_color": 3052,
+      "tile_preset_resistance_3_label": 3021,
+      "tile_preset_resistance_3_order": 2977,
+      "tile_preset_resistance_3_value": 3000,
+      "tile_preset_resistance_4_color": 3161,
+      "tile_preset_resistance_4_label": 3130,
+      "tile_preset_resistance_4_order": 3086,
+      "tile_preset_resistance_4_value": 3109,
+      "tile_preset_resistance_5_color": 3270,
+      "tile_preset_resistance_5_label": 3239,
+      "tile_preset_resistance_5_order": 3195,
+      "tile_preset_resistance_5_value": 3218,
+      "tile_preset_speed_1_color": 3383,
+      "tile_preset_speed_1_label": 3352,
+      "tile_preset_speed_1_order": 3304,
+      "tile_preset_speed_1_value": 3327,
+      "tile_preset_speed_2_color": 3496,
+      "tile_preset_speed_2_label": 3465,
+      "tile_preset_speed_2_order": 3417,
+      "tile_preset_speed_2_value": 3440,
+      "tile_preset_speed_3_color": 3609,
+      "tile_preset_speed_3_label": 3578,
+      "tile_preset_speed_3_order": 3530,
+      "tile_preset_speed_3_value": 3553,
+      "tile_preset_speed_4_color": 3722,
+      "tile_preset_speed_4_label": 3691,
+      "tile_preset_speed_4_order": 3643,
+      "tile_preset_speed_4_value": 3666,
+      "tile_preset_speed_5_color": 3835,
+      "tile_preset_speed_5_label": 3804,
+      "tile_preset_speed_5_order": 3756,
+      "tile_preset_speed_5_value": 3779,
+      "tile_remainingtimetrainprogramrow_order": 2061,
+      "tile_resistance_order": 858,
+      "tile_rss_order": 2727,
+      "tile_speed_order": 402,
+      "tile_steering_angle_order": 2363,
+      "tile_step_count_order": 2665,
+      "tile_strokes_count_order": 2273,
+      "tile_strokes_length_order": 2318,
+      "tile_target_cadence_order": 1683,
+      "tile_target_incline_order": 1883,
+      "tile_target_pace_order": 1851,
+      "tile_target_peloton_resistance_order": 1638,
+      "tile_target_power_order": 1728,
+      "tile_target_resistance_order": 1592,
+      "tile_target_speed_order": 1819,
+      "tile_target_zone_order": 1774,
+      "tile_targetmets_order": 2196,
+      "tile_vertical_oscillation_order": 2588,
+      "tile_watt_color_enabled": 902,
+      "tile_watt_kg_order": 1914,
+      "tile_watt_order": 919,
+      "tile_weight_loss_order": 965,
+      "toorx_3_0": 12684,
+      "toorx_65s_evo": 12524,
+      "toorx_bike": 12699,
+      "toorx_bike_srx_500": 12567,
+      "toorx_ftms": 12744,
+      "toorx_ftms_treadmill": 12714,
+      "toorx_srx_3500": 12582,
+      "toorxtreadmill_discovery_completed": 12840,
+      "top_bar_enabled": 6909,
+      "toputure_teb1": 6635,
+      "trainprogram_auto_lap_on_segment": 9793,
+      "trainprogram_clipboard_workout_enabled": 9738,
+      "trainprogram_cooldown_speed": 10275,
+      "trainprogram_incline_max": 10534,
+      "trainprogram_incline_min": 10509,
+      "trainprogram_period_seconds": 10434,
+      "trainprogram_pid_hr_pushy_zone_limit": 10005,
+      "trainprogram_pid_hr_recovery_zone_limit": 9971,
+      "trainprogram_pid_ignore_inclination": 10039,
+      "trainprogram_pid_pushy": 9944,
+      "trainprogram_random": 10396,
+      "trainprogram_resistance_max": 10584,
+      "trainprogram_resistance_min": 10559,
+      "trainprogram_rest_speed": 10298,
+      "trainprogram_sound_on_segment": 9765,
+      "trainprogram_speed_max": 10484,
+      "trainprogram_speed_min": 10459,
+      "trainprogram_stop_at_end": 9711,
+      "trainprogram_total": 10409,
+      "trainprogram_warmup_speed": 10252,
+      "treadmillDataPoints": 791,
+      "treadmill_difficulty_gain_or_offset": 10771,
+      "treadmill_direct_distance": 10743,
+      "treadmill_follow_wattage": 9820,
+      "treadmill_force_running_activity": 10687,
+      "treadmill_force_speed": 10659,
+      "treadmill_inclination_override_0": 124,
+      "treadmill_inclination_override_05": 146,
+      "treadmill_inclination_override_10": 168,
+      "treadmill_inclination_override_100": 564,
+      "treadmill_inclination_override_105": 586,
+      "treadmill_inclination_override_110": 608,
+      "treadmill_inclination_override_115": 630,
+      "treadmill_inclination_override_120": 652,
+      "treadmill_inclination_override_125": 674,
+      "treadmill_inclination_override_130": 696,
+      "treadmill_inclination_override_135": 718,
+      "treadmill_inclination_override_140": 740,
+      "treadmill_inclination_override_145": 762,
+      "treadmill_inclination_override_15": 190,
+      "treadmill_inclination_override_150": 784,
+      "treadmill_inclination_override_20": 212,
+      "treadmill_inclination_override_25": 234,
+      "treadmill_inclination_override_30": 256,
+      "treadmill_inclination_override_35": 278,
+      "treadmill_inclination_override_40": 300,
+      "treadmill_inclination_override_45": 322,
+      "treadmill_inclination_override_50": 344,
+      "treadmill_inclination_override_55": 366,
+      "treadmill_inclination_override_60": 388,
+      "treadmill_inclination_override_65": 410,
+      "treadmill_inclination_override_70": 432,
+      "treadmill_inclination_override_75": 454,
+      "treadmill_inclination_override_80": 476,
+      "treadmill_inclination_override_85": 498,
+      "treadmill_inclination_override_90": 520,
+      "treadmill_inclination_override_95": 542,
+      "treadmill_inclination_ovveride_gain": 78,
+      "treadmill_inclination_ovveride_offset": 101,
+      "treadmill_incline_max": 10873,
+      "treadmill_incline_min": 10837,
+      "treadmill_pid_heart_max": 9909,
+      "treadmill_pid_heart_min": 9887,
+      "treadmill_pid_heart_zone": 9849,
+      "treadmill_simulate_inclination_with_speed": 11040,
+      "treadmill_speed_max": 10909,
+      "treadmill_speed_min": 10945,
+      "treadmill_step_incline": 14099,
+      "treadmill_step_speed": 10799,
+      "trx_route_key": 12510,
+      "tts_act_cadence": 195,
+      "tts_act_calories": 251,
+      "tts_act_elapsed": 503,
+      "tts_act_elevation": 237,
+      "tts_act_ftp": 405,
+      "tts_act_heart": 447,
+      "tts_act_inclination": 181,
+      "tts_act_jouls": 489,
+      "tts_act_odometer": 265,
+      "tts_act_pace": 279,
+      "tts_act_peloton_resistance": 517,
+      "tts_act_resistance": 321,
+      "tts_act_speed": 139,
+      "tts_act_target_cadence": 573,
+      "tts_act_target_incline": 643,
+      "tts_act_target_pace": 629,
+      "tts_act_target_peloton_resistance": 559,
+      "tts_act_target_power": 587,
+      "tts_act_target_speed": 615,
+      "tts_act_target_zone": 601,
+      "tts_act_watt": 363,
+      "tts_act_watt_kg": 657,
+      "tts_avg_cadence": 209,
+      "tts_avg_heart": 461,
+      "tts_avg_pace": 293,
+      "tts_avg_peloton_resistance": 531,
+      "tts_avg_resistance": 335,
+      "tts_avg_speed": 153,
+      "tts_avg_watt": 377,
+      "tts_avg_watt_kg": 671,
+      "tts_description_enabled": 125,
+      "tts_enabled": 87,
+      "tts_max_cadence": 223,
+      "tts_max_heart": 475,
+      "tts_max_pace": 307,
+      "tts_max_peloton_resistance": 545,
+      "tts_max_resistance": 349,
+      "tts_max_speed": 167,
+      "tts_max_watt": 391,
+      "tts_max_watt_kg": 685,
+      "tts_summary_sec": 101,
+      "ui_zoom": 2860,
+      "umay_s100_treadmill": 11725,
+      "user_email": 3234,
+      "user_nickname": 3197,
+      "virtual_device_echelon": 16418,
+      "virtual_device_force_bike": 10632,
+      "virtual_device_force_treadmill": 16504,
+      "virtual_device_ifit": 16589,
+      "virtual_device_onlyheart": 16390,
+      "virtual_device_rower": 16446,
+      "virtual_device_rower_pm5": 16474,
+      "virtual_device_tacx": 16616,
+      "virtualbike_forceresistance": 16532,
+      "virtufit_etappe": 5758,
+      "volume_change_gears": 13831,
+      "wahoo_rgt_dircon": 16653,
+      "waterrower_usb": 12940,
+      "watt_bike_emulator": 765,
+      "watt_gain": 13461,
+      "watt_ignore_builtin": 14164,
+      "watt_offset": 13423,
+      "weight": 2948,
+      "weight_kg_unit": 638,
+      "yesoul_peloton_formula": 5662,
+      "zero_zt2500_treadmill": 11712,
+      "zwift_api_autoinclination": 8466,
+      "zwift_api_poll": 8430,
+      "zwift_click": 763,
+      "zwift_erg": 4203,
+      "zwift_erg_filter": 4568,
+      "zwift_erg_filter_down": 4606,
+      "zwift_erg_resistance_down": 4644,
+      "zwift_erg_resistance_up": 4682,
+      "zwift_gear_ui_aligned": 8403,
+      "zwift_inclination_gain": 14025,
+      "zwift_inclination_offset": 13987,
+      "zwift_negative_inclination_x2": 13959,
+      "zwift_ocr": 8493,
+      "zwift_ocr_climb_portal": 8496,
+      "zwift_password": 8286,
+      "zwift_play": 763,
+      "zwift_play_emulator": 762,
+      "zwift_play_vibration": 15872,
+      "zwift_username": 8248,
+      "zwift_workout_ocr": 8496,
+      "zwiftplay_gear_lb": 16072,
+      "zwiftplay_gear_ls1": 16000,
+      "zwiftplay_gear_ls2": 16012,
+      "zwiftplay_gear_paddle_left": 16048,
+      "zwiftplay_gear_paddle_right": 16060,
+      "zwiftplay_gear_rb": 16084,
+      "zwiftplay_gear_rs1": 16024,
+      "zwiftplay_gear_rs2": 16036,
+      "zwiftplay_swap": 15926
+    },
+    "externalEntryOrderByKey": {
+      "miles_unit": 20,
+      "shortcut_auto_resistance": 313,
+      "shortcut_avs_climb": 318,
+      "shortcut_avs_cruise": 317,
+      "shortcut_avs_sprint": 319,
+      "shortcut_biggears_minus": 225,
+      "shortcut_biggears_plus": 224,
+      "shortcut_erg_mode": 305,
+      "shortcut_ext_incline_minus": 301,
+      "shortcut_ext_incline_plus": 300,
+      "shortcut_fan_minus": 291,
+      "shortcut_fan_plus": 290,
+      "shortcut_gears_minus": 220,
+      "shortcut_gears_plus": 219,
+      "shortcut_inclination_minus": 210,
+      "shortcut_inclination_plus": 209,
+      "shortcut_lap": 192,
+      "shortcut_peloton_offset_minus": 276,
+      "shortcut_peloton_offset_plus": 275,
+      "shortcut_peloton_remaining_minus": 281,
+      "shortcut_peloton_remaining_plus": 280,
+      "shortcut_peloton_resistance_minus": 271,
+      "shortcut_peloton_resistance_plus": 270,
+      "shortcut_pid_hr_minus": 296,
+      "shortcut_pid_hr_plus": 295,
+      "shortcut_power_avg": 309,
+      "shortcut_preset_inclination_1": 355,
+      "shortcut_preset_inclination_2": 356,
+      "shortcut_preset_inclination_3": 357,
+      "shortcut_preset_inclination_4": 358,
+      "shortcut_preset_inclination_5": 359,
+      "shortcut_preset_powerzone_1": 368,
+      "shortcut_preset_powerzone_2": 369,
+      "shortcut_preset_powerzone_3": 370,
+      "shortcut_preset_powerzone_4": 371,
+      "shortcut_preset_powerzone_5": 372,
+      "shortcut_preset_powerzone_6": 373,
+      "shortcut_preset_powerzone_7": 374,
+      "shortcut_preset_resistance_1": 329,
+      "shortcut_preset_resistance_2": 330,
+      "shortcut_preset_resistance_3": 331,
+      "shortcut_preset_resistance_4": 332,
+      "shortcut_preset_resistance_5": 333,
+      "shortcut_preset_speed_1": 342,
+      "shortcut_preset_speed_2": 343,
+      "shortcut_preset_speed_3": 344,
+      "shortcut_preset_speed_4": 345,
+      "shortcut_preset_speed_5": 346,
+      "shortcut_remaining_time_minus": 286,
+      "shortcut_remaining_time_plus": 285,
+      "shortcut_resistance_minus": 215,
+      "shortcut_resistance_plus": 214,
+      "shortcut_speed_minus": 205,
+      "shortcut_speed_plus": 204,
+      "shortcut_start_stop": 184,
+      "shortcut_stop": 188,
+      "shortcut_target_incline_minus": 258,
+      "shortcut_target_incline_plus": 257,
+      "shortcut_target_power_minus": 243,
+      "shortcut_target_power_plus": 242,
+      "shortcut_target_resistance_minus": 238,
+      "shortcut_target_resistance_plus": 237,
+      "shortcut_target_speed_minus": 253,
+      "shortcut_target_speed_plus": 252,
+      "shortcut_target_zone_minus": 248,
+      "shortcut_target_zone_plus": 247,
+      "shortcuts_enabled": 113,
+      "tile_auto_virtual_shifting_climb_order": 5654,
+      "tile_auto_virtual_shifting_cruise_order": 5611,
+      "tile_auto_virtual_shifting_sprint_order": 5697,
+      "tile_avg_pace_order": 768,
+      "tile_avg_watt_lap_order": 1057,
+      "tile_avgwatt_order": 1011,
+      "tile_biggears_order": 2003,
+      "tile_biggears_swap": 2024,
+      "tile_cadence_color_enabled": 478,
+      "tile_cadence_order": 508,
+      "tile_calories_order": 629,
+      "tile_coretemperature_order": 5387,
+      "tile_datetime_order": 2228,
+      "tile_elapsed_order": 1286,
+      "tile_elevation_order": 554,
+      "tile_erg_mode_order": 2697,
+      "tile_ext_incline_order": 2453,
+      "tile_fan_order": 1196,
+      "tile_ftp_order": 1089,
+      "tile_gears_order": 1959,
+      "tile_grade_adjusted_pace_order": 800,
+      "tile_ground_contact_order": 2543,
+      "tile_heart_order": 1163,
+      "tile_heart_show_as_percent": 1133,
+      "tile_heat_time_in_zone_1_order": 5432,
+      "tile_heat_time_in_zone_2_order": 5477,
+      "tile_heat_time_in_zone_3_order": 5522,
+      "tile_heat_time_in_zone_4_order": 5567,
+      "tile_hr_time_in_zone_1_order": 5133,
+      "tile_hr_time_in_zone_2_order": 5178,
+      "tile_hr_time_in_zone_3_order": 5223,
+      "tile_hr_time_in_zone_4_order": 5268,
+      "tile_hr_time_in_zone_5_order": 5313,
+      "tile_hr_time_in_zone_individual_mode": 5350,
+      "tile_hrv_order": 5784,
+      "tile_inclination_order": 447,
+      "tile_instantaneous_stride_length_order": 2498,
+      "tile_jouls_order": 1241,
+      "tile_lapelapsed_order": 1499,
+      "tile_mets_order": 2151,
+      "tile_moving_time_order": 1331,
+      "tile_negative_inclination_order": 585,
+      "tile_nextrowstrainprogram_order": 2106,
+      "tile_odometer_order": 674,
+      "tile_pace_color_enabled": 718,
+      "tile_pace_last500m_order": 2633,
+      "tile_pace_order": 735,
+      "tile_peloton_offset_order": 1376,
+      "tile_peloton_remaining_order": 1421,
+      "tile_peloton_resistance_color_enabled": 1530,
+      "tile_peloton_resistance_order": 1546,
+      "tile_pid_hr_order": 2408,
+      "tile_power_avg_order": 5740,
+      "tile_preset_inclination_1_color": 3944,
+      "tile_preset_inclination_1_label": 3913,
+      "tile_preset_inclination_1_order": 3869,
+      "tile_preset_inclination_1_value": 3892,
+      "tile_preset_inclination_2_color": 4054,
+      "tile_preset_inclination_2_label": 4022,
+      "tile_preset_inclination_2_order": 3978,
+      "tile_preset_inclination_2_value": 4001,
+      "tile_preset_inclination_3_color": 4162,
+      "tile_preset_inclination_3_label": 4131,
+      "tile_preset_inclination_3_order": 4087,
+      "tile_preset_inclination_3_value": 4110,
+      "tile_preset_inclination_4_color": 4271,
+      "tile_preset_inclination_4_label": 4240,
+      "tile_preset_inclination_4_order": 4196,
+      "tile_preset_inclination_4_value": 4219,
+      "tile_preset_inclination_5_color": 4380,
+      "tile_preset_inclination_5_label": 4349,
+      "tile_preset_inclination_5_order": 4305,
+      "tile_preset_inclination_5_value": 4328,
+      "tile_preset_powerzone_1_color": 4480,
+      "tile_preset_powerzone_1_label": 4453,
+      "tile_preset_powerzone_1_order": 4413,
+      "tile_preset_powerzone_1_value": 4434,
+      "tile_preset_powerzone_2_color": 4581,
+      "tile_preset_powerzone_2_label": 4554,
+      "tile_preset_powerzone_2_order": 4514,
+      "tile_preset_powerzone_2_value": 4535,
+      "tile_preset_powerzone_3_color": 4682,
+      "tile_preset_powerzone_3_label": 4655,
+      "tile_preset_powerzone_3_order": 4615,
+      "tile_preset_powerzone_3_value": 4636,
+      "tile_preset_powerzone_4_color": 4783,
+      "tile_preset_powerzone_4_label": 4756,
+      "tile_preset_powerzone_4_order": 4716,
+      "tile_preset_powerzone_4_value": 4737,
+      "tile_preset_powerzone_5_color": 4884,
+      "tile_preset_powerzone_5_label": 4857,
+      "tile_preset_powerzone_5_order": 4817,
+      "tile_preset_powerzone_5_value": 4838,
+      "tile_preset_powerzone_6_color": 4985,
+      "tile_preset_powerzone_6_label": 4958,
+      "tile_preset_powerzone_6_order": 4918,
+      "tile_preset_powerzone_6_value": 4939,
+      "tile_preset_powerzone_7_color": 5086,
+      "tile_preset_powerzone_7_label": 5059,
+      "tile_preset_powerzone_7_order": 5019,
+      "tile_preset_powerzone_7_value": 5040,
+      "tile_preset_resistance_1_color": 2834,
+      "tile_preset_resistance_1_label": 2803,
+      "tile_preset_resistance_1_order": 2759,
+      "tile_preset_resistance_1_value": 2782,
+      "tile_preset_resistance_2_color": 2943,
+      "tile_preset_resistance_2_label": 2912,
+      "tile_preset_resistance_2_order": 2868,
+      "tile_preset_resistance_2_value": 2891,
+      "tile_preset_resistance_3_color": 3052,
+      "tile_preset_resistance_3_label": 3021,
+      "tile_preset_resistance_3_order": 2977,
+      "tile_preset_resistance_3_value": 3000,
+      "tile_preset_resistance_4_color": 3161,
+      "tile_preset_resistance_4_label": 3130,
+      "tile_preset_resistance_4_order": 3086,
+      "tile_preset_resistance_4_value": 3109,
+      "tile_preset_resistance_5_color": 3270,
+      "tile_preset_resistance_5_label": 3239,
+      "tile_preset_resistance_5_order": 3195,
+      "tile_preset_resistance_5_value": 3218,
+      "tile_preset_speed_1_color": 3383,
+      "tile_preset_speed_1_label": 3352,
+      "tile_preset_speed_1_order": 3304,
+      "tile_preset_speed_1_value": 3327,
+      "tile_preset_speed_2_color": 3496,
+      "tile_preset_speed_2_label": 3465,
+      "tile_preset_speed_2_order": 3417,
+      "tile_preset_speed_2_value": 3440,
+      "tile_preset_speed_3_color": 3609,
+      "tile_preset_speed_3_label": 3578,
+      "tile_preset_speed_3_order": 3530,
+      "tile_preset_speed_3_value": 3553,
+      "tile_preset_speed_4_color": 3722,
+      "tile_preset_speed_4_label": 3691,
+      "tile_preset_speed_4_order": 3643,
+      "tile_preset_speed_4_value": 3666,
+      "tile_preset_speed_5_color": 3835,
+      "tile_preset_speed_5_label": 3804,
+      "tile_preset_speed_5_order": 3756,
+      "tile_preset_speed_5_value": 3779,
+      "tile_remainingtimetrainprogramrow_order": 2061,
+      "tile_resistance_order": 858,
+      "tile_rss_order": 2727,
+      "tile_speed_order": 402,
+      "tile_steering_angle_order": 2363,
+      "tile_step_count_order": 2665,
+      "tile_strokes_count_order": 2273,
+      "tile_strokes_length_order": 2318,
+      "tile_target_cadence_order": 1683,
+      "tile_target_incline_order": 1883,
+      "tile_target_pace_order": 1851,
+      "tile_target_peloton_resistance_order": 1638,
+      "tile_target_power_order": 1728,
+      "tile_target_resistance_order": 1592,
+      "tile_target_speed_order": 1819,
+      "tile_target_zone_order": 1774,
+      "tile_targetmets_order": 2196,
+      "tile_vertical_oscillation_order": 2588,
+      "tile_watt_color_enabled": 902,
+      "tile_watt_kg_order": 1914,
+      "tile_watt_order": 919,
+      "tile_weight_loss_order": 965,
+      "treadmill_inclination_override_0": 124,
+      "treadmill_inclination_override_05": 146,
+      "treadmill_inclination_override_10": 168,
+      "treadmill_inclination_override_100": 564,
+      "treadmill_inclination_override_105": 586,
+      "treadmill_inclination_override_110": 608,
+      "treadmill_inclination_override_115": 630,
+      "treadmill_inclination_override_120": 652,
+      "treadmill_inclination_override_125": 674,
+      "treadmill_inclination_override_130": 696,
+      "treadmill_inclination_override_135": 718,
+      "treadmill_inclination_override_140": 740,
+      "treadmill_inclination_override_145": 762,
+      "treadmill_inclination_override_15": 190,
+      "treadmill_inclination_override_150": 784,
+      "treadmill_inclination_override_20": 212,
+      "treadmill_inclination_override_25": 234,
+      "treadmill_inclination_override_30": 256,
+      "treadmill_inclination_override_35": 278,
+      "treadmill_inclination_override_40": 300,
+      "treadmill_inclination_override_45": 322,
+      "treadmill_inclination_override_50": 344,
+      "treadmill_inclination_override_55": 366,
+      "treadmill_inclination_override_60": 388,
+      "treadmill_inclination_override_65": 410,
+      "treadmill_inclination_override_70": 432,
+      "treadmill_inclination_override_75": 454,
+      "treadmill_inclination_override_80": 476,
+      "treadmill_inclination_override_85": 498,
+      "treadmill_inclination_override_90": 520,
+      "treadmill_inclination_override_95": 542,
+      "treadmill_inclination_ovveride_gain": 78,
+      "treadmill_inclination_ovveride_offset": 101,
+      "tts_act_cadence": 195,
+      "tts_act_calories": 251,
+      "tts_act_elapsed": 503,
+      "tts_act_elevation": 237,
+      "tts_act_ftp": 405,
+      "tts_act_heart": 447,
+      "tts_act_inclination": 181,
+      "tts_act_jouls": 489,
+      "tts_act_odometer": 265,
+      "tts_act_pace": 279,
+      "tts_act_peloton_resistance": 517,
+      "tts_act_resistance": 321,
+      "tts_act_speed": 139,
+      "tts_act_target_cadence": 573,
+      "tts_act_target_incline": 643,
+      "tts_act_target_pace": 629,
+      "tts_act_target_peloton_resistance": 559,
+      "tts_act_target_power": 587,
+      "tts_act_target_speed": 615,
+      "tts_act_target_zone": 601,
+      "tts_act_watt": 363,
+      "tts_act_watt_kg": 657,
+      "tts_avg_cadence": 209,
+      "tts_avg_heart": 461,
+      "tts_avg_pace": 293,
+      "tts_avg_peloton_resistance": 531,
+      "tts_avg_resistance": 335,
+      "tts_avg_speed": 153,
+      "tts_avg_watt": 377,
+      "tts_avg_watt_kg": 671,
+      "tts_description_enabled": 125,
+      "tts_enabled": 87,
+      "tts_max_cadence": 223,
+      "tts_max_heart": 475,
+      "tts_max_pace": 307,
+      "tts_max_peloton_resistance": 545,
+      "tts_max_resistance": 349,
+      "tts_max_speed": 167,
+      "tts_max_watt": 391,
+      "tts_max_watt_kg": 685,
+      "tts_summary_sec": 101
+    },
+    "pageNodeByKey": {
+      "page_custom_gear_table": "bikeOptionsAccordion",
+      "page_custom_inclination_resistance_table": "bikeOptionsAccordion",
+      "page_inclination_overrides": "treadmillAccordion",
+      "page_wahoo_options": "bikeOptionsAccordion"
+    },
+    "pageOrderByKey": {
+      "page_custom_gear_table": 4785,
+      "page_custom_inclination_resistance_table": 4793,
+      "page_inclination_overrides": 11011,
+      "page_keyboard_shortcuts": 377,
+      "page_tiles_options": 6880,
+      "page_tts_text_to_speech_settings": 16128,
+      "page_wahoo_options": 5266
+    },
+    "pageParentTargetByKey": {
+      "page_keyboard_shortcuts": "settings-tiles.qml"
+    },
+    "rootPages": [
+      {
+        "key": "page_tiles_options",
+        "name": "Tiles Options",
+        "target": "settings-tiles.qml",
+        "sourceLine": 6880
+      },
+      {
+        "key": "page_tts_text_to_speech_settings",
+        "name": "TTS (Text to Speech) Settings 🔊",
+        "target": "settings-tts.qml",
+        "sourceLine": 16128
+      }
+    ]
+  }
 }

--- a/tools/check_settings_catalog.py
+++ b/tools/check_settings_catalog.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from check_settings_property_order import settings_properties
+
+
+CATALOG_PATH = Path("src/settings-catalog.json")
+SETTINGS_PATH = Path("src/settings.qml")
+EXPECTED_FORMAT = "qdomyos-zwift-settings-catalog"
+SUPPORTED_TYPES = {"boolean", "integer", "number", "string", "enum", "page"}
+SUPPORTED_CONTROLS = {"button", "internal", "select", "switch", "text", "textfield", "virtualOption", "page"}
+EXPECTED_QML_TYPES = {
+    "boolean": {"bool"},
+    "integer": {"int"},
+    "number": {"double", "real"},
+    "string": {"string", "var"},
+}
+
+
+def read_git_file(ref: str, path: Path) -> str:
+    try:
+        return subprocess.check_output(
+            ["git", "show", f"{ref}:{path.as_posix()}"],
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(f"Unable to read {path} from base ref {ref}") from exc
+
+
+def load_json(text: str, source: str) -> dict:
+    try:
+        value = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"{source} is not valid JSON: {exc}") from exc
+
+    if not isinstance(value, dict):
+        raise RuntimeError(f"{source} must contain a JSON object")
+    return value
+
+
+def require_string(entry: dict, field: str, location: str, errors: list[str]) -> None:
+    if not isinstance(entry.get(field), str) or not entry[field].strip():
+        errors.append(f"{location}: '{field}' must be a non-empty string")
+
+
+def validate_options(options: object, location: str, errors: list[str]) -> None:
+    if options is None:
+        return
+
+    if isinstance(options, list):
+        for index, option in enumerate(options):
+            option_location = f"{location}.options[{index}]"
+            if not isinstance(option, dict):
+                errors.append(f"{option_location}: must be an object")
+                continue
+            require_string(option, "label", option_location, errors)
+            if "sets" in option and not isinstance(option["sets"], str):
+                errors.append(f"{option_location}: 'sets' must be a string")
+        return
+
+    if not isinstance(options, dict):
+        errors.append(f"{location}.options: must be null, an object, or an array")
+        return
+
+    if "values" in options and not isinstance(options["values"], list):
+        errors.append(f"{location}.options.values: must be an array")
+    if "labels" in options and not isinstance(options["labels"], list):
+        errors.append(f"{location}.options.labels: must be an array")
+    if "expression" in options and not isinstance(options["expression"], str):
+        errors.append(f"{location}.options.expression: must be a string")
+    if "source" in options and not isinstance(options["source"], str):
+        errors.append(f"{location}.options.source: must be a string")
+
+    values = options.get("values")
+    labels = options.get("labels")
+    if isinstance(values, list) and isinstance(labels, list) and len(values) != len(labels):
+        errors.append(f"{location}.options: 'values' and 'labels' must have the same length")
+
+    if not any(field in options for field in ("values", "expression")):
+        errors.append(f"{location}.options: expected 'values' or 'expression'")
+
+
+def validate_entry(entry: object, location: str, kind: str, errors: list[str]) -> None:
+    if not isinstance(entry, dict):
+        errors.append(f"{location}: must be an object")
+        return
+
+    common_fields = ["key", "name", "description", "parent", "type", "control"]
+    if kind == "setting":
+        common_fields += [
+            "qmlType",
+            "visible",
+            "defaultValue",
+            "defaultExpression",
+            "options",
+            "restartRequired",
+        ]
+    elif kind == "virtual":
+        common_fields += ["defaultValue", "options", "restartRequired"]
+        # The two legacy model selectors predate the complete catalog format.
+        if entry.get("type") != "enum":
+            common_fields += ["defaultExpression", "visible"]
+    else:
+        common_fields += ["target", "visible"]
+
+    for field in common_fields:
+        if field not in entry:
+            errors.append(f"{location}: missing required field '{field}'")
+
+    for field in ("key", "name", "parent"):
+        require_string(entry, field, location, errors)
+
+    if "description" in entry and entry["description"] is not None and not isinstance(entry["description"], str):
+        errors.append(f"{location}: 'description' must be a string or null")
+
+    if entry.get("type") not in SUPPORTED_TYPES:
+        errors.append(f"{location}: unsupported type {entry.get('type')!r}")
+    if entry.get("control") not in SUPPORTED_CONTROLS:
+        errors.append(f"{location}: unsupported control {entry.get('control')!r}")
+    if kind == "setting" and entry.get("type") in EXPECTED_QML_TYPES:
+        if entry.get("qmlType") not in EXPECTED_QML_TYPES[entry["type"]]:
+            errors.append(
+                f"{location}: qmlType {entry.get('qmlType')!r} does not match "
+                f"type {entry.get('type')!r}"
+            )
+
+    if kind == "setting" and not isinstance(entry.get("defaultExpression"), str):
+        errors.append(f"{location}: 'defaultExpression' must be a string")
+    if kind in ("setting", "virtual") and not isinstance(entry.get("restartRequired"), bool):
+        errors.append(f"{location}: 'restartRequired' must be boolean")
+    if kind == "setting" and not isinstance(entry.get("visible"), bool):
+        errors.append(f"{location}: 'visible' must be boolean")
+    if kind == "virtual" and entry.get("type") != "enum" and not isinstance(entry.get("visible"), bool):
+        errors.append(f"{location}: 'visible' must be boolean")
+    if kind == "page" and not isinstance(entry.get("visible"), bool):
+        errors.append(f"{location}: 'visible' must be boolean")
+    if kind == "page":
+        require_string(entry, "target", location, errors)
+
+    if kind != "page":
+        if "options" in entry:
+            validate_options(entry["options"], location, errors)
+        else:
+            errors.append(f"{location}: missing required field 'options'")
+
+
+def validate_catalog(catalog: dict, qml_text: str) -> tuple[list[str], set[str]]:
+    errors: list[str] = []
+
+    if catalog.get("schemaVersion") != 1:
+        errors.append("top level: 'schemaVersion' must be 1")
+    if catalog.get("format") != EXPECTED_FORMAT:
+        errors.append(f"top level: 'format' must be {EXPECTED_FORMAT!r}")
+
+    hierarchy = catalog.get("legacyHierarchy")
+    if not isinstance(hierarchy, dict):
+        errors.append("top level: 'legacyHierarchy' must be an object")
+    else:
+        for field in ("nodes", "settingNodeByKey", "virtualNodeByKey", "pageNodeByKey"):
+            expected_type = list if field == "nodes" else dict
+            if not isinstance(hierarchy.get(field), expected_type):
+                errors.append(f"legacyHierarchy: '{field}' has the wrong type")
+
+    layout = catalog.get("legacyLayout")
+    if not isinstance(layout, dict):
+        errors.append("top level: 'legacyLayout' must be an object")
+    else:
+        for field in ("rootPages",):
+            if not isinstance(layout.get(field), list):
+                errors.append(f"legacyLayout: '{field}' has the wrong type")
+        for field in (
+            "sourceFileByKey",
+            "itemOrderByKey",
+            "pageOrderByKey",
+            "pageParentTargetByKey",
+            "pageNodeByKey",
+            "externalEntryOrderByKey",
+        ):
+            if not isinstance(layout.get(field), dict):
+                errors.append(f"legacyLayout: '{field}' has the wrong type")
+
+    for collection_name in ("settings", "virtualSettings", "pages"):
+        if not isinstance(catalog.get(collection_name), list):
+            errors.append(f"top level: '{collection_name}' must be an array")
+
+    settings = catalog.get("settings", [])
+    virtual_settings = catalog.get("virtualSettings", [])
+    pages = catalog.get("pages", [])
+    if not isinstance(settings, list) or not isinstance(virtual_settings, list) or not isinstance(pages, list):
+        return errors, set()
+
+    if catalog.get("settingCount") != len(settings):
+        errors.append(
+            f"top level: 'settingCount' is {catalog.get('settingCount')!r}, expected {len(settings)}"
+        )
+
+    all_keys: dict[str, str] = {}
+    for collection_name, entries, kind in (
+        ("settings", settings, "setting"),
+        ("virtualSettings", virtual_settings, "virtual"),
+        ("pages", pages, "page"),
+    ):
+        for index, entry in enumerate(entries):
+            location = f"{collection_name}[{index}]"
+            validate_entry(entry, location, kind, errors)
+            if isinstance(entry, dict) and isinstance(entry.get("key"), str):
+                key = entry["key"]
+                if key in all_keys:
+                    errors.append(f"{location}: duplicate key {key!r}; already used by {all_keys[key]}")
+                else:
+                    all_keys[key] = location
+
+    try:
+        qml_keys = set(settings_properties(qml_text))
+    except RuntimeError as exc:
+        errors.append(str(exc))
+        return errors, {entry.get("key") for entry in settings if isinstance(entry, dict)}
+
+    catalog_keys = {entry.get("key") for entry in settings if isinstance(entry, dict)}
+    missing_from_catalog = sorted(qml_keys - catalog_keys)
+    missing_from_qml = sorted(catalog_keys - qml_keys)
+    if missing_from_catalog:
+        errors.append("settings.qml properties missing from catalog: " + ", ".join(missing_from_catalog))
+    if missing_from_qml:
+        errors.append("catalog settings missing from settings.qml: " + ", ".join(missing_from_qml))
+
+    return errors, catalog_keys
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <base-git-ref>", file=sys.stderr)
+        return 2
+
+    base_ref = sys.argv[1]
+    current_catalog_text = CATALOG_PATH.read_text(encoding="utf-8")
+    current_catalog = load_json(current_catalog_text, CATALOG_PATH.as_posix())
+    current_qml_text = SETTINGS_PATH.read_text(encoding="utf-8")
+    errors, current_keys = validate_catalog(current_catalog, current_qml_text)
+
+    base_catalog = load_json(read_git_file(base_ref, CATALOG_PATH), f"{base_ref}:{CATALOG_PATH}")
+    base_settings = base_catalog.get("settings", [])
+    base_keys = {entry.get("key") for entry in base_settings if isinstance(entry, dict)}
+    new_keys = sorted(current_keys - base_keys)
+
+    if current_catalog_text == read_git_file(base_ref, CATALOG_PATH):
+        print("OK: src/settings-catalog.json is unchanged in this PR.")
+    else:
+        print(f"Catalog changed: {len(new_keys)} new setting(s).")
+        for key in new_keys:
+            print(f"  + {key}")
+
+    if errors:
+        print("ERROR: settings catalog validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+
+    print(f"OK: validated {len(current_catalog['settings'])} persistent settings, "
+          f"{len(current_catalog['virtualSettings'])} virtual settings, and "
+          f"{len(current_catalog['pages'])} pages.")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except (OSError, RuntimeError, KeyError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(2)

--- a/tools/check_settings_catalog.py
+++ b/tools/check_settings_catalog.py
@@ -218,9 +218,17 @@ def validate_catalog(catalog: dict, qml_text: str) -> tuple[list[str], set[str]]
         qml_keys = set(settings_properties(qml_text))
     except RuntimeError as exc:
         errors.append(str(exc))
-        return errors, {entry.get("key") for entry in settings if isinstance(entry, dict)}
+        return errors, {
+            entry["key"]
+            for entry in settings
+            if isinstance(entry, dict) and isinstance(entry.get("key"), str)
+        }
 
-    catalog_keys = {entry.get("key") for entry in settings if isinstance(entry, dict)}
+    catalog_keys = {
+        entry["key"]
+        for entry in settings
+        if isinstance(entry, dict) and isinstance(entry.get("key"), str)
+    }
     missing_from_catalog = sorted(qml_keys - catalog_keys)
     missing_from_qml = sorted(catalog_keys - qml_keys)
     if missing_from_catalog:
@@ -244,7 +252,11 @@ def main() -> int:
 
     base_catalog = load_json(read_git_file(base_ref, CATALOG_PATH), f"{base_ref}:{CATALOG_PATH}")
     base_settings = base_catalog.get("settings", [])
-    base_keys = {entry.get("key") for entry in base_settings if isinstance(entry, dict)}
+    base_keys = {
+        entry["key"]
+        for entry in base_settings
+        if isinstance(entry, dict) and isinstance(entry.get("key"), str)
+    }
     new_keys = sorted(current_keys - base_keys)
 
     if current_catalog_text == read_git_file(base_ref, CATALOG_PATH):


### PR DESCRIPTION
## Reference

This change prepares the settings catalog for the new Settings UI refactor. The catalog format remains backward-compatible with the current settings UI.

## Changes

- Update the catalog to include the current 1001 settings.
- Add the legacy hierarchy and layout metadata required by the new Settings UI.
- Add restart metadata and normalized enum values/labels.
- Keep the change limited to src/settings-catalog.json.

## Testing

- Parsed src/settings-catalog.json successfully.
- Verified all catalog setting keys already exist in the master settings.qml.
- Verified the current settings UI only consumes settings, virtualSettings, and pages, so the added metadata is ignored until the new UI is merged.