### PR TITLE
fix: normalize ZBike2.0 FTMS resistance

### DIFF
--- a/src/devices/ftmsbike/ftmsbike.cpp
+++ b/src/devices/ftmsbike/ftmsbike.cpp
@@ -10,6 +10,7 @@
 #include <QMetaEnum>
 #include <QSettings>
 #include <QThread>
+#include <QtMath>
 #include <math.h>
 #ifdef Q_OS_ANDROID
 #include <QLowEnergyConnectionParameters>
@@ -201,6 +202,26 @@ void ftmsbike::init() {
 }
 
 ftmsbike::~ftmsbike() {
+}
+
+resistance_t ftmsbike::normalizedResistanceForDevice(const QString &deviceName, double rawResistance) {
+    if (deviceName != QStringLiteral("ZBike2.0")) {
+        return static_cast<resistance_t>(rawResistance);
+    }
+
+    if (!std::isfinite(rawResistance)) {
+        return 0;
+    }
+
+    return qBound<resistance_t>(0, qRound((rawResistance - 50.0) / 10.0), 15);
+}
+
+resistance_t ftmsbike::rawResistanceForDevice(const QString &deviceName, resistance_t displayedResistance) {
+    if (deviceName != QStringLiteral("ZBike2.0") || displayedResistance < 0) {
+        return displayedResistance;
+    }
+
+    return qBound<resistance_t>(50, displayedResistance * 10 + 50, 200);
 }
 
 void ftmsbike::zwiftPlayInit() {
@@ -483,7 +504,7 @@ void ftmsbike::update() {
             powerForced = false;
             requestPower = -1;
             init();
-            forceResistance(currentResistance().value());
+            forceResistance(rawResistanceForDevice(bluetoothDevice.name(), currentResistance().value()));
         }
 
         auto virtualBike = this->VirtualBike();        
@@ -960,7 +981,7 @@ void ftmsbike::characteristicChanged(const QLowEnergyCharacteristic &characteris
                     d = d / 10.0;
                 // for this bike, i will use the resistance that I set directly because the bike sends a different ratio.
                 if(!SL010 && !TITAN_7000 && !SPORT01 && !TOPUTURE_TEB5 && !FS_YK && !SMARTBIKE_3DIGIT) {
-                    Resistance = d;
+                    Resistance = normalizedResistanceForDevice(bluetoothDevice.name(), d);
                     native_resistance_received = true;
                     calculatedResistanceFallbackSince = QDateTime();
                 }
@@ -1620,7 +1641,9 @@ void ftmsbike::characteristicChanged(const QLowEnergyCharacteristic &characteris
         if (gears() != 0) {
             gears_modified_inclination += (gearsModifier() * GEARS_SLOPE_MULTIPLIER / 100.0);
         }
-        _inclinationResistanceTable.collectData(gears_modified_inclination, Resistance.value(), m_watt.value());
+        _inclinationResistanceTable.collectData(gears_modified_inclination,
+                                                rawResistanceForDevice(bluetoothDevice.name(), Resistance.value()),
+                                                m_watt.value());
     }
 
 #ifdef Q_OS_IOS

--- a/src/devices/ftmsbike/ftmsbike.h
+++ b/src/devices/ftmsbike/ftmsbike.h
@@ -81,6 +81,8 @@ class ftmsbike : public bike {
     double maxGears() override;
     double minGears() override;
     void enableManualResistancePowerAdjustment(resistance_t resistance);
+    static resistance_t normalizedResistanceForDevice(const QString &deviceName, double rawResistance);
+    static resistance_t rawResistanceForDevice(const QString &deviceName, resistance_t displayedResistance);
 
     // Most FTMS bikes can use QZ's software ERG emulation, but FS-YK devices
     // should stay on direct resistance control because it doesn't send the current resistance value and it conflicts

--- a/tst/Devices/TestFtmsBikeResistance.cpp
+++ b/tst/Devices/TestFtmsBikeResistance.cpp
@@ -1,0 +1,1 @@
+#include "TestFtmsBikeResistance.h"

--- a/tst/Devices/TestFtmsBikeResistance.h
+++ b/tst/Devices/TestFtmsBikeResistance.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <gtest/gtest.h>
+#include <QString>
+
+#include "devices/ftmsbike/ftmsbike.h"
+
+TEST(FtmsBikeResistanceTest, NormalizesOnlyExactZBike20Name) {
+    EXPECT_EQ(ftmsbike::normalizedResistanceForDevice(QStringLiteral("ZBike2.0"), 50), 0);
+    EXPECT_EQ(ftmsbike::normalizedResistanceForDevice(QStringLiteral("ZBike2.0"), 60), 1);
+    EXPECT_EQ(ftmsbike::normalizedResistanceForDevice(QStringLiteral("ZBike2.0"), 70), 2);
+    EXPECT_EQ(ftmsbike::normalizedResistanceForDevice(QStringLiteral("ZBike2.0"), 100), 5);
+    EXPECT_EQ(ftmsbike::normalizedResistanceForDevice(QStringLiteral("ZBike2.0"), 110), 6);
+    EXPECT_EQ(ftmsbike::normalizedResistanceForDevice(QStringLiteral("ZBike2.0"), 120), 7);
+    EXPECT_EQ(ftmsbike::normalizedResistanceForDevice(QStringLiteral("ZBike2.0"), 200), 15);
+}
+
+TEST(FtmsBikeResistanceTest, RoundsAndClampsZBike20Resistance) {
+    EXPECT_EQ(ftmsbike::normalizedResistanceForDevice(QStringLiteral("ZBike2.0"), 98), 5);
+    EXPECT_EQ(ftmsbike::normalizedResistanceForDevice(QStringLiteral("ZBike2.0"), 99), 5);
+    EXPECT_EQ(ftmsbike::normalizedResistanceForDevice(QStringLiteral("ZBike2.0"), 101), 5);
+    EXPECT_EQ(ftmsbike::normalizedResistanceForDevice(QStringLiteral("ZBike2.0"), 102), 5);
+    EXPECT_EQ(ftmsbike::normalizedResistanceForDevice(QStringLiteral("ZBike2.0"), 0), 0);
+    EXPECT_EQ(ftmsbike::normalizedResistanceForDevice(QStringLiteral("ZBike2.0"), 999), 15);
+}
+
+TEST(FtmsBikeResistanceTest, KeepsRawResistanceForOtherFtmsDeviceNames) {
+    EXPECT_EQ(ftmsbike::normalizedResistanceForDevice(QStringLiteral("ZBike2.0 Pro"), 100), 100);
+    EXPECT_EQ(ftmsbike::normalizedResistanceForDevice(QStringLiteral("Other FTMS Bike"), 100), 100);
+}
+
+TEST(FtmsBikeResistanceTest, ConvertsDisplayedZBike20ResistanceBackToRawOnlyWhenNeeded) {
+    EXPECT_EQ(ftmsbike::rawResistanceForDevice(QStringLiteral("ZBike2.0"), 0), 50);
+    EXPECT_EQ(ftmsbike::rawResistanceForDevice(QStringLiteral("ZBike2.0"), 5), 100);
+    EXPECT_EQ(ftmsbike::rawResistanceForDevice(QStringLiteral("ZBike2.0"), 15), 200);
+    EXPECT_EQ(ftmsbike::rawResistanceForDevice(QStringLiteral("ZBike2.0"), -1), -1);
+    EXPECT_EQ(ftmsbike::rawResistanceForDevice(QStringLiteral("ZBike2.0 Pro"), 5), 5);
+}

--- a/tst/qdomyos-zwift-tests.pro
+++ b/tst/qdomyos-zwift-tests.pro
@@ -31,6 +31,7 @@ SOURCES += \
         Devices/TestSchwinn411510EParser.cpp \
         Devices/TestZwiftRideController.cpp \
         Devices/TestApexBikeParser.cpp \
+        Devices/TestFtmsBikeResistance.cpp \
         Devices/TestKeepBikeParser.cpp \
         Devices/TestRenphoBikeKnobGears.cpp \
         Devices/TestNordictrackEllipticalS700Parser.cpp \
@@ -65,6 +66,7 @@ HEADERS += \
     Devices/devicetestdataindex.h \
     Devices/TestSchwinn411510EParser.h \
     Devices/TestApexBikeParser.h \
+    Devices/TestFtmsBikeResistance.h \
     Devices/TestKeepBikeParser.h \
     Devices/TestRenphoBikeKnobGears.h \
     Devices/TestNordictrackEllipticalS700Parser.h \


### PR DESCRIPTION
## Summary
- Normalize the FTMS resistance reported by the exact Bluetooth device name `ZBike2.0` from raw values 50..200 to user-facing levels 0..15.
- Preserve unchanged resistance behavior for all other FTMS device names.
- Convert the normalized current value back to raw FTMS units only where the existing code reuses current resistance as a physical value.
- Add focused conversion tests.

## Reference
Carlos Alberto

## Test status
- `git diff --check` passed.
- Full qmake/make verification was attempted with `-j1` but interrupted because the build exceeded the available execution window; no passing build/test result is claimed.

No requestResistance == -1 behavior change is included in this PR.