### PR TITLE
docs: add confirmed BH Nexor and BKOOL compatibility FAQ

### DIFF
--- a/docs/faq/README.md
+++ b/docs/faq/README.md
@@ -6,6 +6,7 @@ This directory contains practical QZ frequently asked questions, organized by ca
 
 - [Android](android.md)
 - [Bike and trainer troubleshooting](bike-troubleshooting.md)
+- [Device compatibility](device-compatibility.md)
 - [Integrations and authentication](integrations.md)
 - [Rowing](rowing.md)
 - [Training programs](training-programs.md)

--- a/docs/faq/device-compatibility.md
+++ b/docs/faq/device-compatibility.md
@@ -1,0 +1,15 @@
+# Device compatibility
+
+## Is the BH Fitness Nexor Dual / i-Nexor compatible with QZ?
+
+Yes. QZ has current support for BH Fitness bikes that use the iConcept/BH DUALKIT Bluetooth protocol, including the Nexor-specific handling used by devices advertising with a `BH-` name.
+
+A confirmed support case with a BH Fitness Nexor Dual connected successfully to QZ and allowed resistance control from QZ.
+
+If the bike connects and responds correctly inside QZ but a downstream training app cannot see QZ, treat that as a separate virtual-device/advertising issue rather than a bike-compatibility problem.
+
+## Is the BKOOL Smart Bike v1 compatible with QZ?
+
+Yes. QZ includes a dedicated BKOOL bike implementation, and a confirmed support case with a BKOOL Smart Bike v1 connected successfully and could then be used with MyWhoosh through QZ.
+
+This confirms the basic bike-to-QZ and QZ-to-training-app path. It does not imply that MyWhoosh virtual gear difficulty will feel identical to the bike's previous native integration; gear-range or resistance-feel tuning should be treated separately if needed.


### PR DESCRIPTION
## Summary

Adds a new Device compatibility FAQ category based on reusable support conversations from Sep 11, 2026.

- documents confirmed BH Fitness Nexor Dual / i-Nexor compatibility and resistance control, verified against the current iConcept/BH device handling in QZ
- documents confirmed BKOOL Smart Bike v1 compatibility and successful use with MyWhoosh through QZ, backed by QZ's dedicated BKOOL bike implementation
- keeps unresolved MyWhoosh gear-feel tuning out of the FAQ
- adds the new category to `docs/faq/README.md`

No screenshots are included because they are not necessary to explain these compatibility answers.