### PR TITLE
Enable custom resistance power table for F-Bike Heavy Pro

### DIFF
--- a/src/devices/ftmsbike/ftmsbike.cpp
+++ b/src/devices/ftmsbike/ftmsbike.cpp
@@ -262,7 +262,8 @@ void ftmsbike::forcePower(int16_t requestPower) {
 }
 
 bool ftmsbike::isManualResistanceBike() const {
-    return SMARTBIKE_3DIGIT || TX_500MB_IRON;
+    return SMARTBIKE_3DIGIT || TX_500MB_IRON ||
+           bluetoothDevice.name().toUpper().startsWith(QStringLiteral("FBIKE-HEAVY-PRO"));
 }
 
 void ftmsbike::enableManualResistancePowerAdjustment(resistance_t resistance) {


### PR DESCRIPTION
## Summary

Treat `FBIKE-HEAVY-PRO` as an FTMS bike with manual resistance when the existing **Custom resistance power table** is enabled, and make QZ's Resistance +/- control work even while Zwift is connected to QZ's virtual FTMS trainer.

This lets the user use the QZ Resistance tile as a manual/virtual resistance level: changing the selected resistance changes the watts QZ exposes to virtual trainers such as Wahoo KICKR 0000, with the existing cadence scaling applied by the custom table.

The custom table remains opt-in, so the normal F-Bike watt/resistance path is unchanged unless the user enables that setting.

## Root cause / Issue #5094

The debug log from #5094 showed that:

- QZ was receiving the Resistance +/- actions and producing `writing resistance ...` requests.
- Zwift was correctly connected to QZ's `Wahoo KICKR 0000` virtual trainer via Direct Connect.
- Once the virtual FTMS client was connected, the normal FTMS routing guard skipped `forceResistance()` for local resistance changes.
- `enableManualResistancePowerAdjustment()` was therefore never reached, so `manualResistanceTarget` did not change.
- The submitted log also had `cscbike_custom_resistance_power_table = false`, so the custom watt path was not active during that test.

## Change

- Recognize `FBIKE-HEAVY-PRO` as a manual-resistance bike only when **Custom resistance power table** is enabled.
- For this F-Bike/manual-table case, apply local Resistance changes directly through `enableManualResistancePowerAdjustment()` before the virtual-FTMS routing filter.
- Do not send those software-only resistance changes to the physical F-Bike.
- Ignore gear-only updates for this path: the intended control for this bike is the QZ **Resistance** tile, not **Gears**.

## Test procedure

1. Enable **Custom resistance power table** and configure the resistance/watt points.
2. Restart QZ if needed and select `FBIKE-HEAVY-PRO` as the FTMS bike.
3. Connect Zwift/MyWhoosh to QZ's `Wahoo KICKR 0000` virtual trainer.
4. Start pedaling and use QZ **Resistance +/-**.
5. Verify that the Resistance tile changes and the debug log contains `Current Watt (custom resistance table): ...` with watts changing according to the selected resistance and cadence.

Refs #5094.