### PR TITLE
docs: add Android background connection FAQ

### DIFF
--- a/docs/faq/README.md
+++ b/docs/faq/README.md
@@ -4,6 +4,7 @@ This directory contains practical QZ frequently asked questions, organized by ca
 
 ## Categories
 
+- [Android](android.md)
 - [Bike and trainer troubleshooting](bike-troubleshooting.md)
 - [Integrations and authentication](integrations.md)
 - [Rowing](rowing.md)

--- a/docs/faq/android.md
+++ b/docs/faq/android.md
@@ -1,0 +1,9 @@
+# Android
+
+## Zwift loses its connection to QZ after about a minute when QZ is in the background. What should I do?
+
+On Android, enable **Settings > Experimental Settings > Android Notification** in QZ, then restart QZ before starting your session.
+
+This setting creates an active QZ notification while the app is running and is required for same-device Zwift operation on Android. In a confirmed support case, enabling it stopped a repeatable disconnect that occurred about every 60 seconds whenever Zwift was in the foreground.
+
+This workaround is Android-specific. iOS does not provide QZ with the same background mechanism; if your iOS setup requires QZ and the training app to remain active at the same time, use separate devices.


### PR DESCRIPTION
## Summary

Adds a reusable Android FAQ based on a confirmed support resolution from September 5, 2026.

- Documents the **Android Notification** setting for cases where Zwift loses its connection to QZ after about a minute when QZ is backgrounded.
- Notes that the workaround is Android-specific and that iOS setups requiring both apps active should use separate devices.
- Adds a dedicated Android category to `docs/faq/README.md`.

The existing FAQ and `docs/qz_faq_public.md` were checked first. The other strong confirmed case from the day—using Stryd as a treadmill source with Speed Gain and manual inclination—is already covered in `docs/faq/treadmill-troubleshooting.md`, so it was intentionally not duplicated.