### PR TITLE
feat: map ProForm physical resistance to virtual gears

### DIFF
--- a/src/devices/nordictrackifitadbbike/nordictrackifitadbbike.cpp
+++ b/src/devices/nordictrackifitadbbike/nordictrackifitadbbike.cpp
@@ -256,6 +256,13 @@ nordictrackifitadbbike::nordictrackifitadbbike(bool noWriteResistance, bool noHe
     }
 }
 
+int nordictrackifitadbbike::physicalResistanceGearDelta(resistance_t previous, resistance_t current) {
+    if (previous <= 0 || current <= 0)
+        return 0;
+    const int delta = current - previous;
+    return qAbs(delta) <= 5 ? delta : 0;
+}
+
 bool nordictrackifitadbbike::inclinationAvailableByHardware() { 
     QSettings settings;
     bool proform_studio_NTEX71021 =
@@ -741,6 +748,20 @@ void nordictrackifitadbbike::update() {
         }
         
         if (currentResistance != Resistance.value()) {
+            const bool gearsFromBike =
+                settings.value(QZSettings::gears_from_bike, QZSettings::default_gears_from_bike).toBool();
+            const bool gearResistanceMode = settings.value(
+                QZSettings::nordictrackadbbike_gear_resistance_mode,
+                QZSettings::default_nordictrackadbbike_gear_resistance_mode).toBool();
+            if (gearsFromBike && !gearResistanceMode && requestResistance == -1) {
+                const int delta = bike::physicalResistanceGearDelta(lastDeviceResistance, currentResistance);
+                if (delta != 0) {
+                    lastRawRequestedResistanceValue = -1;
+                    setGears(gears() + delta);
+                    qDebug() << "Physical resistance change applied to gears:" << delta << "new gears:" << gears();
+                }
+            }
+            lastDeviceResistance = currentResistance;
             Resistance = currentResistance;
             emit debug(QString("gRPC Resistance: %1").arg(currentResistance));
         }
@@ -789,6 +810,7 @@ void nordictrackifitadbbike::update() {
         }
         
         if(requestResistance != - 1) {
+            lastDeviceResistance = requestResistance;
             setGrpcResistance(requestResistance);
             requestResistance = -1;
         } else if (lastGearValue != gears()) {

--- a/src/devices/nordictrackifitadbbike/nordictrackifitadbbike.cpp
+++ b/src/devices/nordictrackifitadbbike/nordictrackifitadbbike.cpp
@@ -754,7 +754,7 @@ void nordictrackifitadbbike::update() {
                 QZSettings::nordictrackadbbike_gear_resistance_mode,
                 QZSettings::default_nordictrackadbbike_gear_resistance_mode).toBool();
             if (gearsFromBike && !gearResistanceMode && requestResistance == -1) {
-                const int delta = bike::physicalResistanceGearDelta(lastDeviceResistance, currentResistance);
+                const int delta = physicalResistanceGearDelta(lastDeviceResistance, currentResistance);
                 if (delta != 0) {
                     lastRawRequestedResistanceValue = -1;
                     setGears(gears() + delta);

--- a/src/devices/nordictrackifitadbbike/nordictrackifitadbbike.h
+++ b/src/devices/nordictrackifitadbbike/nordictrackifitadbbike.h
@@ -77,6 +77,7 @@ class nordictrackifitadbbike : public bike {
     bool ifitCompatible() override;
     void changePower(int32_t power) override;
     bool changeFanSpeed(uint8_t speed) override;
+    static int physicalResistanceGearDelta(resistance_t previous, resistance_t current);
 
   private:
     const resistance_t max_resistance = 20; // max inclination for s22i
@@ -127,6 +128,7 @@ class nordictrackifitadbbike : public bike {
 
     bool gearsAvailable = false;
     double lastGearValue = 0;
+    resistance_t lastDeviceResistance = -1;
     
     // Gear change debouncing
     QTimer *gearDebounceTimer = nullptr;

--- a/tst/Devices/TestPhysicalResistanceGears.cpp
+++ b/tst/Devices/TestPhysicalResistanceGears.cpp
@@ -1,0 +1,1 @@
+#include "TestPhysicalResistanceGears.h"

--- a/tst/Devices/TestPhysicalResistanceGears.h
+++ b/tst/Devices/TestPhysicalResistanceGears.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include "devices/nordictrackifitadbbike/nordictrackifitadbbike.h"
+
+class PhysicalResistanceGearsTestAccess : public nordictrackifitadbbike {
+  public:
+    using nordictrackifitadbbike::physicalResistanceGearDelta;
+};
+
+TEST(PhysicalResistanceGearsTest, IgnoresMissingOrInitialResistance) {
+    EXPECT_EQ(PhysicalResistanceGearsTestAccess::physicalResistanceGearDelta(0, 5), 0);
+    EXPECT_EQ(PhysicalResistanceGearsTestAccess::physicalResistanceGearDelta(5, 0), 0);
+    EXPECT_EQ(PhysicalResistanceGearsTestAccess::physicalResistanceGearDelta(-1, 5), 0);
+}
+
+TEST(PhysicalResistanceGearsTest, AcceptsSmallPositiveAndNegativeChanges) {
+    EXPECT_EQ(PhysicalResistanceGearsTestAccess::physicalResistanceGearDelta(5, 7), 2);
+    EXPECT_EQ(PhysicalResistanceGearsTestAccess::physicalResistanceGearDelta(7, 5), -2);
+    EXPECT_EQ(PhysicalResistanceGearsTestAccess::physicalResistanceGearDelta(5, 10), 5);
+    EXPECT_EQ(PhysicalResistanceGearsTestAccess::physicalResistanceGearDelta(10, 5), -5);
+}
+
+TEST(PhysicalResistanceGearsTest, RapidSuccessiveChangesAccumulateOneStepAtATime) {
+    const int firstDelta = PhysicalResistanceGearsTestAccess::physicalResistanceGearDelta(5, 6);
+    const int secondDelta = PhysicalResistanceGearsTestAccess::physicalResistanceGearDelta(6, 7);
+
+    EXPECT_EQ(firstDelta + secondDelta, 2);
+}
+
+TEST(PhysicalResistanceGearsTest, GearOffsetRaisesLaterNominalResistanceTarget) {
+    const int gearOffset = PhysicalResistanceGearsTestAccess::physicalResistanceGearDelta(5, 7);
+
+    EXPECT_EQ(5 + gearOffset, 7);
+}
+
+TEST(PhysicalResistanceGearsTest, RejectsLargeJumpAsResynchronization) {
+    EXPECT_EQ(PhysicalResistanceGearsTestAccess::physicalResistanceGearDelta(5, 12), 0);
+    EXPECT_EQ(PhysicalResistanceGearsTestAccess::physicalResistanceGearDelta(12, 5), 0);
+}

--- a/tst/qdomyos-zwift-tests.pro
+++ b/tst/qdomyos-zwift-tests.pro
@@ -31,6 +31,7 @@ SOURCES += \
         Devices/TestSchwinn411510EParser.cpp \
         Devices/TestApexBikeParser.cpp \
         Devices/TestKeepBikeParser.cpp \
+        Devices/TestPhysicalResistanceGears.cpp \
         main.cpp
 
 # Avoid the "File too big" error building in Windows. This has happened when a template class is used with Google Test / typed tests
@@ -62,6 +63,7 @@ HEADERS += \
     Devices/TestSchwinn411510EParser.h \
     Devices/TestApexBikeParser.h \
     Devices/TestKeepBikeParser.h \
+    Devices/TestPhysicalResistanceGears.h \
     Devices/TestOctaneTreadmillZR8.h \
     Devices/TestSunnyfitStepper.h \
     Erg/ergtabletestsuite.h \


### PR DESCRIPTION
## Summary
- Reuse `gears_from_bike` for the NordicTrack/ProForm gRPC bike path.
- Treat small externally observed resistance changes as virtual gear deltas.
- Preserve the resulting offset for later inclination/resistance requests.
- Avoid replaying the previous QZ resistance request when applying a physical delta.

## Behavior
With `gears_from_bike` enabled, a device-reported change such as `5 -> 7` becomes a `+2` virtual gear adjustment. A later nominal target of `5` is therefore combined with the current gear offset and produces `7`.

- Initial/invalid samples do not change gears.
- Consecutive small changes accumulate one step at a time.
- Jumps larger than five resistance levels are treated as resynchronization samples.
- No compensating physical resistance write is issued by the reconciliation path.
- Existing inclination handling continues to apply the current gear value.

## Reference
Support request from Mathieu Bastin (`mi_bastin@jmweston.fr`) about ProForm TDF 10.0 physical resistance controls being exposed as virtual gear changes in MyWhoosh.

## Test plan
- [x] Build QZ library with `make -j1` on the gRPC worktree.
- [x] Build the test runner with `make -j1`.
- [x] Run `PhysicalResistanceGearsTest.*`: 5 passed.
- [x] Run the complete local test runner: exit code 0.
- [x] `git diff --check`.

## Scope
This PR targets the `nordictrack-build-grpc` branch and is intentionally based on that branch rather than `master`.
