### PR TITLE
fix(apple-watch): lock workout selection after start

### DIFF
--- a/build-qdomyos-zwift-Qt_5_15_2_for_iOS-Debug/watchkit Extension/MainController.swift
+++ b/build-qdomyos-zwift-Qt_5_15_2_for_iOS-Debug/watchkit Extension/MainController.swift
@@ -71,19 +71,28 @@ extension MainController {
     
     @IBAction func startWorkout() {
         if(!MainController.start){
-            MainController.start = true
-            startButton.setTitle("Stop")
-            WorkoutTracking.authorizeHealthKit()
-            WorkoutTracking.shared.setSport(sport)
-            WorkoutTracking.shared.startWorkOut()
-            WorkoutTracking.shared.delegate = self
-            
-            WatchKitConnection.shared.delegate = self
-            WatchKitConnection.shared.startSession()
+            let selectedSport = sport
+            let workoutName = ["Bike", "Run", "Walk", "Elliptical", "Rowing"][selectedSport]
+            let startAction = WKAlertAction(title: "Start", style: .default) { [weak self] in
+                guard let self = self else { return }
+                MainController.start = true
+                self.startButton.setTitle("Stop")
+                self.cmbSports.setEnabled(false)
+                WorkoutTracking.authorizeHealthKit()
+                WorkoutTracking.shared.setSport(selectedSport)
+                WorkoutTracking.shared.startWorkOut()
+                WorkoutTracking.shared.delegate = self
+
+                WatchKitConnection.shared.delegate = self
+                WatchKitConnection.shared.startSession()
+            }
+            let cancelAction = WKAlertAction(title: "Cancel", style: .cancel) {}
+            presentAlert(withTitle: "Start Workout", message: "Start \(workoutName) workout?", preferredStyle: .alert, actions: [cancelAction, startAction])
         }
         else {
             MainController.start = false
             startButton.setTitle("Start")
+            cmbSports.setEnabled(true)
             WorkoutTracking.shared.stopWorkOut()
         }
     }


### PR DESCRIPTION
## Reference

Reference: support request from Jason about locking the Apple Watch workout selection after Start

## Summary

- ask the user to confirm the selected workout when tapping Start
- lock the Watch workout picker while the workout is active
- re-enable workout selection after Stop

## Validation

- git diff --check
- based on updated master at 446f37d8e
- Xcode build not run: xcodebuild is unavailable in this Linux environment