### PR TITLE
fix: detect Diadora Exess as FitShow treadmill

### DIFF
--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -2981,6 +2981,8 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                         (b.name().toUpper().startsWith(QStringLiteral("NOBLEPRO CONNECT")) && !deviceHasService(b, QBluetoothUuid((quint16)0x1826))) || // FTMS
                         (b.name().startsWith(QStringLiteral("SW")) && b.name().length() == 14 &&
                          !b.name().contains('(') && !b.name().contains(')') && !deviceHasService(b, QBluetoothUuid((quint16)0x1826))) ||
+                        (b.name().startsWith(QStringLiteral("SW")) && b.name().length() == 15 &&
+                         b.name().indexOf('-') == 10) || // FitShow SW fingerprint: SW5731CAXI-0061
                         (b.name().toUpper().startsWith(QStringLiteral("WINFITA"))) || //  also FTMS
                         b.name().toUpper().startsWith(QStringLiteral("TUNTURI T80-")) ||   // FTMS
                         (b.name().toUpper().startsWith(QStringLiteral("SW-BLE"))) ||       // FTMS

--- a/tst/Devices/devicetestdataindex.cpp
+++ b/tst/Devices/devicetestdataindex.cpp
@@ -462,6 +462,13 @@ void DeviceTestDataIndex::Initialize() {
         // SW, 14 characters total
         ->acceptDeviceName("SW345678901234", DeviceNameComparison::Exact)
         ->acceptDeviceName("SWFOURTEENCHAR", DeviceNameComparison::Exact)
+
+        // FitShow SW fingerprint: 15 characters with '-' at index 10
+        ->acceptDeviceName("SW5731CAXI-0061", DeviceNameComparison::Exact)
+        ->acceptDeviceName("SW12345678-1234", DeviceNameComparison::Exact)
+        ->rejectDeviceName("SW5731CAXI0-061", DeviceNameComparison::Exact)
+        ->rejectDeviceName("SW5731CAXI-006", DeviceNameComparison::Exact)
+
         ->acceptDeviceName("WINFITA", DeviceNameComparison::StartsWithIgnoreCase)
         ->acceptDeviceName("NOBLEPRO CONNECT", DeviceNameComparison::StartsWithIgnoreCase)
 


### PR DESCRIPTION
## Summary
- Recognize the Diadora Exess 11.6 Bluetooth name `SW5731CAXI-0061` as a FitShow treadmill.
- Use the observed SW fingerprint: 15 characters with `-` at index 10.
- Add focused valid/invalid device-name coverage.

## Validation
- `git diff --check` passed.
- Compilation and test execution were intentionally skipped per request.
- Real-device validation is still pending.

Reference: support request about Diadora Exess 11.6 compatibility with Zwift via QZ Fitness.