### PR TITLE
Fix Horizon custom protocol speed unit handling

### DIFF
--- a/src/devices/horizontreadmill/horizontreadmill.cpp
+++ b/src/devices/horizontreadmill/horizontreadmill.cpp
@@ -1559,6 +1559,10 @@ void horizontreadmill::characteristicChanged(const QLowEnergyCharacteristic &cha
         settings.value(QZSettings::heart_rate_belt_name, QZSettings::default_heart_rate_belt_name).toString();
     bool treadmill_direct_distance =
         settings.value(QZSettings::treadmill_direct_distance, QZSettings::default_treadmill_direct_distance).toBool();
+    const double horizon_speed_multiplier =
+        settings.value(QZSettings::sole_treadmill_miles, QZSettings::default_sole_treadmill_miles).toBool()
+            ? 1.60934
+            : 1.0;
 
     QDateTime now = QDateTime::currentDateTime();
     double weight = settings.value(QZSettings::weight, QZSettings::default_weight).toFloat();
@@ -1597,7 +1601,7 @@ void horizontreadmill::characteristicChanged(const QLowEnergyCharacteristic &cha
         parseSpeed((((double)(((uint16_t)((uint8_t)lastPacketComplete.at(25)) << 8) |
                            (uint16_t)((uint8_t)lastPacketComplete.at(24)))) /
                  100.0) *
-                1.60934); // miles/h
+                horizon_speed_multiplier);
         emit debug(QStringLiteral("Current Speed: ") + QString::number(Speed.value()));
 
         parseInclination(treadmillInclinationOverride((double)((uint8_t)lastPacketComplete.at(30)) / 10.0));
@@ -1623,7 +1627,7 @@ void horizontreadmill::characteristicChanged(const QLowEnergyCharacteristic &cha
     } else if (characteristic.uuid() == QBluetoothUuid((quint16)0xFFF4) && newValue.length() > 70 &&
                newValue.at(0) == 0x55 && newValue.at(5) == 0x12) {
         parseSpeed((((double)(((uint16_t)((uint8_t)newValue.at(62)) << 8) | (uint16_t)((uint8_t)newValue.at(61)))) / 1000.0) *
-                       1.60934); // miles/h
+                       horizon_speed_multiplier);
         emit debug(QStringLiteral("Current Speed: ") + QString::number(Speed.value()));
 
         parseInclination(treadmillInclinationOverride((double)((uint8_t)newValue.at(63)) / 10.0));

--- a/src/settings.qml
+++ b/src/settings.qml
@@ -11505,6 +11505,20 @@ import AndroidStatusBar 1.0
                                 onClicked: { settings.horizon_treadmill_force_ftms = checked; window.settings_restart_to_apply = true; }
                             }
                             IndicatorOnlySwitch {
+                                id: horizonTreadmillSpeedMilesDelegate
+                                text: qsTr("Horizon speed is in miles")
+                                spacing: 0
+                                bottomPadding: 0
+                                topPadding: 0
+                                rightPadding: 0
+                                leftPadding: 0
+                                clip: false
+                                checked: settings.sole_treadmill_miles
+                                Layout.alignment: Qt.AlignLeft | Qt.AlignTop
+                                Layout.fillWidth: true
+                                onClicked: settings.sole_treadmill_miles = checked
+                            }
+                            IndicatorOnlySwitch {
                                 id: horizon78TreadmillDelegate
                                 text: qsTr("Horizon 7.8 start issue")
                                 spacing: 0


### PR DESCRIPTION
## Summary

Horizon proprietary packet parsing previously assumed incoming speed was always in mph and always multiplied by 1.60934. A Horizon 7.4AT configured for metric units sends an already-km/h value, so 10 km/h was displayed as 16.0934 km/h.

Reference: Kyle D.

This PR:
- Reuses the existing sole_treadmill_miles setting for both proprietary Horizon speed packet formats.
- Keeps the default true, preserving existing Horizon behavior.
- Exposes the same setting in Horizon Treadmill Options as Horizon speed is in miles.
- Lets metric Horizon users turn it off to keep the decoded km/h value unchanged.
- Leaves FTMS parsing and global miles_unit behavior unchanged.

Outgoing Horizon speed commands were inspected and intentionally left untouched: the established proprietary command path encodes requested speed in the treadmill protocol's expected mph representation, and changing it without device-specific evidence could send an incorrect speed.

## Validation

- git diff --check passes.
- Focused arithmetic checks confirm 10.0 becomes 16.0934 when enabled and 10.0 when disabled.
- Existing desktop build was started; the cached target began rebuilding a large set of unrelated generated sources, so it was stopped before completion. No Horizon parser unit tests exist in the repository; existing Horizon tests cover device discovery/configuration.