### PR TITLE
docs: add rowing and Stryd setup FAQs

### DIFF
--- a/docs/faq/README.md
+++ b/docs/faq/README.md
@@ -6,6 +6,7 @@ This directory contains practical QZ frequently asked questions, organized by ca
 
 - [Bike and trainer troubleshooting](bike-troubleshooting.md)
 - [Integrations and authentication](integrations.md)
+- [Rowing](rowing.md)
 - [Treadmill troubleshooting](treadmill-troubleshooting.md)
 - [Zwift and virtual gearing](zwift.md)
 

--- a/docs/faq/rowing.md
+++ b/docs/faq/rowing.md
@@ -1,0 +1,23 @@
+# Rowing
+
+## Can I use QZ as a virtual rower when my rowing machine cannot broadcast usable data?
+
+Yes. QZ can act as a virtual FTMS rower and provide generated rowing data to a training app such as Kinomap even when the original rowing machine cannot expose usable fitness data.
+
+For a basic setup:
+
+1. Enable QZ's virtual rower functionality.
+2. In the training app, pair QZ as an **FTMS rower**.
+3. For Kinomap, keep the **PM5** compatibility option disabled unless you are specifically using a Concept2/PM5 setup.
+4. Start with the speed and watt offsets set to **0**.
+5. Use the **Target Watt** tile on the QZ dashboard to change the generated effort. Changing the target watts changes the simulated rowing metrics sent by QZ.
+
+If Bluetooth discovery is unreliable with both apps on the same device, running QZ and the training app on separate devices can simplify the connection.
+
+This setup was explicitly confirmed working in a support case where the original rower could not provide usable data to the training app.
+
+## How can I show my rowing pace per 500 m in QZ?
+
+Open **QZ Settings > Tiles** and enable **Pace Last 500m**.
+
+The tile shows rowing pace as the time needed to cover 500 metres, the standard pace format commonly used for rowing.

--- a/docs/faq/treadmill-troubleshooting.md
+++ b/docs/faq/treadmill-troubleshooting.md
@@ -17,3 +17,17 @@ QZ can use the Zwift integration for **automatic inclination**. Configure your Z
 Zwift does not provide QZ with a treadmill target speed in the same way, so Zwift cannot directly drive automatic treadmill speed through this integration.
 
 If you want automatic speed changes for a structured workout, recreate the workout in the **QZ workout editor** and run it from QZ. QZ can then control the treadmill speed according to the workout steps while the Zwift integration supplies the inclination information.
+
+## Can I use a Stryd footpod with a non-smart treadmill and send the data to Zwift through QZ?
+
+Yes. If the treadmill itself has no FTMS or other usable fitness connection, QZ can connect directly to a **Stryd** sensor and use it as the treadmill data source, then expose the resulting treadmill data to Zwift.
+
+A Garmin Virtual Run or Garmin Companion bridge is not required for this setup.
+
+1. Pair the Stryd sensor directly with QZ.
+2. Configure the external power/running sensor to be used as the treadmill source in QZ.
+3. If the reported running speed needs calibration, use QZ's speed gain adjustment.
+4. When the treadmill does not report inclination, enter the treadmill incline manually in QZ.
+5. Pair Zwift with QZ as the treadmill source.
+
+QZ's current Stryd implementation supports using the external sensor as a treadmill source, including the `power_sensor_as_treadmill` configuration.


### PR DESCRIPTION
## Summary

- add a new `Rowing` FAQ category
- document using QZ as a virtual FTMS rower when the original rower cannot broadcast usable data, including Kinomap FTMS/PM5 guidance and the `Target Watt` tile
- document the `Pace Last 500m` tile for rowing pace
- document using a Stryd sensor directly with QZ as the treadmill source for a non-smart treadmill and forwarding the resulting treadmill data to Zwift

## Source

Support conversations from 2026-09-04. The virtual-rower procedure was explicitly confirmed working. The rowing pace and Stryd entries are reusable capability/setup guidance verified against the current QZ repository. Existing `docs/faq/` and `docs/qz_faq_public.md` were checked to avoid duplicate guidance.

Unresolved troubleshooting, code-fix-only cases, and guidance already documented elsewhere were intentionally excluded.

## Images

No screenshots are required for these entries.