### PR TITLE
docs: add FAQ guidance from Sep 7 support cases

### DIFF
--- a/docs/faq/bike-troubleshooting.md
+++ b/docs/faq/bike-troubleshooting.md
@@ -15,6 +15,21 @@ This can restore the normal bike data stream when the Garmin ANT bike option int
 
 Bike resistance and incline are different values. A Yesoul bike may report resistance without reporting a real incline value. QZ's incline tile can instead be populated by an external source such as Zwift or a GPX route. A resistance-to-incline conversion requires a specific mapping and should not be assumed from the resistance percentage alone.
 
+## QZ cannot connect reliably to my bike even though the bike is supported. What else should I check?
+
+Check whether another nearby phone, tablet, watch, training app, or companion app is already connecting to the bike over Bluetooth.
+
+Many fitness devices accept only one active Bluetooth connection for a given service. A device you are not actively using may reconnect automatically in the background and prevent QZ from taking the connection.
+
+To test this:
+
+1. Fully close other fitness apps that know the bike.
+2. Temporarily disable Bluetooth on nearby phones or tablets that have previously paired with or used the bike.
+3. Power-cycle the bike if necessary.
+4. Start QZ first and let it connect before opening the training app that will connect to QZ.
+
+In a confirmed support case, an unnoticed second device was connecting to the bike; removing that competing connection restored QZ connectivity.
+
 ## MyWhoosh connects to QZ for my Echelon bike, but power stays at 0 W. What should I check?
 
 If the Echelon bike itself is already working normally in QZ and MyWhoosh can see/connect to the QZ device but the workout data remains at zero, check whether **Virtual Echelon** is still enabled from a previous setup or unlock attempt.

--- a/docs/faq/integrations.md
+++ b/docs/faq/integrations.md
@@ -35,6 +35,19 @@ When MyWhoosh lists the virtual QZ devices, select **Wahoo KICK 0000** as the **
 
 In a confirmed support case, selecting the external cadence sensor in QZ restored cadence immediately; the `cadence_sensor_as_bike` setting is also part of QZ's current device-discovery configuration.
 
+## Can I use Zwift Ride virtual gears with Kinomap through QZ?
+
+Yes. QZ can use the Zwift Ride controllers for shifting while Kinomap connects to QZ as the virtual trainer.
+
+For this setup:
+
+1. Enable **Zwift Play** in **QZ Settings > Accessories**.
+2. Wake the Zwift Ride controllers before starting QZ so QZ can discover them.
+3. In **Bike Options**, keep **FTMS Bike** set to **Disabled** unless you specifically need to force a particular FTMS bike implementation.
+4. Start QZ and verify that the controllers are connected, then pair the QZ virtual trainer in Kinomap.
+
+If the controllers appear connected but gear changes do not work in Kinomap, check **FTMS Bike** first. Selecting a trainer model there can make QZ use the wrong bike path for this setup. In a confirmed support case, changing **FTMS Bike** from a KICKR model back to **Disabled** restored virtual shifting immediately.
+
 ## Can I use QZ virtual gears with Rouvy?
 
 Yes. QZ can manage virtual gear changes while Rouvy controls the trainer through QZ. The current QZ gear is handled by QZ itself, so you should not expect Rouvy to display QZ's virtual gear number on its ride screen.


### PR DESCRIPTION
Adds reusable FAQ guidance from QZ support conversations on 2026-09-07.

Included:
- Zwift Ride virtual gears with Kinomap: enable Zwift Play, wake controllers before QZ, and keep FTMS Bike disabled unless explicitly required. A confirmed case was fixed by changing FTMS Bike from a KICKR model back to Disabled.
- Bluetooth connection conflicts: another nearby device/app can automatically take the bike connection and prevent QZ from connecting; start QZ first after removing competing connections. A confirmed case was resolved this way.

Excluded unresolved troubleshooting, code-fix-only cases, feature requests, and cases already covered by the existing FAQ (including Garmin live ANT+/FIT upload and cadence-sensor/MyWhoosh setup).