### PR TITLE
docs: add Manual Device troubleshooting FAQ

### DIFF
--- a/docs/faq/bike-troubleshooting.md
+++ b/docs/faq/bike-troubleshooting.md
@@ -30,6 +30,18 @@ To test this:
 
 In a confirmed support case, an unnoticed second device was connecting to the bike; removing that competing connection restored QZ connectivity.
 
+## QZ keeps finding or searching for the wrong nearby fitness device. How can I force the intended trainer or bike?
+
+If several supported Bluetooth fitness devices are nearby and QZ selects or keeps searching for the wrong one, use the **Manual Device** setting to restrict discovery to the device you actually want to use.
+
+1. Open **QZ Settings > Advanced Settings**.
+2. Set **Manual Device** to the Bluetooth name of the intended bike or trainer.
+3. Fully close and restart QZ, then let it reconnect.
+
+QZ stores this selection as its device filter and uses it instead of unrestricted automatic discovery. To return to automatic device selection later, set **Manual Device** back to **Disabled**.
+
+In a confirmed support case, QZ was searching for a different nearby fitness machine instead of the intended smart trainer. Selecting the trainer under **Manual Device** restored the expected connection.
+
 ## MyWhoosh connects to QZ for my Echelon bike, but power stays at 0 W. What should I check?
 
 If the Echelon bike itself is already working normally in QZ and MyWhoosh can see/connect to the QZ device but the workout data remains at zero, check whether **Virtual Echelon** is still enabled from a previous setup or unlock attempt.


### PR DESCRIPTION
## Summary

Adds one reusable FAQ entry from QZ support conversations on September 9, 2026.

- Documents how to use **Settings > Advanced Settings > Manual Device** when QZ finds or keeps searching for the wrong nearby Bluetooth fitness device.
- Explains how to return to automatic discovery by setting **Manual Device** back to **Disabled**.
- The support case contained explicit confirmation that selecting the intended trainer restored the expected connection.

I checked the existing `docs/faq/` content and `docs/qz_faq_public.md` first. Other reusable-looking cases from the day were already covered, including short Android Bluetooth device names, Android Notification for same-device Zwift, Zwift auto-inclination credentials, and competing Bluetooth connections.