### PR TITLE
fix: improve French wizard translations

### DIFF
--- a/src/translations/qdomyos-zwift_fr.ts
+++ b/src/translations/qdomyos-zwift_fr.ts
@@ -1297,12 +1297,12 @@ Les questions suivantes personnaliseront QZ pour votre équipement et vos object
     <message>
         <location filename="../Wizard.qml" line="172"/>
         <source>Help with a specific feature</source>
-        <translation>Aide avec une fonctionnalité spécifique</translation>
+        <translation>Aide pour une fonctionnalité spécifique</translation>
     </message>
     <message>
         <location filename="../Wizard.qml" line="181"/>
         <source>I&apos;m fine, thanks.</source>
-        <translation>Je vais bien, merci.</translation>
+        <translation>C&apos;est tout bon, merci.</translation>
     </message>
     <message>
         <location filename="../Wizard.qml" line="211"/>


### PR DESCRIPTION
Reference: support request from matthieu.f.graveleau@gmail.com about French translations

## Summary
- improve the French translation for “Help with a specific feature”
- use a more natural French wording for “I'm fine, thanks.”
- incorporates suggestions from Matthieu Graveleau

## Test plan
- `git diff --check`
- XML parse of `src/translations/qdomyos-zwift_fr.ts`
- `lrelease src/translations/qdomyos-zwift_fr.ts -qm /tmp/qdomyos-zwift_fr.qm`