### PR TITLE
Allow FTMS selection to override Life Fitness treadmill auto-detection

### DIFF
--- a/src/devices/bluetooth.cpp
+++ b/src/devices/bluetooth.cpp
@@ -1622,6 +1622,8 @@ void bluetooth::deviceDiscovered(const QBluetoothDeviceInfo &device) {
                 }
                 this->signalBluetoothDeviceConnected(speraXTreadmill);
             } else if ((b.name().toUpper().startsWith(QStringLiteral("LF")) && (b.name().length() == 18 || b.name().length() == 15)) &&
+                       ftms_bike.contains(QZSettings::default_ftms_bike) &&
+                       ftms_treadmill.contains(QZSettings::default_ftms_treadmill) &&
                        !lifefitnessTreadmill && filter) {
                 this->setLastBluetoothDevice(b);
                 this->stopDiscovery();


### PR DESCRIPTION
## Summary

- Keep the existing Life Fitness `LF` 15/18-character treadmill auto-detection when both generic FTMS selections are disabled.
- Skip the Life Fitness-specific treadmill branch when either **FTMS Bike** or **FTMS Treadmill** has an explicit device selection.
- Let the existing generic FTMS branches handle the selected device instead.

## Reference

This comes from the Schipper support case reported on September 12, 2026.

The Life Fitness bike `LF0924cf03e1dcc209` (LifeCycle ASPC-SL-CGCXN-12) is currently caught by the Life Fitness treadmill name heuristic before the generic FTMS Bike branch. Cadence and power were available only when treating it as a treadmill, while bike-specific behavior could not be used.

With this change, an explicit FTMS Bike or FTMS Treadmill selection takes precedence over the Life Fitness automatic treadmill classification.

## Validation

The change is intentionally limited to the Life Fitness auto-detection guard. Existing FTMS Bike and FTMS Treadmill exact-name matching remains unchanged. Hardware confirmation with the reported Life Fitness bike is still required.