### PR TITLE
docs: add Horizon FTMS troubleshooting FAQ

### DIFF
--- a/docs/faq/treadmill-troubleshooting.md
+++ b/docs/faq/treadmill-troubleshooting.md
@@ -10,6 +10,18 @@ If speed is updating but distance is still not behaving correctly, check **QZ Se
 
 In a confirmed support case, the session/distance started working after correcting these settings. QZ's current treadmill implementation also calculates distance from speed when `Treadmill Direct Distance` is disabled.
 
+## My Horizon treadmill connects to QZ but behaves incorrectly or does not expose all expected data/control. What should I try?
+
+Some Horizon treadmills expose both Horizon's proprietary Bluetooth service and the standard FTMS service. If QZ connects but the treadmill behaves incorrectly, try forcing QZ to use FTMS instead of the proprietary Horizon protocol.
+
+1. Open **QZ Settings > Treadmill Options > Horizon Treadmill options**.
+2. Enable **Force Using FTMS**.
+3. Restart QZ and reconnect the treadmill.
+
+This setting is especially relevant when the treadmill advertises a usable FTMS service. QZ's Horizon implementation explicitly detects this situation and can prompt the user to enable **Force Using FTMS**. In a confirmed Horizon 7.4AT support case, enabling it resolved most of the connection/control issues.
+
+Note that some treadmill consoles disable their physical controls while an app has an active Bluetooth control connection. That behavior can be firmware-specific and is separate from QZ's protocol selection.
+
 ## Can Zwift automatically control both treadmill incline and speed through QZ?
 
 QZ can use the Zwift integration for **automatic inclination**. Configure your Zwift credentials in QZ and enable the Zwift auto-inclination option.


### PR DESCRIPTION
Adds a reusable treadmill troubleshooting FAQ from the September 8 support conversations.

- Documents when to enable **Force Using FTMS** for Horizon treadmills that expose both proprietary Horizon Bluetooth and standard FTMS.
- Includes the exact settings path and restart/reconnect sequence.
- Notes that a Horizon 7.4AT support case explicitly confirmed that enabling this resolved most connection/control issues.
- Keeps firmware-specific console lockout behavior separate from QZ protocol selection.

I checked the existing `docs/faq/` content and repository documentation first; there was no substantially overlapping Horizon FTMS troubleshooting entry.