### PR TITLE
Request FTMS control for iConsole+ rowers

### DIFF
--- a/src/devices/ftmsrower/ftmsrower.cpp
+++ b/src/devices/ftmsrower/ftmsrower.cpp
@@ -78,7 +78,7 @@ void ftmsrower::update() {
     }
 
     if (initRequest) {
-        if(I_ROWER || SF_RW || ROWER || MRK_R06) {
+        if(I_ROWER || SF_RW || ROWER || MRK_R06 || ICONSOLE_PLUS) {
             uint8_t write[] = {FTMS_REQUEST_CONTROL};
             writeCharacteristic(write, sizeof(write), "start", false, true);
 


### PR DESCRIPTION
iConsole+ rowers can reject FTMS Start/Resume with `Control Not Permitted` when QZ sends `0x07` without first requesting control.

This minimal change adds `ICONSOLE_PLUS` to the existing rower path that sends:

1. `FTMS_REQUEST_CONTROL` (`0x00`)
2. `FTMS_START_RESUME` (`0x07`)

No other behavior is changed.