### PR TITLE
horizontreadmill: stop reconnect storms exhausting the Android BLE stack

### DIFF
--- a/src/devices/horizontreadmill/horizontreadmill.cpp
+++ b/src/devices/horizontreadmill/horizontreadmill.cpp
@@ -88,6 +88,18 @@ void horizontreadmill::waitForAPacket() {
 }
 
 void horizontreadmill::btinit() {
+    if (btinitRunning)
+        return;
+    btinitRunning = true;
+    initRequest = false;
+
+    // Each profile group below retries via "goto initN" when the machine does not acknowledge it.
+    // That retry was unbounded: if a machine stops acknowledging, btinit() re-sends the same group
+    // forever. Captured in the field at 468 writes/sec - 33,494 writes in 71s, 876 repeats of a
+    // single group - until the link collapsed. Cap the retries and carry on instead.
+    int initRetry[9] = {0};
+    const int INIT_MAX_RETRY = 3;
+
     QSettings settings;
     QStringList horizon_treadmill_profile_users;
     horizon_treadmill_profile_users.append(
@@ -294,13 +306,15 @@ void horizontreadmill::btinit() {
             writeCharacteristic(gattCustomService, gattWriteCharCustomService, initData14, sizeof(initData14),
                                 QStringLiteral("init"), false, true);
 
-            if (!initPacketRecv) {
+            if (!initPacketRecv && ++initRetry[1] <= INIT_MAX_RETRY) {
                 if(gattFTMSService && homeform::singleton()) {
                     homeform::singleton()->setToastRequested("Enable the 'Force Using FTMS' setting under the Settings->Treadmill Options->Horizon Treadmill options and restart the app");
                 }
                 qDebug() << "init 1 not received";
                 waitForAPacket();
                 goto init1;
+            } else if (!initPacketRecv) {
+                qDebug() << "init 1 not acknowledged after" << INIT_MAX_RETRY << "attempts, continuing";
             }
 
             if(homeform::singleton()) {
@@ -387,10 +401,12 @@ void horizontreadmill::btinit() {
             writeCharacteristic(gattCustomService, gattWriteCharCustomService, initData14, sizeof(initData14),
                                 QStringLiteral("init"), false, true);
 
-            if (!initPacketRecv) {
-                qDebug() << "init 2 not received";
+            if (!initPacketRecv && ++initRetry[2] <= INIT_MAX_RETRY) {
+                qDebug() << "init 2 not received, retry" << initRetry[2];
                 waitForAPacket();
                 goto init2;
+            } else if (!initPacketRecv) {
+                qDebug() << "init 2 not acknowledged after" << INIT_MAX_RETRY << "attempts, continuing";
             }
 
             if(homeform::singleton()) {
@@ -477,10 +493,12 @@ void horizontreadmill::btinit() {
             writeCharacteristic(gattCustomService, gattWriteCharCustomService, initData14, sizeof(initData14),
                                 QStringLiteral("init"), false, true);
 
-            if (!initPacketRecv) {
-                qDebug() << "init 3 not received";
+            if (!initPacketRecv && ++initRetry[3] <= INIT_MAX_RETRY) {
+                qDebug() << "init 3 not received, retry" << initRetry[3];
                 waitForAPacket();
                 goto init3;
+            } else if (!initPacketRecv) {
+                qDebug() << "init 3 not acknowledged after" << INIT_MAX_RETRY << "attempts, continuing";
             }
 
             if(homeform::singleton()) {
@@ -567,10 +585,12 @@ void horizontreadmill::btinit() {
             writeCharacteristic(gattCustomService, gattWriteCharCustomService, initData14, sizeof(initData14),
                                 QStringLiteral("init"), false, true);
 
-            if (!initPacketRecv) {
-                qDebug() << "init 4 not received";
+            if (!initPacketRecv && ++initRetry[4] <= INIT_MAX_RETRY) {
+                qDebug() << "init 4 not received, retry" << initRetry[4];
                 waitForAPacket();
                 goto init4;
+            } else if (!initPacketRecv) {
+                qDebug() << "init 4 not acknowledged after" << INIT_MAX_RETRY << "attempts, continuing";
             }
 
             if(homeform::singleton()) {
@@ -657,10 +677,12 @@ void horizontreadmill::btinit() {
             writeCharacteristic(gattCustomService, gattWriteCharCustomService, initData14, sizeof(initData14),
                                 QStringLiteral("init"), false, true);
 
-            if (!initPacketRecv) {
-                qDebug() << "init 5 not received";
+            if (!initPacketRecv && ++initRetry[5] <= INIT_MAX_RETRY) {
+                qDebug() << "init 5 not received, retry" << initRetry[5];
                 waitForAPacket();
                 goto init5;
+            } else if (!initPacketRecv) {
+                qDebug() << "init 5 not acknowledged after" << INIT_MAX_RETRY << "attempts, continuing";
             }
 
             if(homeform::singleton()) {
@@ -747,10 +769,12 @@ void horizontreadmill::btinit() {
             writeCharacteristic(gattCustomService, gattWriteCharCustomService, initData14, sizeof(initData14),
                                 QStringLiteral("init"), false, true);
 
-            if (!initPacketRecv) {
-                qDebug() << "init 6 not received";
+            if (!initPacketRecv && ++initRetry[6] <= INIT_MAX_RETRY) {
+                qDebug() << "init 6 not received, retry" << initRetry[6];
                 waitForAPacket();
                 goto init6;
+            } else if (!initPacketRecv) {
+                qDebug() << "init 6 not acknowledged after" << INIT_MAX_RETRY << "attempts, continuing";
             }
 
             if(homeform::singleton()) {
@@ -837,10 +861,12 @@ void horizontreadmill::btinit() {
             writeCharacteristic(gattCustomService, gattWriteCharCustomService, initData14, sizeof(initData14),
                                 QStringLiteral("init"), false, true);
 
-            if (!initPacketRecv) {
-                qDebug() << "init 7 not received";
+            if (!initPacketRecv && ++initRetry[7] <= INIT_MAX_RETRY) {
+                qDebug() << "init 7 not received, retry" << initRetry[7];
                 waitForAPacket();
                 goto init7;
+            } else if (!initPacketRecv) {
+                qDebug() << "init 7 not acknowledged after" << INIT_MAX_RETRY << "attempts, continuing";
             }
 
             if(homeform::singleton()) {
@@ -867,10 +893,12 @@ void horizontreadmill::btinit() {
             writeCharacteristic(gattCustomService, gattWriteCharCustomService, initData4, sizeof(initData4),
                                 QStringLiteral("init"), false, true);
 
-            if (!initPacketRecv) {
-                qDebug() << "init 8 not received";
+            if (!initPacketRecv && ++initRetry[8] <= INIT_MAX_RETRY) {
+                qDebug() << "init 8 not received, retry" << initRetry[8];
                 waitForAPacket();
                 goto init8;
+            } else if (!initPacketRecv) {
+                qDebug() << "init 8 not acknowledged after" << INIT_MAX_RETRY << "attempts, continuing";
             }
 
             if(homeform::singleton()) {
@@ -904,6 +932,7 @@ void horizontreadmill::btinit() {
     }
 
     initDone = true;
+    btinitRunning = false;
 }
 
 float horizontreadmill::float_one_point_round(float value) { return ((float)((int)(value * 10))) / 10; }
@@ -2842,11 +2871,30 @@ bool horizontreadmill::connected() {
 
 void horizontreadmill::controllerStateChanged(QLowEnergyController::ControllerState state) {
     qDebug() << QStringLiteral("controllerStateChanged") << state;
-    if (state == QLowEnergyController::UnconnectedState && m_control) {
-        qDebug() << QStringLiteral("trying to connect back again...");
-
+    if (state == QLowEnergyController::ConnectedState) {
+        reconnectAttempts = 0;   // link is up again; forget the backoff
+    } else if (state == QLowEnergyController::UnconnectedState && m_control) {
         initDone = false;
-        m_control->connectToDevice();
+
+        // Reconnecting immediately, on a controller that was never closed, makes Android answer
+        // every subsequent attempt with GATT error 133. Captured on a Unihertz Jelly 2: one good
+        // connection, a single drop, then 38 consecutive 133s at ~2/sec that never recovered for
+        // the rest of the session. The same machine held a link for 75s+ from a Linux host with no
+        // errors, so the peripheral was fine - the retry storm was exhausting the local stack.
+        //
+        // Close the GATT client first, then back off 1,2,4,8,16s between attempts.
+        m_control->disconnectFromDevice();
+
+        const int delay = 1000 * (1 << qMin(reconnectAttempts, 4));
+        reconnectAttempts++;
+        qDebug() << QStringLiteral("reconnect attempt") << reconnectAttempts
+                 << QStringLiteral("in") << delay << QStringLiteral("ms");
+        QTimer::singleShot(delay, this, [this]() {
+            if (m_control && m_control->state() == QLowEnergyController::UnconnectedState) {
+                qDebug() << QStringLiteral("trying to connect back again...");
+                m_control->connectToDevice();
+            }
+        });
     }
 }
 

--- a/src/devices/horizontreadmill/horizontreadmill.h
+++ b/src/devices/horizontreadmill/horizontreadmill.h
@@ -84,6 +84,12 @@ class horizontreadmill : public treadmill {
 
     bool initDone = false;
     bool initRequest = false;
+    // btinit() blocks for a long time inside nested event loops (writeCharacteristic() and
+    // waitForAPacket() both call loop.exec()), during which the refresh timer keeps firing
+    // update(). Guards against update() re-entering btinit() while it is still running.
+    bool btinitRunning = false;
+    // Consecutive failed reconnects, used for backoff. Reset on a successful connection.
+    int reconnectAttempts = 0;
     bool initPacketRecv = false;
 
     bool noWriteResistance = false;


### PR DESCRIPTION
Three related faults in the Horizon custom (FFF0) connection path, all captured on a **Horizon 7.0 AE with a Unihertz Jelly 2**. Throughout testing the same machine held a BLE link for 75s+ from a Linux host with zero errors, so the peripheral itself was never at fault.

### 1. Unbounded profile-upload retry

Each profile group retries via `goto initN` when the machine doesn't acknowledge it, with no attempt limit. A machine that stops acknowledging gets the same group re-sent indefinitely:

```
33,494 writes in 71s  =  468 writes/sec
876 repeats of a single profile group
```

Now capped at 3 attempts per group, then logs and continues.

### 2. Reconnect storm exhausting the Android BLE stack

Reconnects fired immediately with no backoff, on a controller that was never closed. After a single drop:

```
+  0.0s   CONNECTED OK
+164.8s   Error(133)     <- link drops
+165.5s   Error(133)     ... 38 consecutive, ~2/sec
          never recovers for the rest of the session
```

`disconnectFromDevice()` is now called before retrying, and attempts back off 1/2/4/8/16s, resetting on success.

### 3. `btinit()` re-entrancy guard

`btinit()` blocks for a long time inside nested event loops (`writeCharacteristic()` and `waitForAPacket()` both call `loop.exec()`), during which the refresh timer keeps firing `update()`. Added a guard so a second handshake can't start while one is running.

**To be clear: this third one is defensive hardening, not a fix for an observed failure.** I initially believed I had evidence of concurrent `btinit()` runs, but that turned out to be a miscount on my part and I could not reproduce it. Happy to drop it if you'd prefer the PR stay strictly to what's demonstrated.

### Result

| | before | after |
|---|---|---|
| `Error(133)` | 38 | 0 |
| disconnects | 39 | 0 |
| session | dead after first drop, repeated Start presses | stable for the full run |

Treadmill behaviour is otherwise untouched — this changes only the retry limits and the reconnect path. Tested on Android/arm64 against a 7.0 AE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
