### PR TITLE
docs: add MyWhoosh cadence sensor setup FAQ

### DIFF
--- a/docs/faq/integrations.md
+++ b/docs/faq/integrations.md
@@ -20,6 +20,21 @@ In this setup the watch does not need to be paired to QZ as an ANT+ sensor. Conf
 
 Choose **ANT+ SDM/footpod** when you want the watch itself to see and record the treadmill speed/distance during the workout. Choose **Garmin Connect FIT upload** when your main goal is simply to have the finished activity and its metrics in Garmin Connect.
 
+## Can I use a basic indoor bike with a Bluetooth cadence sensor in MyWhoosh through QZ?
+
+Yes. QZ can use a compatible Bluetooth cadence sensor as the bike data source and expose a virtual bike/trainer that MyWhoosh can connect to.
+
+1. Open **QZ Settings > Accessories** and select the Bluetooth sensor under **Cadence sensor**, then confirm the selection.
+2. Enable the option that uses the **cadence sensor as a bike**.
+3. Confirm that cadence is updating in QZ before opening MyWhoosh.
+4. Run MyWhoosh on a separate device and pair the virtual QZ trainer.
+
+When MyWhoosh lists the virtual QZ devices, select **Wahoo KICK 0000** as the **Power Source**. If MyWhoosh also shows a separate **Controllable/Trainer** field, select **Wahoo KICK 0000** there as well.
+
+**Wahoo HRM** is only QZ's virtual heart-rate device, so select it only in MyWhoosh's heart-rate field if you also want QZ to forward heart rate.
+
+In a confirmed support case, selecting the external cadence sensor in QZ restored cadence immediately; the `cadence_sensor_as_bike` setting is also part of QZ's current device-discovery configuration.
+
 ## Peloton login from QZ stays on a spinning screen on an Echelon console. What should I try?
 
 On some Echelon consoles, the built-in **Lightning** browser may no longer complete the Peloton authentication flow correctly. QZ can appear to remain on the spinning login screen even though the problem is actually the browser on the console.


### PR DESCRIPTION
## Summary

- document how to use a Bluetooth cadence sensor as the bike source in QZ for a basic/dumb indoor bike
- explain that `cadence_sensor_as_bike` must be enabled so QZ treats the cadence sensor as the primary bike source
- clarify MyWhoosh pairing: select `Wahoo KICK 0000` for Power Source and Controllable/Trainer when available, while `Wahoo HRM` is only for heart rate

## Source

Reusable QZ support guidance from 2026-09-02. The external cadence-sensor selection was explicitly confirmed working by the user, and the `cadence_sensor_as_bike` behavior was verified against the current QZ settings/device-discovery code.

The separate Android short-device-name workaround from the same day's support was not duplicated because it is already documented in `docs/qz_faq_public.md`.

## Images

No screenshots are required for this entry.