### PR TITLE
feat: parse SRX-500 FTMS power

### DIFF
--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -566,6 +566,9 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
     bool toorx_ftms = settings.value(QZSettings::toorx_ftms, QZSettings::default_toorx_ftms).toBool();
     bool toorx_ftms_treadmill =
         settings.value(QZSettings::toorx_ftms_treadmill, QZSettings::default_toorx_ftms_treadmill).toBool();
+    QString ftms_bike = settings.value(QZSettings::ftms_bike, QZSettings::default_ftms_bike).toString();
+    // An explicitly selected FTMS bike takes precedence over model-specific Toorx handlers.
+    const bool ftms_bike_configured = !ftms_bike.startsWith(QZSettings::default_ftms_bike);
     bool toorx_bike = (settings.value(QZSettings::toorx_bike, QZSettings::default_toorx_bike).toBool() ||
                        settings.value(QZSettings::jll_IC400_bike, QZSettings::default_jll_IC400_bike).toBool() ||
                        settings.value(QZSettings::fytter_ri08_bike, QZSettings::default_fytter_ri08_bike).toBool() ||
@@ -576,7 +579,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                        settings.value(QZSettings::toorx_bike_srx_500, QZSettings::default_toorx_bike_srx_500).toBool() ||
                        settings.value(QZSettings::hertz_xr_770, QZSettings::default_hertz_xr_770).toBool() ||
                        settings.value(QZSettings::taurua_ic90, QZSettings::default_taurua_ic90).toBool()) &&
-                      !toorx_ftms;
+                      !toorx_ftms && !ftms_bike_configured;
     bool snode_bike = settings.value(QZSettings::snode_bike, QZSettings::default_snode_bike).toBool();
     bool fitplus_bike = settings.value(QZSettings::fitplus_bike, QZSettings::default_fitplus_bike).toBool() ||
                         settings.value(QZSettings::virtufit_etappe, QZSettings::default_virtufit_etappe).toBool();
@@ -656,7 +659,6 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
     bool sole_inclination =
         settings.value(QZSettings::sole_treadmill_inclination, QZSettings::default_sole_treadmill_inclination).toBool();
     QString ftms_rower = settings.value(QZSettings::ftms_rower, QZSettings::default_ftms_rower).toString();
-    QString ftms_bike = settings.value(QZSettings::ftms_bike, QZSettings::default_ftms_bike).toString();
     QString ftms_treadmill = settings.value(QZSettings::ftms_treadmill, QZSettings::default_ftms_treadmill).toString();
     QString ftms_elliptical = settings.value(QZSettings::ftms_elliptical, QZSettings::default_ftms_elliptical).toString();
     bool saris_trainer = settings.value(QZSettings::saris_trainer, QZSettings::default_saris_trainer).toBool();

--- a/src/devices/trxappgateusbbike/trxappgateusbbike.cpp
+++ b/src/devices/trxappgateusbbike/trxappgateusbbike.cpp
@@ -17,6 +17,78 @@
 
 using namespace std::chrono_literals;
 
+bool trxappgateusbbike::parseSrx500FtmsPower(const QByteArray &packet, double &power) {
+    if (packet.length() < 2) {
+        return false;
+    }
+
+    const uint16_t flags = (static_cast<uint16_t>(static_cast<uint8_t>(packet.at(1))) << 8) |
+                           static_cast<uint16_t>(static_cast<uint8_t>(packet.at(0)));
+    int index = 2;
+
+    const auto skip = [&packet, &index](int count) {
+        if (index + count > packet.length()) {
+            return false;
+        }
+        index += count;
+        return true;
+    };
+    const auto readSigned16 = [&packet, &index](double &value) {
+        if (index + 2 > packet.length()) {
+            return false;
+        }
+        const uint16_t raw = static_cast<uint16_t>(static_cast<uint8_t>(packet.at(index))) |
+                             (static_cast<uint16_t>(static_cast<uint8_t>(packet.at(index + 1))) << 8);
+        value = static_cast<double>(static_cast<qint16>(raw));
+        index += 2;
+        return true;
+    };
+
+    // Indoor Bike Data fields precede power in the order defined by FTMS.
+    if (!(flags & 0x0001) && !skip(2)) { // instantaneous speed
+        return false;
+    }
+    if ((flags & 0x0002) && !skip(2)) { // average speed
+        return false;
+    }
+    if ((flags & 0x0004) && !skip(2)) { // instantaneous cadence
+        return false;
+    }
+    if ((flags & 0x0008) && !skip(2)) { // average cadence
+        return false;
+    }
+    if ((flags & 0x0010) && !skip(3)) { // total distance
+        return false;
+    }
+    if ((flags & 0x0020) && !skip(2)) { // resistance level
+        return false;
+    }
+
+    bool powerFound = false;
+    double instantPower = 0;
+    double averagePower = 0;
+    if (flags & 0x0040) { // instantaneous power
+        if (!readSigned16(instantPower)) {
+            return false;
+        }
+        powerFound = true;
+    }
+    if (flags & 0x0080) { // average power
+        if (!readSigned16(averagePower)) {
+            return false;
+        }
+        if (!powerFound) {
+            power = averagePower;
+            powerFound = true;
+        }
+    }
+
+    if (powerFound && (flags & 0x0040)) {
+        power = instantPower;
+    }
+    return powerFound;
+}
+
 trxappgateusbbike::trxappgateusbbike(bool noWriteResistance, bool noHeartService, int8_t bikeResistanceOffset,
                                      double bikeResistanceGain) {
     m_watt.setType(metric::METRIC_WATT, deviceType());
@@ -232,6 +304,17 @@ void trxappgateusbbike::characteristicChanged(const QLowEnergyCharacteristic &ch
         settings.value(QZSettings::heart_rate_belt_name, QZSettings::default_heart_rate_belt_name).toString();
     emit packetReceived();
 
+    if (bike_type == TOORX_SRX_500 && characteristic.uuid() == QBluetoothUuid((quint16)0x2AD2)) {
+        double power = 0;
+        if (parseSrx500FtmsPower(newValue, power) && power >= 0) {
+            ftmsWatt = power;
+            lastFtmsWattTime = QDateTime::currentMSecsSinceEpoch();
+            m_watt = power;
+            emit debug(QStringLiteral("Current FTMS watt: ") + QString::number(power));
+        }
+        return;
+    }
+
     qDebug() << newValue.toHex(' ') << bike_type;
 
     lastPacket = newValue;
@@ -281,6 +364,10 @@ void trxappgateusbbike::characteristicChanged(const QLowEnergyCharacteristic &ch
         speed = GetSpeedFromPacket(newValue);
         resistance = GetResistanceFromPacket(newValue);
         watt = GetWattFromPacket(newValue);
+        if (bike_type == TOORX_SRX_500 && lastFtmsWattTime > 0 &&
+            QDateTime::currentMSecsSinceEpoch() - lastFtmsWattTime <= 2000) {
+            watt = ftmsWatt;
+        }
         if (!settings.value(QZSettings::kcal_ignore_builtin, QZSettings::default_kcal_ignore_builtin).toBool())
             KCal = GetKcalFromPacket(newValue);
         else {
@@ -1145,6 +1232,40 @@ void trxappgateusbbike::serviceScanDone(void) {
 
     connect(gattCommunicationChannelService, &QLowEnergyService::stateChanged, this, &trxappgateusbbike::stateChanged);
     gattCommunicationChannelService->discoverDetails();
+
+    if (bike_type == TYPE::TOORX_SRX_500 && m_control->services().contains(QBluetoothUuid((quint16)0x1826))) {
+        gattFTMSService = m_control->createServiceObject(QBluetoothUuid((quint16)0x1826));
+        if (gattFTMSService) {
+            connect(gattFTMSService, &QLowEnergyService::stateChanged, this, &trxappgateusbbike::ftmsStateChanged);
+            gattFTMSService->discoverDetails();
+        }
+    }
+}
+
+void trxappgateusbbike::ftmsStateChanged(QLowEnergyService::ServiceState state) {
+    if (state != QLowEnergyService::ServiceDiscovered) {
+        return;
+    }
+
+    connect(gattFTMSService, &QLowEnergyService::characteristicChanged, this,
+            &trxappgateusbbike::characteristicChanged);
+    for (const QLowEnergyCharacteristic &characteristic : gattFTMSService->characteristics()) {
+        emit debug(QStringLiteral("FTMS characteristic ") + characteristic.uuid().toString());
+        if (characteristic.uuid() == QBluetoothUuid((quint16)0x2AD2) &&
+            (characteristic.properties() & (QLowEnergyCharacteristic::Notify | QLowEnergyCharacteristic::Indicate))) {
+            const QLowEnergyDescriptor ccc =
+                characteristic.descriptor(QBluetoothUuid::ClientCharacteristicConfiguration);
+            if (!ccc.isValid()) {
+                emit debug(QStringLiteral("FTMS SRX-500 Indoor Bike Data has no CCC descriptor"));
+                continue;
+            }
+            QByteArray descriptor;
+            descriptor.append((characteristic.properties() & QLowEnergyCharacteristic::Notify) ? char(0x01) : char(0x02));
+            descriptor.append(char(0x00));
+            gattFTMSService->writeDescriptor(ccc, descriptor);
+            emit debug(QStringLiteral("FTMS SRX-500 Indoor Bike Data power enabled"));
+        }
+    }
 }
 
 void trxappgateusbbike::errorService(QLowEnergyService::ServiceError err) {

--- a/src/devices/trxappgateusbbike/trxappgateusbbike.h
+++ b/src/devices/trxappgateusbbike/trxappgateusbbike.h
@@ -38,6 +38,7 @@ class trxappgateusbbike : public bike {
     trxappgateusbbike(bool noWriteResistance, bool noHeartService, int8_t bikeResistanceOffset,
                       double bikeResistanceGain);
     bool connected() override;
+    static bool parseSrx500FtmsPower(const QByteArray &packet, double &power);
     resistance_t maxResistance() override { return 32; }
     resistance_t resistanceFromPowerRequest(uint16_t power) override;
 
@@ -77,6 +78,7 @@ class trxappgateusbbike : public bike {
     QByteArray lastPacket;
 
     QLowEnergyService *gattCommunicationChannelService = nullptr;
+    QLowEnergyService *gattFTMSService = nullptr;
     QLowEnergyCharacteristic gattWriteCharacteristic;
     QLowEnergyCharacteristic gattNotify1Characteristic;
     QLowEnergyCharacteristic gattNotify2Characteristic;
@@ -84,6 +86,8 @@ class trxappgateusbbike : public bike {
     bool initDone = false;
     bool initRequest = false;
     bool readyToStart = false;
+    double ftmsWatt = 0;
+    qint64 lastFtmsWattTime = 0;
 
     typedef enum TYPE {
         TRXAPPGATE = 0,
@@ -142,6 +146,7 @@ class trxappgateusbbike : public bike {
     void characteristicWritten(const QLowEnergyCharacteristic &characteristic, const QByteArray &newValue);
     void descriptorWritten(const QLowEnergyDescriptor &descriptor, const QByteArray &newValue);
     void stateChanged(QLowEnergyService::ServiceState state);
+    void ftmsStateChanged(QLowEnergyService::ServiceState state);
     void controllerStateChanged(QLowEnergyController::ControllerState state);
 
     void serviceDiscovered(const QBluetoothUuid &gatt);

--- a/tst/Devices/TestToorxSrx500Parser.cpp
+++ b/tst/Devices/TestToorxSrx500Parser.cpp
@@ -1,0 +1,1 @@
+#include "TestToorxSrx500Parser.h"

--- a/tst/Devices/TestToorxSrx500Parser.h
+++ b/tst/Devices/TestToorxSrx500Parser.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include "devices/trxappgateusbbike/trxappgateusbbike.h"
+
+TEST(ToorxSrx500ParserTest, ReadsInstantPowerFromIndoorBikeData) {
+    double power = 0;
+
+    const bool parsed = trxappgateusbbike::parseSrx500FtmsPower(
+        QByteArray::fromHex("6402ae0b0a011300ca005600"), power);
+
+    EXPECT_TRUE(parsed);
+    EXPECT_DOUBLE_EQ(power, 202.0);
+}
+
+TEST(ToorxSrx500ParserTest, UsesAveragePowerWhenInstantPowerIsAbsent) {
+    double power = 0;
+
+    const bool parsed = trxappgateusbbike::parseSrx500FtmsPower(
+        QByteArray::fromHex("8100c800"), power);
+
+    EXPECT_TRUE(parsed);
+    EXPECT_DOUBLE_EQ(power, 200.0);
+}
+
+TEST(ToorxSrx500ParserTest, RejectsIndoorBikeDataWithoutPower) {
+    double power = 0;
+
+    const bool parsed = trxappgateusbbike::parseSrx500FtmsPower(
+        QByteArray::fromHex("0402ae0b0a01"), power);
+
+    EXPECT_FALSE(parsed);
+}

--- a/tst/qdomyos-zwift-tests.pro
+++ b/tst/qdomyos-zwift-tests.pro
@@ -35,6 +35,7 @@ SOURCES += \
         Devices/TestRenphoBikeKnobGears.cpp \
         Devices/TestNordictrackEllipticalS700Parser.cpp \
         Devices/TestXcxBikeParser.cpp \
+        Devices/TestToorxSrx500Parser.cpp \
         main.cpp
 
 # Avoid the "File too big" error building in Windows. This has happened when a template class is used with Google Test / typed tests
@@ -69,6 +70,7 @@ HEADERS += \
     Devices/TestRenphoBikeKnobGears.h \
     Devices/TestNordictrackEllipticalS700Parser.h \
     Devices/TestXcxBikeParser.h \
+    Devices/TestToorxSrx500Parser.h \
     Devices/TestOctaneTreadmillZR8.h \
     Devices/TestSunnyfitStepper.h \
     Erg/ergtabletestsuite.h \


### PR DESCRIPTION
## Summary
- Subscribe to the SRX-500 advertised Fitness Machine Service (0x1826).
- Parse Indoor Bike Data (0x2AD2) instant power, with average-power fallback.
- Prefer a fresh FTMS power value while retaining the existing FFF0 parser as fallback.
- Add focused parser regression tests.

## Reference
Reference: #578

## Evidence
The SRX-500 support log advertises 0x1826 but the existing driver only opens the vendor FFF0 service. The 0x2AD2/0x2A63 values previously visible in the log were QZ virtual-device notifications, not physical-bike notifications.

## Test plan
- `make -f Makefile -j1` (library)
- `make -f Makefile -j1` (test target)
- `./qdomyos-zwift-tests --gtest_filter=ToorxSrx500ParserTest.*` — 3 passed
- `./qdomyos-zwift-tests` — passed

Hardware validation with a live SRX-500 is still pending; the new runtime logs identify the discovered FTMS characteristics and whether 0x2AD2 notifications are available.