### PR TITLE
fix: limit LifeSmart TM55 discovery to FTMS

### DIFF
--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -1682,6 +1682,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                         b.name().toUpper().startsWith(QStringLiteral("T118_")) ||
                         b.name().toUpper().startsWith(QStringLiteral("TM4500")) ||
                         b.name().toUpper().startsWith(QStringLiteral("TM6500")) ||
+                        b.name().toUpper().startsWith(QStringLiteral("TM55-")) || // LifeSmart TM55
                         b.name().toUpper().startsWith(QStringLiteral("RUNN ")) ||
                         b.name().toUpper().startsWith(QStringLiteral("YS_T")) ||
                         b.name().toUpper().startsWith(QStringLiteral("YPOO-MINI PRO-")) ||

--- a/src/devices/horizontreadmill/horizontreadmill.cpp
+++ b/src/devices/horizontreadmill/horizontreadmill.cpp
@@ -2621,6 +2621,10 @@ void horizontreadmill::serviceScanDone(void) {
                 qDebug() << s << "skipping (DOMYOS-TC will use only FTMS)";
                 continue;
             }
+            if (TM55_TREADMILL && s != _FTMSServiceId) {
+                qDebug() << s << "skipping (TM55 treadmill will use only FTMS 0x1826)";
+                continue;
+            }
 
             qDebug() << s << "discovering...";
             gattCommunicationChannelService.append(m_control->createServiceObject(s));
@@ -2767,6 +2771,9 @@ void horizontreadmill::deviceDiscovered(const QBluetoothDeviceInfo &device) {
             qDebug() << QStringLiteral("TM6500 treadmill found");
             TM6500 = true;
             minInclination = -3.0;
+        } else if (device.name().toUpper().startsWith(QStringLiteral("TM55-"))) {
+            qDebug() << QStringLiteral("TM55 treadmill found; will use only FTMS service (0x1826)");
+            TM55_TREADMILL = true;
         } else if (device.name().toUpper().startsWith(QStringLiteral("MRK-T"))) {
             qDebug() << QStringLiteral("MERACH treadmill workaround ON!");
             MERACH_TREADMILL = true;

--- a/src/devices/horizontreadmill/horizontreadmill.h
+++ b/src/devices/horizontreadmill/horizontreadmill.h
@@ -127,6 +127,7 @@ class horizontreadmill : public treadmill {
     bool TM4800 = false;
     bool TM4500 = false;
     bool TM6500 = false;
+    bool TM55_TREADMILL = false;
     bool FS_TREADMILL = false;
     bool WT_TREADMILL = false;
     bool THERUN_T15 = false;

--- a/tst/Devices/devicetestdataindex.cpp
+++ b/tst/Devices/devicetestdataindex.cpp
@@ -692,7 +692,7 @@ void DeviceTestDataIndex::Initialize() {
             // FTMS
             {"T318_", "T218_", "TRX3500", "JFTMPARAGON", "PARAGON X", "JFTM", "CT800",
              "MOBVOI TM", "DK202000725", "CTM780102C6BB32D62", "MX-TM ", "MATRIXTF50", "MOBVOI TM",
-             "KETTLER TREADMILL", "ASSAULTRUNNER"}, DeviceNameComparison::StartsWithIgnoreCase);
+             "KETTLER TREADMILL", "ASSAULTRUNNER", "TM55-"}, DeviceNameComparison::StartsWithIgnoreCase);
 
 
     // Horizon Treadmill (Toorx)


### PR DESCRIPTION
## Summary
- Fixes the LifeSmart TM55- treadmill path from issue #5029.
- Restricts post-connection service detail discovery to FTMS `0x1826` for `TM55-` devices.
- Leaves the existing generic TM55 device routing unchanged and adds `TM55-` to the Horizon treadmill detection fixtures.

## Reference
Reference: #5029

Closes #5029

## Evidence
The issue logs identify the device as `TM55-2288` and show additional services alongside FTMS: `0x180A`, `0x180D`, `0x1826`, `0xAE00`, `0xAE30`, `0xAE3A`, `0xFFE0`, and `0xFFF0`.

## Test plan
- `git diff --check`
- qmake + `make -j1` for the main library: passed
- Horizon treadmill detection tests: 16 tests, 12 passed, 4 skipped as not applicable
- Full `qdomyos-zwift-tests`: 624 tests, 513 passed, 111 skipped, 0 failed

Real LifeSmart TM55 hardware validation is not available in this environment.