### PR TITLE
docs: add FAQ guidance from Sep 6 support cases

### DIFF
--- a/docs/faq/README.md
+++ b/docs/faq/README.md
@@ -8,6 +8,7 @@ This directory contains practical QZ frequently asked questions, organized by ca
 - [Bike and trainer troubleshooting](bike-troubleshooting.md)
 - [Integrations and authentication](integrations.md)
 - [Rowing](rowing.md)
+- [Training programs](training-programs.md)
 - [Treadmill troubleshooting](treadmill-troubleshooting.md)
 - [Zwift and virtual gearing](zwift.md)
 

--- a/docs/faq/android.md
+++ b/docs/faq/android.md
@@ -7,3 +7,9 @@ On Android, enable **Settings > Experimental Settings > Android Notification** i
 This setting creates an active QZ notification while the app is running and is required for same-device Zwift operation on Android. In a confirmed support case, enabling it stopped a repeatable disconnect that occurred about every 60 seconds whenever Zwift was in the foreground.
 
 This workaround is Android-specific. iOS does not provide QZ with the same background mechanism; if your iOS setup requires QZ and the training app to remain active at the same time, use separate devices.
+
+## Debug logging is enabled, but QZ has stopped creating new log files. What should I try?
+
+If older debug logs are still present but QZ no longer creates new ones, delete the **entire QZ log folder**, not only the files inside it. Then start QZ again so the app can recreate the folder and generate fresh logs.
+
+This recovery step was confirmed to restore debug-log creation in an Android support case where the debug-log setting was already enabled but no new files were being written.

--- a/docs/faq/training-programs.md
+++ b/docs/faq/training-programs.md
@@ -1,0 +1,18 @@
+# Training programs
+
+## Can I create an incline ramp in a QZ XML training program?
+
+QZ XML training programs support a direct speed ramp with `speedfrom` and `speedto`, but there is currently no generic `inclinefrom` / `inclineto` attribute for an incline ramp. The `inclination` attribute sets the incline for a row.
+
+To simulate a gradual incline change, split the ramp into consecutive short rows and increase or decrease `inclination` a little on each row. For example:
+
+```xml
+<row duration="00:00:30" speed="8.0" inclination="1" forcespeed="1" zonehr="0"/>
+<row duration="00:00:30" speed="8.0" inclination="2" forcespeed="1" zonehr="0"/>
+<row duration="00:00:30" speed="8.0" inclination="3" forcespeed="1" zonehr="0"/>
+<row duration="00:00:30" speed="8.0" inclination="4" forcespeed="1" zonehr="0"/>
+```
+
+Use as many steps as needed for the smoothness you want and for what your treadmill can safely accept. This stepped-incline workaround, as well as normal `speedfrom` / `speedto` ramps, has been confirmed working in a real QZ training program.
+
+For the full XML attribute reference and speed-ramp behavior, see [`train-programs-examples/README.md`](../../train-programs-examples/README.md).


### PR DESCRIPTION
## Summary

Adds reusable FAQ guidance extracted from confirmed QZ support cases from September 6, 2026.

- Android: when debug logging is enabled but QZ stops creating new log files, delete the entire QZ log folder so QZ can recreate it. The customer explicitly confirmed this restored logging.
- Training programs: document that XML supports direct speed ramps with `speedfrom` / `speedto`, while incline ramps must currently be simulated with consecutive rows using progressively changing `inclination` values. The stepped-incline workaround was explicitly confirmed working.
- Adds the new Training programs category to `docs/faq/README.md`.

Existing `docs/faq/`, `docs/qz_faq_public.md`, and the XML authoring guide were checked first to avoid duplicating existing guidance. Unresolved Rouvy/MyWhoosh troubleshooting, nightly-build-dependent behavior, and one-off hypotheses were excluded.