### PR TITLE
Add optional Alternative Pace tile for running sensors

### DIFF
--- a/src/devices/bluetooth.h
+++ b/src/devices/bluetooth.h
@@ -183,6 +183,7 @@ class bluetooth : public QObject, public SignalHandler {
     bluetoothdevice *device();
     bluetoothdevice *externalInclination() { return eliteRizer; }
     bluetoothdevice *heartRateDevice() { return heartRateBelt; }
+    strydrunpowersensor *runningPowerSensor() { return powerSensorRun; }
     QList<QBluetoothDeviceInfo> devices;
     bool onlyDiscover = false;
     volatile bool homeformLoaded = false;

--- a/src/devices/strydrunpowersensor/strydrunpowersensor.cpp
+++ b/src/devices/strydrunpowersensor/strydrunpowersensor.cpp
@@ -392,6 +392,9 @@ void strydrunpowersensor::characteristicChanged(const QLowEnergyCharacteristic &
         // Unit is in m/s with a resolution of 1/256
         uint16_t speedMs = (((uint16_t)((uint8_t)newValue.at(2)) << 8) | (uint16_t)((uint8_t)newValue.at(1)));
         double speed = (((double)speedMs) / 256.0) * 3.6; // km/h
+        // Keep the running sensor speed available for the alternative pace tile without
+        // changing the inherited treadmill speed metric.
+        alternativeSpeedValue = speed;
         bool stryd_speed_instead_treadmill = settings.value(QZSettings::stryd_speed_instead_treadmill, QZSettings::default_stryd_speed_instead_treadmill).toBool();
         if(stryd_speed_instead_treadmill)
             emit speedChanged(speed);
@@ -415,8 +418,6 @@ void strydrunpowersensor::characteristicChanged(const QLowEnergyCharacteristic &
         Cadence = cadence;
         emit cadenceChanged(cadence);
         if (treadmill_from_sensor) {
-            Speed = speed;
-
             emit speedChanged(speed);
             Distance += ((Speed.value() / 3600000.0) *
                          ((double)lastRefreshCadenceChanged.msecsTo(now)));

--- a/src/devices/strydrunpowersensor/strydrunpowersensor.h
+++ b/src/devices/strydrunpowersensor/strydrunpowersensor.h
@@ -38,6 +38,8 @@ class strydrunpowersensor : public treadmill {
   public:
     strydrunpowersensor(bool noWriteResistance, bool noHeartService, bool noVirtualDevice);
     bool connected() override;
+    double alternativeSpeed() const { return alternativeSpeedValue; }
+    QTime alternativePace() { return speedToPace(alternativeSpeedValue); }
 
   private:
     void writeCharacteristic(uint8_t *data, uint8_t data_len, QString info, bool disable_log = false,
@@ -68,6 +70,7 @@ class strydrunpowersensor : public treadmill {
     bool noWriteResistance = false;
     bool noHeartService = false;
     bool noVirtualDevice = false;
+    double alternativeSpeedValue = 0;
 
     uint16_t oldLastCrankEventTime = 0;
     uint16_t oldCrankRevs = 0;

--- a/src/homeform.cpp
+++ b/src/homeform.cpp
@@ -541,6 +541,9 @@ homeform::homeform(QQmlApplicationEngine *engine, bluetooth *bl) {
     pace =
         new DataObject(tr("Pace (m/%1)").arg(unit), QStringLiteral("icons/icons/pace.png"),
                        QStringLiteral("0:00"), false, QStringLiteral("pace"), 48, labelFontSize);
+    alternative_pace =
+        new DataObject(tr("Alternative Pace (m/%1)").arg(unit), QStringLiteral("icons/icons/pace.png"),
+                       QStringLiteral("N/A"), false, QStringLiteral("alternative_pace"), 48, labelFontSize);
 
     avg_pace =
         new DataObject(tr("Avg Pace (m/%1)").arg(unit), QStringLiteral("icons/icons/pace.png"),
@@ -2208,6 +2211,16 @@ void homeform::sortTiles() {
                 settings.value(QZSettings::tile_pace_order, 0).toInt() == i) {
                 pace->setGridId(i);
                 dataList.append(pace);
+            }
+
+            if (settings.value(QZSettings::tile_alternative_pace_enabled,
+                               QZSettings::default_tile_alternative_pace_enabled)
+                        .toBool() &&
+                settings.value(QZSettings::tile_alternative_pace_order,
+                               QZSettings::default_tile_alternative_pace_order)
+                        .toInt() == i) {
+                alternative_pace->setGridId(i);
+                dataList.append(alternative_pace);
             }
 
             if (settings.value(QZSettings::tile_avg_pace_enabled, QZSettings::default_tile_avg_pace_enabled).toBool() &&
@@ -6575,6 +6588,15 @@ void homeform::update() {
                 ((treadmill *)bluetoothManager->device())->averagePace().toString(QStringLiteral("m:ss")) +
                 QStringLiteral(" MAX: ") +
                 ((treadmill *)bluetoothManager->device())->maxPace().toString(QStringLiteral("m:ss")));
+            strydrunpowersensor *runningPowerSensor = bluetoothManager->runningPowerSensor();
+            if (runningPowerSensor && runningPowerSensor->alternativeSpeed() > 2) {
+                this->alternative_pace->setValue(runningPowerSensor->alternativePace().toString(QStringLiteral("m:ss")));
+                this->alternative_pace->setSecondLine(
+                    QStringLiteral("Speed: ") + QString::number(runningPowerSensor->alternativeSpeed() * unit_conversion, 'f', 1));
+            } else {
+                this->alternative_pace->setValue(QStringLiteral("N/A"));
+                this->alternative_pace->setSecondLine(QString());
+            }
             this->avg_pace->setValue(
                 ((treadmill *)bluetoothManager->device())->averagePace().toString(QStringLiteral("m:ss")));
             this->avg_pace->setSecondLine(

--- a/src/homeform.h
+++ b/src/homeform.h
@@ -880,6 +880,7 @@ public:
     DataObject *calories;
     DataObject *odometer;
     DataObject *pace;
+    DataObject *alternative_pace;
     DataObject *avg_pace;
     DataObject *grade_adjusted_pace;
     DataObject *datetime;

--- a/src/qzsettings.cpp
+++ b/src/qzsettings.cpp
@@ -154,6 +154,8 @@ const QString QZSettings::tile_avg_pace_enabled = QStringLiteral("tile_avg_pace_
 const QString QZSettings::tile_avg_pace_order = QStringLiteral("tile_avg_pace_order");
 const QString QZSettings::tile_grade_adjusted_pace_enabled = QStringLiteral("tile_grade_adjusted_pace_enabled");
 const QString QZSettings::tile_grade_adjusted_pace_order = QStringLiteral("tile_grade_adjusted_pace_order");
+const QString QZSettings::tile_alternative_pace_enabled = QStringLiteral("tile_alternative_pace_enabled");
+const QString QZSettings::tile_alternative_pace_order = QStringLiteral("tile_alternative_pace_order");
 const QString QZSettings::tile_resistance_enabled = QStringLiteral("tile_resistance_enabled");
 const QString QZSettings::tile_resistance_order = QStringLiteral("tile_resistance_order");
 const QString QZSettings::tile_watt_enabled = QStringLiteral("tile_watt_enabled");
@@ -1285,7 +1287,7 @@ const QString QZSettings::default_shortcut_start_stop = QStringLiteral("");
 const QString QZSettings::shortcut_stop = QStringLiteral("shortcut_stop");
 const QString QZSettings::default_shortcut_stop = QStringLiteral("");
 
-const uint32_t allSettingsCount = 1005;
+const uint32_t allSettingsCount = 1007;
 
 QVariant allSettings[allSettingsCount][2] = {
     {QZSettings::cryptoKeySettingsProfiles, QZSettings::default_cryptoKeySettingsProfiles},
@@ -1392,6 +1394,8 @@ QVariant allSettings[allSettingsCount][2] = {
     {QZSettings::tile_pace_order, QZSettings::default_tile_pace_order},
     {QZSettings::tile_grade_adjusted_pace_enabled, QZSettings::default_tile_grade_adjusted_pace_enabled},
     {QZSettings::tile_grade_adjusted_pace_order, QZSettings::default_tile_grade_adjusted_pace_order},
+    {QZSettings::tile_alternative_pace_enabled, QZSettings::default_tile_alternative_pace_enabled},
+    {QZSettings::tile_alternative_pace_order, QZSettings::default_tile_alternative_pace_order},
     {QZSettings::tile_resistance_enabled, QZSettings::default_tile_resistance_enabled},
     {QZSettings::tile_resistance_order, QZSettings::default_tile_resistance_order},
     {QZSettings::tile_watt_enabled, QZSettings::default_tile_watt_enabled},

--- a/src/qzsettings.h
+++ b/src/qzsettings.h
@@ -445,6 +445,12 @@ class QZSettings {
     static const QString tile_grade_adjusted_pace_order;
     static constexpr int default_tile_grade_adjusted_pace_order = 79;
 
+    static const QString tile_alternative_pace_enabled;
+    static constexpr bool default_tile_alternative_pace_enabled = false;
+
+    static const QString tile_alternative_pace_order;
+    static constexpr int default_tile_alternative_pace_order = 80;
+
     static const QString tile_resistance_enabled;
     static constexpr bool default_tile_resistance_enabled = true;
 

--- a/src/settings-catalog.json
+++ b/src/settings-catalog.json
@@ -2,7 +2,7 @@
   "$schema": "https://qdomyos-zwift.local/settings-catalog.schema.json",
   "schemaVersion": 1,
   "format": "qdomyos-zwift-settings-catalog",
-  "settingCount": 1001,
+  "settingCount": 1003,
   "pages": [
     {
       "key": "page_custom_gear_table",
@@ -15837,6 +15837,37 @@
       "defaultExpression": "\"0|4\\n1|6\\n2|8\\n3|10\\n4|11\\n5|11.5\\n6|12\\n8|13\\n10|14\\n12|15\\n15|16\"",
       "options": null,
       "restartRequired": true
+    },
+    {
+      "key": "tile_alternative_pace_enabled",
+      "name": "Alternative Pace",
+      "description": "Show pace calculated from an available running sensor, such as HRM Pro Plus or Stryd.",
+      "parent": "Tiles",
+      "type": "boolean",
+      "qmlType": "bool",
+      "control": "switch",
+      "visible": true,
+      "defaultValue": false,
+      "defaultExpression": "false",
+      "options": null,
+      "restartRequired": false
+    },
+    {
+      "key": "tile_alternative_pace_order",
+      "name": "order index",
+      "description": "Display order for the Alternative Pace tile.",
+      "parent": "tile_alternative_pace_enabled",
+      "type": "integer",
+      "qmlType": "int",
+      "control": "select",
+      "visible": true,
+      "defaultValue": 80,
+      "defaultExpression": "80",
+      "options": {
+        "source": "expression",
+        "expression": "rootItem.tile_order"
+      },
+      "restartRequired": false
     }
   ],
   "legacyHierarchy": {
@@ -17544,6 +17575,8 @@
       "tile_gears_order": "settings-tiles.qml",
       "tile_grade_adjusted_pace_enabled": "settings-tiles.qml",
       "tile_grade_adjusted_pace_order": "settings-tiles.qml",
+      "tile_alternative_pace_enabled": "settings-tiles.qml",
+      "tile_alternative_pace_order": "settings-tiles.qml",
       "tile_ground_contact_enabled": "settings-tiles.qml",
       "tile_ground_contact_order": "settings-tiles.qml",
       "tile_heart_enabled": "settings-tiles.qml",
@@ -18479,6 +18512,7 @@
       "tile_ftp_order": 1089,
       "tile_gears_order": 1959,
       "tile_grade_adjusted_pace_order": 800,
+      "tile_alternative_pace_order": 800,
       "tile_ground_contact_order": 2543,
       "tile_heart_order": 1163,
       "tile_heart_show_as_percent": 1133,
@@ -18886,6 +18920,7 @@
       "tile_ftp_order": 1089,
       "tile_gears_order": 1959,
       "tile_grade_adjusted_pace_order": 800,
+      "tile_alternative_pace_order": 800,
       "tile_ground_contact_order": 2543,
       "tile_heart_order": 1163,
       "tile_heart_show_as_percent": 1133,

--- a/src/settings-tiles.qml
+++ b/src/settings-tiles.qml
@@ -813,6 +813,19 @@ ScrollView {
             }
         }
 
+        Label {
+            text: qsTr("Shows the pace calculated from an available running sensor, such as HRM Pro Plus or Stryd. The treadmill pace remains unchanged.")
+            font.bold: true
+            font.italic: true
+            font.pixelSize: Qt.application.font.pixelSize - 2
+            textFormat: Text.PlainText
+            wrapMode: Text.WordWrap
+            verticalAlignment: Text.AlignVCenter
+            Layout.alignment: Qt.AlignLeft | Qt.AlignTop
+            Layout.fillWidth: true
+            color: Material.color(Material.Lime)
+        }
+
         AccordionCheckElement {
             id: gradeAdjustedPaceEnabledAccordion
             title: qsTr("Grade Adjusted Pace")

--- a/src/settings-tiles.qml
+++ b/src/settings-tiles.qml
@@ -367,6 +367,8 @@ ScrollView {
         property string shortcut_start_stop: ""            
         property bool tile_watt_color_enabled: true
         property bool tile_pace_color_enabled: true
+        property bool tile_alternative_pace_enabled: false
+        property int  tile_alternative_pace_order: 80
     }
 
 
@@ -777,6 +779,36 @@ ScrollView {
                     text: qsTr("OK")
                     Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
                     onClicked: {settings.tile_avg_pace_order = avgpaceOrderTextField.displayText; toast.show(qsTr("Setting saved!")); }
+                }
+            }
+        }
+
+        AccordionCheckElement {
+            id: alternativePaceEnabledAccordion
+            title: qsTr("Alternative Pace")
+            linkedBoolSetting: "tile_alternative_pace_enabled"
+            settings: settings
+            accordionContent: RowLayout {
+                spacing: 10
+                Label {
+                    id: labelalternativePaceOrder
+                    text: qsTr("order index:")
+                    Layout.fillWidth: true
+                    horizontalAlignment: Text.AlignRight
+                }
+                ComboBox {
+                    id: alternativePaceOrderTextField
+                    model: rootItem.tile_order
+                    displayText: settings.tile_alternative_pace_order
+                    Layout.fillHeight: false
+                    Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                    onActivated: displayText = alternativePaceOrderTextField.currentValue
+                }
+                Button {
+                    id: okalternativePaceOrderButton
+                    text: qsTr("OK")
+                    Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                    onClicked: { settings.tile_alternative_pace_order = alternativePaceOrderTextField.displayText; toast.show(qsTr("Setting saved!")); }
                 }
             }
         }

--- a/src/settings.qml
+++ b/src/settings.qml
@@ -1743,6 +1743,8 @@ import AndroidStatusBar 1.0
             property bool nordictrack_incline_trainer_x7i_ntl15010_0: false
             property bool custom_inclination_resistance_table_enabled: false
             property string custom_inclination_resistance_table: "0|4\n1|6\n2|8\n3|10\n4|11\n5|11.5\n6|12\n8|13\n10|14\n12|15\n15|16"
+            property bool tile_alternative_pace_enabled: false
+            property int tile_alternative_pace_order: 80
         }
 
 


### PR DESCRIPTION
## Summary

Adds an optional `Alternative Pace` tile for treadmill sessions. The tile shows pace calculated from the connected running sensor (for example HRM Pro Plus or Stryd) while keeping the treadmill's primary speed/pace metric unchanged.

## User request reference

Requested by the user in the email thread from `ogperalta@hotmail.com`, subject: `Visualizar Ritmo de trotadora y también ritmo de HRM Pro Plus`.

The request was to display the sensor-derived pace in real time alongside the treadmill pace. The neutral name `Alternative Pace` is intentional because the source may be HRM Pro Plus, Stryd, or another compatible running sensor.

## Implementation

- Parses and retains RSC running-sensor speed in a dedicated field, without writing to the inherited treadmill `Speed` metric.
- Adds the `Alternative Pace` tile, disabled by default and configurable from Tiles settings, including display order.
- Shows `N/A` when no valid alternative sensor speed is available.
- Updates the persistent settings catalog and backend defaults.

## Verification

- JSON settings catalog count and entries validated.
- `git diff --check` passed.
- Compiled the affected `qzsettings`, `homeform`, and `strydrunpowersensor` objects successfully (warnings are pre-existing project warnings).