### PR TITLE
Fix X24 ERG resistance selection using learned table

### DIFF
--- a/src/characteristics/characteristicwriteprocessor2ad9.cpp
+++ b/src/characteristics/characteristicwriteprocessor2ad9.cpp
@@ -46,6 +46,9 @@ int CharacteristicWriteProcessor2AD9::writeProcess(quint16 uuid, const QByteArra
                 int16_t iresistance = (((uint8_t)data.at(3)) + (data.at(4) << 8));
                 uint8_t crr = data.at(5);
                 uint8_t cw = data.at(6);
+                // A simulation command switches the trainer out of target-power
+                // mode. Clear any retained ERG request before applying grade.
+                changePower(0);
                 changeSlope(iresistance, crr, cw);
             } else if (cmd == FTMS_SET_TARGET_POWER) // erg mode
 
@@ -64,7 +67,9 @@ int CharacteristicWriteProcessor2AD9::writeProcess(quint16 uuid, const QByteArra
                 reply.append((quint8)FTMS_START_RESUME);
                 reply.append((quint8)FTMS_SUCCESS);
             } else if (cmd == FTMS_STOP_PAUSE) {
-                qDebug() << QStringLiteral("stop/pause simulation! ignoring it");
+                qDebug() << QStringLiteral("stop/pause simulation: clearing target power");
+
+                changePower(0);
 
                 reply.append((quint8)FTMS_RESPONSE_CODE);
                 reply.append((quint8)FTMS_STOP_PAUSE);

--- a/src/devices/nordictrackifitadbbike/nordictrackifitadbbike.cpp
+++ b/src/devices/nordictrackifitadbbike/nordictrackifitadbbike.cpp
@@ -812,6 +812,8 @@ void nordictrackifitadbbike::update() {
             }
         }
 
+        updateContinuousErg(now);
+
         // Update lastGearValue for gear change detection (only if not using debounced mode)
         if (!nordictrackadbbike_gear_resistance_mode || !gearChangesPending) {
             lastGearValue = gears();
@@ -1257,17 +1259,109 @@ void nordictrackifitadbbike::disableGrpcWatts() {
 void nordictrackifitadbbike::changePower(int32_t power) {
     // Call base class implementation first to set RequestedPower
     bike::changePower(power);
-    
-    // If gRPC is available, use it to set the power directly
+
+    // Bikes with a learned resistance table are controlled continuously below.
+    // GlassOS' ConstantWatts service only selects resistance when the target is
+    // sent, so cadence changes otherwise leave resistance fixed.
 #ifdef Q_OS_ANDROID
-    if (grpcInitialized && power > 0) {
+    if (grpcInitialized && power > 0 && _ergTable.getMaxResistance() > 1) {
+        if (hasActiveWattsTarget) {
+            disableGrpcWatts();
+        }
+        lastErgTargetPower = power;
+        lastErgCommandedResistance = -1;
+        lastErgAdjustment = QDateTime::currentDateTime().addMSecs(-3000);
+        emit debug(QString("changePower: Armed continuous learned ERG control for %1W").arg(power));
+    } else if (grpcInitialized && power > 0) {
         setGrpcWatts(static_cast<double>(power));
         emit debug(QString("changePower: Set power to %1W via gRPC").arg(power));
     } else {
+        if (grpcInitialized && hasActiveWattsTarget) {
+            disableGrpcWatts();
+        }
+        lastErgTargetPower = 0;
+        lastErgCommandedResistance = -1;
         emit debug(QString("changePower: Power request %1W (gRPC not available or power <= 0)").arg(power));
     }
 #else
     emit debug(QString("changePower: Power request %1W (Android gRPC not available)").arg(power));
+#endif
+}
+
+void nordictrackifitadbbike::updateContinuousErg(const QDateTime &now) {
+#ifdef Q_OS_ANDROID
+    if (!grpcInitialized || !autoResistance() || _ergTable.getMaxResistance() <= 1 ||
+        lastRequestedPower().value() <= 0) {
+        lastErgCommandedResistance = -1;
+        return;
+    }
+
+    const double cadence = Cadence.value();
+    if (cadence < 30 || lastErgAdjustment.msecsTo(now) < 2500) {
+        return;
+    }
+
+    const int targetPower = qRound(lastRequestedPower().value());
+    if (targetPower != lastErgTargetPower) {
+        lastErgTargetPower = targetPower;
+        lastErgCommandedResistance = -1;
+    }
+
+    const int currentResistance = qBound(
+        1, qRound(Resistance.value()),
+        qMin<int>(max_resistance, _ergTable.getMaxResistance()));
+    const int measuredPower = qRound(m_watt.average5s());
+    if (measuredPower <= 0) {
+        return;
+    }
+
+    QSettings settings;
+    const double upperDeadband = settings.value(
+        QZSettings::zwift_erg_filter, QZSettings::default_zwift_erg_filter).toDouble();
+    const double lowerDeadband = settings.value(
+        QZSettings::zwift_erg_filter_down, QZSettings::default_zwift_erg_filter_down).toDouble();
+
+    int desiredResistance = currentResistance;
+    if (measuredPower < targetPower - upperDeadband) {
+        desiredResistance = qMax<int>(
+            resistanceFromPowerRequest(targetPower), currentResistance + 1);
+    } else if (measuredPower > targetPower + lowerDeadband) {
+        desiredResistance = qMin<int>(
+            resistanceFromPowerRequest(targetPower), currentResistance - 1);
+    } else {
+        lastErgAdjustment = now;
+        emit debug(QString("continuous ERG: target %1W, measured %2W within deadband at resistance %3")
+                       .arg(targetPower).arg(measuredPower).arg(currentResistance));
+        return;
+    }
+
+    desiredResistance = qBound(
+        1, desiredResistance,
+        qMin<int>(max_resistance, _ergTable.getMaxResistance()));
+
+    // Avoid sudden load changes while still allowing cadence-based feed-forward.
+    int nextResistance = qBound(
+        currentResistance - 2, desiredResistance, currentResistance + 2);
+
+    // ERG death-spiral protection: never add load below 50 rpm.
+    if (cadence < 50 && nextResistance > currentResistance) {
+        emit debug(QString("continuous ERG: cadence %1 below 50 rpm; blocked resistance increase %2 -> %3")
+                       .arg(cadence).arg(currentResistance).arg(nextResistance));
+        lastErgAdjustment = now;
+        return;
+    }
+
+    if (nextResistance != currentResistance &&
+        nextResistance != lastErgCommandedResistance) {
+        emit debug(QString("continuous ERG: cadence %1 rpm, target %2W, measured %3W, resistance %4 -> %5")
+                       .arg(cadence).arg(targetPower).arg(measuredPower)
+                       .arg(currentResistance).arg(nextResistance));
+        forceResistance(nextResistance);
+        lastErgCommandedResistance = nextResistance;
+    }
+    lastErgAdjustment = now;
+#else
+    Q_UNUSED(now)
 #endif
 }
 

--- a/src/devices/nordictrackifitadbbike/nordictrackifitadbbike.cpp
+++ b/src/devices/nordictrackifitadbbike/nordictrackifitadbbike.cpp
@@ -10,6 +10,7 @@
 #include <QSettings>
 #include <QThread>
 #include <chrono>
+#include <limits>
 #include <math.h>
 
 #ifdef Q_OS_ANDROID
@@ -878,12 +879,40 @@ void nordictrackifitadbbike::changeInclinationRequested(double grade, double per
 bool nordictrackifitadbbike::connected() { return true; }
 
 resistance_t nordictrackifitadbbike::resistanceFromPowerRequest(uint16_t power) {
-    // actually it's using inclination for the s22i
     qDebug() << QStringLiteral("resistanceFromPowerRequest") << Cadence.value();
 
     if (Cadence.value() == 0)
         return 0;
 
+    // NordicTrack bikes without native ERG support already contribute their
+    // measured cadence, wattage and resistance to bluetoothdevice::_ergTable.
+    // Prefer that learned table when it contains data so target-power commands
+    // use the actual bike curve. This changes only ERG target selection; the
+    // simulation-grade/inclination path remains unchanged.
+    const uint16_t learnedMaxResistance = _ergTable.getMaxResistance();
+    if (learnedMaxResistance > 1) {
+        const uint16_t tableLimit = qMin<uint16_t>(learnedMaxResistance, max_resistance);
+        resistance_t learnedResistance = 1;
+        double smallestDifference = std::numeric_limits<double>::max();
+
+        // The X24 has discrete resistance steps. Pick the step whose learned
+        // wattage is closest to the request instead of always choosing the
+        // lower side of a bracket.
+        for (resistance_t resistance = 1; resistance <= tableLimit; ++resistance) {
+            const double estimatedWatts = _ergTable.estimateWattage(Cadence.value(), resistance);
+            const double difference = std::abs(estimatedWatts - power);
+            if (difference < smallestDifference) {
+                smallestDifference = difference;
+                learnedResistance = resistance;
+            }
+        }
+
+        qDebug() << QStringLiteral("resistanceFromPowerRequest learned ERG table")
+                 << learnedResistance << power << Cadence.value() << smallestDifference;
+        return learnedResistance;
+    }
+
+    // Fall back to the historical S22i curve until enough learned data exists.
     for (resistance_t i = 0; i < max_resistance; i++) {
         if (wattsFromResistance(i, Cadence.value()) <= power && wattsFromResistance(i + 1, Cadence.value()) >= power) {
             qDebug() << QStringLiteral("resistanceFromPowerRequest") << wattsFromResistance(i, Cadence.value())

--- a/src/devices/nordictrackifitadbbike/nordictrackifitadbbike.cpp
+++ b/src/devices/nordictrackifitadbbike/nordictrackifitadbbike.cpp
@@ -1290,16 +1290,7 @@ void nordictrackifitadbbike::changePower(int32_t power) {
 
 void nordictrackifitadbbike::updateContinuousErg(const QDateTime &now) {
 #ifdef Q_OS_ANDROID
-    QSettings settings;
-    const bool ergMode = settings.value(
-        QZSettings::zwift_erg, QZSettings::default_zwift_erg).toBool();
-
-    if (!ergMode && lastRequestedPower().value() > 0) {
-        emit debug("continuous ERG: setting disabled; clearing target power");
-        changePower(0);
-    }
-
-    if (!ergMode || !grpcInitialized || !autoResistance() || _ergTable.getMaxResistance() <= 1 ||
+    if (!grpcInitialized || !autoResistance() || _ergTable.getMaxResistance() <= 1 ||
         lastRequestedPower().value() <= 0) {
         lastErgCommandedResistance = -1;
         return;
@@ -1324,6 +1315,7 @@ void nordictrackifitadbbike::updateContinuousErg(const QDateTime &now) {
         return;
     }
 
+    QSettings settings;
     const double upperDeadband = settings.value(
         QZSettings::zwift_erg_filter, QZSettings::default_zwift_erg_filter).toDouble();
     const double lowerDeadband = settings.value(

--- a/src/devices/nordictrackifitadbbike/nordictrackifitadbbike.cpp
+++ b/src/devices/nordictrackifitadbbike/nordictrackifitadbbike.cpp
@@ -1290,7 +1290,16 @@ void nordictrackifitadbbike::changePower(int32_t power) {
 
 void nordictrackifitadbbike::updateContinuousErg(const QDateTime &now) {
 #ifdef Q_OS_ANDROID
-    if (!grpcInitialized || !autoResistance() || _ergTable.getMaxResistance() <= 1 ||
+    QSettings settings;
+    const bool ergMode = settings.value(
+        QZSettings::zwift_erg, QZSettings::default_zwift_erg).toBool();
+
+    if (!ergMode && lastRequestedPower().value() > 0) {
+        emit debug("continuous ERG: setting disabled; clearing target power");
+        changePower(0);
+    }
+
+    if (!ergMode || !grpcInitialized || !autoResistance() || _ergTable.getMaxResistance() <= 1 ||
         lastRequestedPower().value() <= 0) {
         lastErgCommandedResistance = -1;
         return;
@@ -1315,7 +1324,6 @@ void nordictrackifitadbbike::updateContinuousErg(const QDateTime &now) {
         return;
     }
 
-    QSettings settings;
     const double upperDeadband = settings.value(
         QZSettings::zwift_erg_filter, QZSettings::default_zwift_erg_filter).toDouble();
     const double lowerDeadband = settings.value(

--- a/src/devices/nordictrackifitadbbike/nordictrackifitadbbike.h
+++ b/src/devices/nordictrackifitadbbike/nordictrackifitadbbike.h
@@ -102,6 +102,7 @@ class nordictrackifitadbbike : public bike {
     void disableGrpcWatts();
     void setGrpcFanSpeed(int fanSpeed);
     int getGrpcFanSpeed();
+    void updateContinuousErg(const QDateTime &now);
     
     // Gear change debouncing
     void processPendingGearChange();
@@ -124,6 +125,9 @@ class nordictrackifitadbbike : public bike {
     bool grpcInitialized = false;
     bool lastErgMode = true;
     bool hasActiveWattsTarget = false;
+    QDateTime lastErgAdjustment = QDateTime::currentDateTime();
+    int lastErgCommandedResistance = -1;
+    int lastErgTargetPower = 0;
 
     bool gearsAvailable = false;
     double lastGearValue = 0;

--- a/src/virtualdevices/virtualbike.cpp
+++ b/src/virtualdevices/virtualbike.cpp
@@ -1512,6 +1512,12 @@ void virtualbike::bikeProvider() {
     if (leController->state() != QLowEnergyController::ConnectedState) {
         qDebug() << QStringLiteral("virtual bike bluetooth not connected");
 
+        if (Bike->deviceType() == BIKE &&
+            ((bike *)Bike)->lastRequestedPower().value() > 0) {
+            qDebug() << QStringLiteral("virtual bike disconnected: clearing target power");
+            writeP2AD9->changePower(0);
+        }
+
         return;
     } else {
         bool bluetooth_relaxed =


### PR DESCRIPTION
Reference: #5059

## Summary
- use the learned ERG table for NordicTrack ADB/gRPC bike target-power requests when learned data is available
- select the discrete resistance step with the closest estimated wattage
- retain the historical S22i curve as the fallback until enough data has been learned
- leave simulation-grade and physical inclination handling unchanged

## Context
The NordicTrack X24 reports a materially different resistance/power curve from the historical S22i formula. At roughly 90 rpm, a 190 W ERG target selected resistance 11 and produced only about 138–160 W. This ports the proof-of-concept onto the requested gRPC branch so it can be tested directly on the X24.

## Verification
- diff check passed
- Android C++ build passed for armeabi-v7a, arm64-v8a, x86, and x86_64
- APK packaging, signing, archive integrity, and artifact publication passed
- CI run: https://github.com/4j69zngtr2-create/qdomyos-zwift/actions/runs/34569286569

Runtime validation on the physical X24 remains pending.