### PR TITLE
fix: detect Elite Misuro B+ as stages bike

### DIFF
--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -2129,6 +2129,7 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                         (b.name().toUpper().startsWith("RACER S")) ||
                         ((b.name().toUpper().startsWith("KU")) && b.name().length() == 2) ||
                         (b.name().toUpper().startsWith("ELITETRAINER")) ||
+                        (b.name().toUpper().startsWith("MISURO B+")) ||
                         (b.name().toUpper().startsWith("TOUR 600")) ||
                         (b.name().toUpper().startsWith("SMART+ #")) ||
                         (b.name().toUpper().startsWith(QStringLiteral("QD")) && b.name().length() == 2) ||

--- a/tst/Devices/devicetestdataindex.cpp
+++ b/tst/Devices/devicetestdataindex.cpp
@@ -1192,7 +1192,7 @@ void DeviceTestDataIndex::Initialize() {
     // Stages Bike
     RegisterNewDeviceTestData(DeviceIndex::StagesBike)
         ->expectDevice<stagesbike>()        
-        ->acceptDeviceNames({"STAGES ", "TACX SATORI", "RACER S", "ELITETRAINER"}, DeviceNameComparison::StartsWithIgnoreCase)
+        ->acceptDeviceNames({"STAGES ", "TACX SATORI", "RACER S", "ELITETRAINER", "MISURO B+"}, DeviceNameComparison::StartsWithIgnoreCase)
         ->acceptDeviceNames({"QD","DFC", "KU"}, DeviceNameComparison::IgnoreCase)
         ->excluding(stagesBikeExclusions);
 


### PR DESCRIPTION
## Summary
- Detect Elite Misuro B+ Bluetooth power sensors through the existing `stagesbike` driver.
- Add discovery coverage for the `MISURO B+` name prefix.

## Context
Reported in a QZ Fitness support thread about an Elite Misuro B+ used with a trainer and MyWhoosh.

Reference: QZ Fitness support thread about Elite Misuro B+ / MyWhoosh

## Test plan
- `./qdomyos-zwift-tests --gtest_filter='*StagesBike*'` — 8/8 passed
- `./qdomyos-zwift-tests` — exit code 0
- `git diff --check`

Physical-device validation is still pending.
