### PR TITLE
docs: add treadmill and Rouvy FAQ guidance

### DIFF
--- a/docs/faq/README.md
+++ b/docs/faq/README.md
@@ -6,6 +6,7 @@ This directory contains practical QZ frequently asked questions, organized by ca
 
 - [Bike and trainer troubleshooting](bike-troubleshooting.md)
 - [Integrations and authentication](integrations.md)
+- [Treadmill troubleshooting](treadmill-troubleshooting.md)
 - [Zwift and virtual gearing](zwift.md)
 
 More category files can be added when a reusable support case or capability question does not fit an existing category.

--- a/docs/faq/integrations.md
+++ b/docs/faq/integrations.md
@@ -35,6 +35,14 @@ When MyWhoosh lists the virtual QZ devices, select **Wahoo KICK 0000** as the **
 
 In a confirmed support case, selecting the external cadence sensor in QZ restored cadence immediately; the `cadence_sensor_as_bike` setting is also part of QZ's current device-discovery configuration.
 
+## Can I use QZ virtual gears with Rouvy?
+
+Yes. QZ can manage virtual gear changes while Rouvy controls the trainer through QZ. The current QZ gear is handled by QZ itself, so you should not expect Rouvy to display QZ's virtual gear number on its ride screen.
+
+If using the phone's volume buttons to shift is inconvenient, enable QZ's **volume buttons change gears** option and use a Bluetooth media/volume remote. QZ handles volume-up and volume-down key events as gear controls when this option is enabled, so a small handlebar-mounted Bluetooth remote that sends the same keys can be used for shifting.
+
+On Android, the system volume overlay may still briefly appear when those keys are pressed; that does not prevent QZ from using the key presses for gear changes.
+
 ## Peloton login from QZ stays on a spinning screen on an Echelon console. What should I try?
 
 On some Echelon consoles, the built-in **Lightning** browser may no longer complete the Peloton authentication flow correctly. QZ can appear to remain on the spinning login screen even though the problem is actually the browser on the console.

--- a/docs/faq/treadmill-troubleshooting.md
+++ b/docs/faq/treadmill-troubleshooting.md
@@ -1,0 +1,19 @@
+# Treadmill troubleshooting
+
+## QZ is connected to my treadmill, but the session or distance is not updating. What should I check?
+
+First check whether the QZ workout session itself is paused. If the **Play** button at the top of QZ is flashing, press it to resume/start the QZ session.
+
+The QZ Play button controls the QZ workout session; it does not necessarily start the treadmill belt. Depending on the treadmill, you may still need to press Start on the treadmill itself.
+
+If speed is updating but distance is still not behaving correctly, check **QZ Settings > Treadmill options > Treadmill Direct Distance**. Some treadmills do not provide a usable direct distance value. In that case, disable **Treadmill Direct Distance** so QZ calculates distance from speed over time instead.
+
+In a confirmed support case, the session/distance started working after correcting these settings. QZ's current treadmill implementation also calculates distance from speed when `Treadmill Direct Distance` is disabled.
+
+## Can Zwift automatically control both treadmill incline and speed through QZ?
+
+QZ can use the Zwift integration for **automatic inclination**. Configure your Zwift credentials in QZ and enable the Zwift auto-inclination option.
+
+Zwift does not provide QZ with a treadmill target speed in the same way, so Zwift cannot directly drive automatic treadmill speed through this integration.
+
+If you want automatic speed changes for a structured workout, recreate the workout in the **QZ workout editor** and run it from QZ. QZ can then control the treadmill speed according to the workout steps while the Zwift integration supplies the inclination information.


### PR DESCRIPTION
## Summary

- add a new treadmill troubleshooting FAQ category
- document the confirmed case where a paused QZ session and `Treadmill Direct Distance` configuration prevented correct treadmill session/distance behavior
- clarify that QZ's Play button controls the QZ workout session and may not start the treadmill belt itself
- document Zwift treadmill behavior: QZ can use Zwift for automatic inclination, while automatic speed should be driven from a QZ workout because Zwift does not provide the treadmill target speed
- document QZ virtual gearing with Rouvy, including that QZ's gear number is not displayed by Rouvy and that Bluetooth media/volume remotes can be used with QZ's volume-button gear control

## Source

Reusable QZ support cases and setup questions from 2026-09-03. Troubleshooting guidance was included only where the support thread confirmed the result; capability guidance was checked against the current QZ settings/code and existing documentation.

## Duplicate check

Checked `docs/faq/` and `docs/qz_faq_public.md`. The dumb-bike/cadence-sensor case from the same day was excluded because it is already covered by the existing MyWhoosh cadence-sensor FAQ. The standalone APK question was also excluded because nightly APK installation is already covered by the legacy FAQ.

## Images

No screenshots are required for these entries.