### PR TITLE
Fix rower Target Resistance jumps when FTMS telemetry changes

### DIFF
--- a/src/devices/rower.cpp
+++ b/src/devices/rower.cpp
@@ -12,7 +12,18 @@ void rower::changeSpeed(double speed) {
         requestSpeed = speed;
 }
 void rower::changeResistance(resistance_t resistance) {
+    // Target Resistance changes the difficulty multiplier and then feeds the current
+    // hardware resistance back into this method. If telemetry changes at the same
+    // time, keep the previous raw request as the stable base instead of multiplying
+    // the new telemetry value by the new difficulty.
+    if (lastRawRequestedResistanceValue != -1 &&
+        lastRawRequestedResistanceDifficult != m_difficult &&
+        resistance == currentResistance().value()) {
+        resistance = lastRawRequestedResistanceValue;
+    }
+
     lastRawRequestedResistanceValue = resistance;
+    lastRawRequestedResistanceDifficult = m_difficult;
     if (autoResistanceEnable) {
         requestResistance = (resistance * m_difficult) + gears();;
         emit resistanceChanged(requestResistance);

--- a/src/devices/rower.h
+++ b/src/devices/rower.h
@@ -69,6 +69,7 @@ class rower : public bluetoothdevice {
     double CrankRevs = 0;
     double m_gears = 0;
     resistance_t lastRawRequestedResistanceValue = -1;
+    double lastRawRequestedResistanceDifficult = 1.0;
 
     metric m_pelotonResistance;
 

--- a/tst/Devices/TestRowerTargetResistance.cpp
+++ b/tst/Devices/TestRowerTargetResistance.cpp
@@ -1,0 +1,52 @@
+#include <gtest/gtest.h>
+
+#include "devices/rower.h"
+
+class RowerTargetResistanceTestDevice : public rower {
+  public:
+    void setReportedResistance(resistance_t resistance) { Resistance = resistance; }
+};
+
+TEST(RowerTargetResistanceRegressionTest, JorotoTelemetryChangesDoNotReplaceRawResistanceBase) {
+    RowerTargetResistanceTestDevice device;
+    device.setAutoResistance(false);
+
+    // Reproduce the JOROTO MR40 support case: the rower reports resistance 1,
+    // then flips to 2 while Target Resistance is increasing the difficulty gain.
+    device.setDifficult(1.0);
+    device.setReportedResistance(1);
+    device.changeResistance(device.currentResistance().value());
+    EXPECT_DOUBLE_EQ(device.lastRequestedResistance().value(), 1.0);
+
+    device.setReportedResistance(2);
+    device.setDifficult(2.0);
+    device.changeResistance(device.currentResistance().value());
+
+    // Keep raw resistance 1 as the base: 1 * 2.0 == 2. The old behavior
+    // replaced the base with telemetry 2 and jumped to 2 * 2.0 == 4.
+    EXPECT_DOUBLE_EQ(device.lastRequestedResistance().value(), 2.0);
+
+    device.setDifficult(3.0);
+    device.changeResistance(device.currentResistance().value());
+    EXPECT_DOUBLE_EQ(device.lastRequestedResistance().value(), 3.0);
+}
+
+TEST(RowerTargetResistanceRegressionTest, ExplicitResistanceRequestStillReplacesRawBase) {
+    RowerTargetResistanceTestDevice device;
+    device.setAutoResistance(false);
+
+    device.setDifficult(2.0);
+    device.setReportedResistance(1);
+    device.changeResistance(1);
+    EXPECT_DOUBLE_EQ(device.lastRequestedResistance().value(), 2.0);
+
+    // With unchanged difficulty this is a real new raw request, not a Target
+    // Resistance multiplier reapplication.
+    device.changeResistance(3);
+    EXPECT_DOUBLE_EQ(device.lastRequestedResistance().value(), 6.0);
+
+    device.setReportedResistance(1);
+    device.setDifficult(3.0);
+    device.changeResistance(device.currentResistance().value());
+    EXPECT_DOUBLE_EQ(device.lastRequestedResistance().value(), 9.0);
+}

--- a/tst/qdomyos-zwift-tests.pro
+++ b/tst/qdomyos-zwift-tests.pro
@@ -35,6 +35,7 @@ SOURCES += \
         Devices/TestRenphoBikeKnobGears.cpp \
         Devices/TestNordictrackEllipticalS700Parser.cpp \
         Devices/TestXcxBikeParser.cpp \
+        Devices/TestRowerTargetResistance.cpp \
         main.cpp
 
 # Avoid the "File too big" error building in Windows. This has happened when a template class is used with Google Test / typed tests


### PR DESCRIPTION
## Reference

User support case with a **JOROTO MR40** (`JOROTO-RW-003417`) on a recent TestFlight build.

The debug log showed the rower reporting FTMS resistance values that alternate between `1` and `2` while the user holds the **Target Resistance** `+` / `-` controls. At the same time the Target Resistance tile changes QZ's `difficult` multiplier.

This exposed a long-standing feedback problem in the rower resistance path: after changing `difficult`, HomeForm calls `rower::changeResistance(currentResistance())`. If the rower's live resistance telemetry changes between button events, that fresh telemetry value becomes the new raw base and is multiplied by the already-increased difficulty.

Example from the support case:

- raw/current resistance `1`, difficulty around `5.7` -> target around `5-6`
- telemetry changes to `2`
- the next Target Resistance event uses `2` as a new base -> target jumps to around `11`

The jumps therefore look random in the UI but are deterministic feedback from live telemetry.

## Fix

Keep track of the difficulty value associated with the last raw rower resistance request.

When `changeResistance()` is called after the difficulty multiplier changed **and** the supplied resistance is just the current hardware telemetry value, treat the call as a difficulty reapplication rather than a new raw resistance request. In that case the previous raw request remains the stable base.

Normal explicit resistance requests still replace the raw base when the difficulty value has not changed.

This keeps the fix local to `rower` and leaves bike/elliptical behavior untouched.

## Regression coverage

Added `TestRowerTargetResistance.cpp` with the JOROTO failure mode:

1. reported resistance starts at `1`
2. raw resistance base is seeded at `1`
3. reported resistance changes to `2`
4. difficulty changes from `1.0` to `2.0`
5. reapplying Target Resistance must produce `1 * 2.0 = 2`, not `2 * 2.0 = 4`
6. another difficulty change continues from the same raw base

A second test verifies that a real explicit resistance request still becomes the new raw base.

## Scope

- Rower base resistance logic only
- No FTMS protocol changes
- No changes to bike or elliptical Target Resistance behavior
- No attempt here to change the separate JOROTO behavior where FTMS Set Target Resistance is answered with `Op Code Not Supported`

The latter is a different issue from the incorrect Target Resistance value shown/calculated by QZ and can be handled separately if needed.