### PR TITLE
Fix Bluetooth device values in settings search

### DIFF
--- a/src/settings.qml
+++ b/src/settings.qml
@@ -283,14 +283,21 @@ import AndroidStatusBar 1.0
             return []
         }
 
+        function isBluetoothDeviceSetting(entry) {
+            return entry && entry.options && entry.options.expression &&
+                   entry.options.expression.indexOf("bluetoothDevices") >= 0
+        }
+
         function optionIndex(entry) {
             var values = optionValues(entry)
             var value = settingValue(entry)
+            var bluetoothDeviceSetting = isBluetoothDeviceSetting(entry)
             for (var i = 0; i < values.length; i++) {
-                if (values[i] === value)
+                var candidate = bluetoothDeviceSetting ? stripRssi(values[i]) : values[i]
+                if (candidate === value)
                     return i
             }
-            return 0
+            return bluetoothDeviceSetting ? -1 : 0
         }
 
         function virtualOptionLabels(entry) {
@@ -2009,6 +2016,9 @@ import AndroidStatusBar 1.0
                                 Layout.maximumHeight: visible ? implicitHeight : 0
                                 model: visible ? settingsPane.optionValues(entry) : []
                                 currentIndex: visible ? settingsPane.optionIndex(entry) : 0
+                                displayText: visible && settingsPane.isBluetoothDeviceSetting(entry)
+                                             ? settingsPane.settingValue(entry)
+                                             : currentText
                                 contentItem: Label {
                                     leftPadding: 12
                                     rightPadding: 36
@@ -2031,7 +2041,7 @@ import AndroidStatusBar 1.0
                                 }
                                 onActivated: {
                                     var selectedValue = currentValue
-                                    if (entry.options && entry.options.expression && entry.options.expression.indexOf("bluetoothDevices") >= 0)
+                                    if (settingsPane.isBluetoothDeviceSetting(entry))
                                         selectedValue = settingsPane.stripRssi(selectedValue)
                                     settingsPane.setSettingValue(entry, selectedValue)
                                 }


### PR DESCRIPTION
## Summary
- keep Bluetooth-backed settings search results in sync with their persisted values
- normalize RSSI suffixes when resolving the selected option
- show the persisted Bluetooth device name even when the current scan list does not contain it
- reuse the same Bluetooth-setting detection for reads and writes

## Why
Bluetooth device names are saved without the dynamic RSSI suffix, while `rootItem.bluetoothDevices` contains values such as `Bike (75%)`. The settings search used an exact comparison, failed to find the saved name, and fell back to index 0 (`Disabled`). The classic settings view already displays the saved setting directly.

## Scope
This applies generically to all catalog settings backed by `rootItem.bluetoothDevices`, including FTMS bike/treadmill/rower/elliptical, HR belt, manual device selection, cadence/power sensors, Elite accessories, and SmartSpin2k.

## Test plan
- select and save an FTMS Bike in the classic settings view
- search for `ftms` and verify the saved device is shown instead of `Disabled`
- refresh Bluetooth devices / allow RSSI to change and verify selection still resolves correctly
- verify a saved device still displays when it is temporarily absent from the current scan list
- verify non-Bluetooth option ComboBoxes are unchanged