### PR TITLE
Fix Dynamax FTMS bike detection

### DIFF
--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -1486,7 +1486,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 this->signalBluetoothDeviceConnected(kingsmithR2Treadmill);
             } else if ((b.name().toUpper().startsWith(QStringLiteral("R1 PRO")) ||
                         b.name().toUpper().startsWith(QStringLiteral("KINGSMITH")) ||
-                        (b.name().toUpper().startsWith(QStringLiteral("DYNAMAX")) && ftms_treadmill.contains(QZSettings::default_ftms_treadmill)) ||
+                        (b.name().toUpper().startsWith(QStringLiteral("DYNAMAX")) && ftms_treadmill.contains(QZSettings::default_ftms_treadmill) && ftms_bike.contains(QZSettings::default_ftms_bike)) ||
                         b.name().toUpper().startsWith(QStringLiteral("WALKINGPAD")) ||
                         b.name().toUpper().startsWith(QStringLiteral("KS-ST-A1P")) ||  // KingSmith Walkingpad A1 Pro #2041
                         // Poland-distributed WalkingPad R2 TRR2FB


### PR DESCRIPTION
## Summary
- prevent DYNAMAX devices from being classified as KingSmith treadmills when an FTMS bike is explicitly configured
- let the device fall through to the generic FTMS bike handler

The user's latest diagnostic session confirms the misclassification: the exported session is marked as `device="treadmill"` / Run even though the Dynamax is configured as an FTMS bike. In that short 1:53 test QZ reports impossible workout totals (110.9 km and 5645 kcal), while speed and power are otherwise plausible.

This is intentionally a one-line condition change: DYNAMAX treadmill auto-detection now also requires the FTMS bike setting to still be at its default value.