### PR TITLE
Fix #2144: keep inner web server port stable across restarts

### DIFF
--- a/src/homeform.cpp
+++ b/src/homeform.cpp
@@ -180,7 +180,8 @@ homeform::homeform(QQmlApplicationEngine *engine, bluetooth *bl) {
 
     settings.setValue(sKey + QStringLiteral("enabled"), true);
     settings.setValue(sKey + QStringLiteral("type"), TEMPLATE_TYPE_WEBSERVER);
-    settings.setValue(sKey + QStringLiteral("port"), 0);
+    if (!settings.contains(sKey + QStringLiteral("port")))
+        settings.setValue(sKey + QStringLiteral("port"), 0);
     this->innerTemplateManager =
         TemplateInfoSenderBuilder::getInstance(innerId, QStringList({QStringLiteral(":/inner_templates/")}), this);
 


### PR DESCRIPTION
## Summary
- Keep the automatically assigned inner QZWS web server port across app restarts instead of resetting it to `0` on every startup.
- If the saved port is already in use, fall back to a dynamic port.
- Persist the **actual** port returned by `QTcpServer::serverPort()` after a successful bind, including after the fallback.

This keeps browser/live-metrics URLs stable without requiring a platform-specific setting. The first run can still choose an available dynamic port automatically.

## Background
This supersedes #4317 and the older #2145 approach. #4317 already had the right general behavior and was tested successfully, but its busy-port fallback kept the old port value after binding to a dynamic port. This version fixes that edge case as well.

Credit to @eenterwebz for the implementation and testing in #4317.

## Test plan
- First launch with no stored inner QZWS port: bind dynamically and persist the assigned port.
- Restart QZ: reuse the same stored port.
- Start with the stored port occupied: bind to a new dynamic port and persist the new actual port.
- Existing #4317 testing confirmed the same port was reused after restart and CI passed on all platforms.

Closes #2144